### PR TITLE
fix(util): add summarizer and rewriter to service mapping

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/util/Helpers.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/util/Helpers.kt
@@ -3,7 +3,9 @@ package com.github.ahatem.qtranslate.core.shared.util
 import com.github.ahatem.qtranslate.api.dictionary.Dictionary
 import com.github.ahatem.qtranslate.api.ocr.OCR
 import com.github.ahatem.qtranslate.api.plugin.Service
+import com.github.ahatem.qtranslate.api.rewriter.Rewriter
 import com.github.ahatem.qtranslate.api.spellchecker.SpellChecker
+import com.github.ahatem.qtranslate.api.summarizer.Summarizer
 import com.github.ahatem.qtranslate.api.translator.Translator
 import com.github.ahatem.qtranslate.api.tts.TextToSpeech
 import com.github.ahatem.qtranslate.core.shared.arch.ServiceType
@@ -16,6 +18,8 @@ fun mapServiceToType(service: Service): ServiceType? {
         is OCR -> ServiceType.OCR
         is SpellChecker -> ServiceType.SPELL_CHECKER
         is Dictionary -> ServiceType.DICTIONARY
+        is Summarizer -> ServiceType.SUMMARIZER
+        is Rewriter -> ServiceType.REWRITER
         else -> null
     }
 }


### PR DESCRIPTION
- missing support for Summarizer and Rewriter service types
- enables correct runtime identification during service mapping

## What does this PR do?

Adds missing support for **Summarizer** and **Rewriter** service types in the service mapping utility.  
This allows these services to be correctly identified during runtime and prevents mapping failures.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

N/A