### PR TITLE
fix(app): prevent multiple app instances with socket lock

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
@@ -13,6 +13,24 @@ import javax.swing.SwingUtilities
 
 fun main() = runBlocking {
 
+    var frame: MainAppFrame? = null
+
+    if (!SingleInstanceGuard.tryLock(onFocusRequested = {
+            SwingUtilities.invokeLater {
+                frame?.apply {
+                    isVisible = true
+                    toFront()
+                    requestFocus()
+                }
+            }
+        })) {
+        return@runBlocking
+    }
+
+    Runtime.getRuntime().addShutdownHook(Thread {
+        SingleInstanceGuard.release()
+    })
+
     AppUiSetup.setSystemProperties()
     AppUiSetup.setRenderingHints()
 
@@ -59,7 +77,7 @@ fun main() = runBlocking {
     }
 
     SwingUtilities.invokeLater {
-        MainAppFrame(
+        frame = MainAppFrame(
             mainStore        = deps.mainStore,
             settingsStore    = deps.settingsStore,
             iconManager      = deps.iconManager,

--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/SingleInstanceGuard.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/SingleInstanceGuard.kt
@@ -1,0 +1,43 @@
+package com.github.ahatem.qtranslate.app
+
+import java.io.PrintWriter
+import java.net.BindException
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+object SingleInstanceGuard {
+
+    private const val PORT = 49185
+    private const val FOCUS_SIGNAL = "FOCUS"
+    private var serverSocket: ServerSocket? = null
+
+
+    fun tryLock(onFocusRequested: () -> Unit): Boolean {
+        return try {
+            serverSocket = ServerSocket(PORT, 1, InetAddress.getByName("localhost"))
+            Thread {
+                while (true) {
+                    runCatching {
+                        serverSocket?.accept()?.use { client ->
+                            val signal = client.getInputStream().bufferedReader().readLine()
+                            if (signal == FOCUS_SIGNAL) onFocusRequested()
+                        }
+                    }
+                }
+            }.apply { isDaemon = true }.start()
+            true
+        } catch (_: BindException) {
+            runCatching {
+                Socket(InetAddress.getByName("localhost"), PORT).use { socket ->
+                    PrintWriter(socket.getOutputStream(), true).println(FOCUS_SIGNAL)
+                }
+            }
+            false
+        }
+    }
+
+    fun release() {
+        serverSocket?.close()
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a single-instance guard to prevent multiple QTranslate windows from opening concurrently. Uses a localhost socket lock — if a second instance is launched, it sends a focus signal to the existing instance which brings it to the front, then exits silently.

## Related issues

Closes #18

## Type of change

- [x] Bug fix

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No UI changes — behaviour only.