### PR TITLE
feat(app): auto-detect OS language on first launch

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
@@ -68,7 +68,11 @@ fun main() = runBlocking {
             .onFailure { e -> logger.error("Failed to load plugins", e) }
     }
 
-    val savedLanguage = LanguageCode(initialConfig.interfaceLanguage)
+    val savedLanguage = if (initialConfig.interfaceLanguage == LanguageCode.ENGLISH.tag) {
+        OsLanguageDetector.detect(deps.localizationManager.availableLanguages)
+    } else {
+        LanguageCode(initialConfig.interfaceLanguage)
+    }
     runCatching {
         deps.localizationManager.loadLanguage(savedLanguage)
         logger.info("Interface language loaded: ${initialConfig.interfaceLanguage}")

--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/OsLanguageDetector.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/OsLanguageDetector.kt
@@ -1,0 +1,23 @@
+package com.github.ahatem.qtranslate.app
+
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import java.util.Locale
+
+object OsLanguageDetector {
+    fun detect(availableLanguages: List<String>): LanguageCode {
+        val osLocale = Locale.getDefault()
+
+        val fullTag = "${osLocale.language}-${osLocale.country}"
+        if (fullTag in availableLanguages) return LanguageCode(fullTag)
+
+        val shortTag = osLocale.language
+        if (shortTag in availableLanguages) return LanguageCode(shortTag)
+
+        val familyMatch = availableLanguages.firstOrNull {
+            it.startsWith("$shortTag-")
+        }
+        if (familyMatch != null) return LanguageCode(familyMatch)
+
+        return LanguageCode.ENGLISH
+    }
+}


### PR DESCRIPTION
## What does this PR do?

On first launch, instead of always defaulting to English, the app now detects the OS locale and automatically loads the matching language file if one exists.

Detection follows this priority:
1. Exact match — `ar-EG` → `ar-EG`
2. Short tag match — `ar-EG` → `ar`
3. Language family match — `ar-EG` → `ar-SA`
4. Fall back to English if nothing matches

If the user has already manually selected a language in settings, detection is skipped entirely.

## Related issues

Closes #15

## Type of change

- [x] New feature

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [ ] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No UI changes — behaviour only.