### PR TITLE
fix(core): prevent concurrent DataStore creation race condition in PluginKeyValueStore

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/storage/PluginKeyValueStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/storage/PluginKeyValueStore.kt
@@ -22,6 +22,7 @@ class PluginKeyValueStore(private val appDataDirectory: File) {
 
     private val dataStores = mutableMapOf<String, DataStore<Preferences>>()
 
+    @Synchronized
     private fun getDataStore(pluginId: String): DataStore<Preferences> =
         dataStores.getOrPut(pluginId) {
             PreferenceDataStoreFactory.create(


### PR DESCRIPTION
## What does this PR do?

`PluginKeyValueStore.getDataStore()` used a plain `mutableMapOf` with `getOrPut` to cache DataStore instances. Since plugins are initialized concurrently via `async` in `PluginManager.loadAndProcessPlugins()`, two threads could hit `getOrPut` simultaneously for the same plugin ID — causing the lambda to execute twice and creating two DataStore instances pointing at the same file.

This is exactly what DataStore forbids, resulting in:
> "There are multiple DataStore instances active for the same file"

The fix adds `@Synchronized` to `getDataStore()`, making the cache lookup and creation atomic.

## Related issues

Closes #17

## Type of change

- [x] Bug fix

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No UI changes — behaviour only.