### PR TITLE
fix(plugin): Resolve ambiguity in Italian language processing for plugin

### DIFF
--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIRewriterService.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIRewriterService.kt
@@ -23,22 +23,29 @@ class AIRewriterService(
         val styleInstruction = when (request.style) {
             RewriteStyle.FORMAL -> "Rewrite in a formal, professional tone. Use precise vocabulary and complete sentences. Remove slang and colloquialisms."
             RewriteStyle.CASUAL -> "Rewrite in a natural, conversational tone. Use everyday language as if speaking to a friend."
-            RewriteStyle.CONCISE -> "Rewrite as briefly as possible. Remove all filler words, redundancy, and unnecessary detail. Every word must earn its place."
-            RewriteStyle.DETAILED -> "Rewrite in an expanded, thorough form. Add relevant context, elaborate on key points, and ensure nothing important is left ambiguous."
-            RewriteStyle.SIMPLIFIED -> "Rewrite using plain, simple language. Aim for a reading level suitable for a general audience. Avoid jargon and complex sentence structures."
+            RewriteStyle.CONCISE -> "Rewrite as briefly as possible. Remove all filler words, redundancy, and unnecessary detail."
+            RewriteStyle.DETAILED -> "Rewrite in an expanded, thorough form. Add relevant context and elaborate on key points."
+            RewriteStyle.SIMPLIFIED -> "Rewrite using plain, simple language suitable for a general audience. Avoid jargon."
         }
 
         val system = """
-            You are a professional writing assistant.
-            $styleInstruction
-            Output ONLY the rewritten text — no preamble, no labels, no quotes.
-            Preserve the original meaning faithfully.
-            Respond in the SAME LANGUAGE as the input text.
-            Preserve paragraph structure and line breaks.
-        """.trimIndent()
+        You are a professional writing assistant.
+        
+        TASK:
+        $styleInstruction
+        
+        RULES:
+        1. Respond in the EXACT SAME LANGUAGE as the source text.
+        2. Output ONLY the rewritten text. 
+        3. Do NOT include any preamble, labels, or introductory phrases (e.g., do not say "Here is the formal version:").
+        4. Preserve original paragraph structure and line breaks.
+        
+        The text to rewrite begins after the '---' delimiter below.
+        ---
+    """.trimIndent()
 
         return client.complete(system, request.text, jsonMode = false).map { rewritten ->
-            RewriteResponse(rewrittenText = rewritten.trim())
+            RewriteResponse(rewrittenText = rewritten.trim().removeSurrounding("\""))
         }
     }
 }

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISpellCheckerService.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISpellCheckerService.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.plugins.ai
 
+import com.github.ahatem.qtranslate.api.language.LanguageCode
 import com.github.ahatem.qtranslate.api.plugin.ServiceError
 import com.github.ahatem.qtranslate.api.plugin.SupportedLanguages
 import com.github.ahatem.qtranslate.api.spellchecker.*
@@ -29,33 +30,40 @@ class AISpellCheckerService(
                 return@coroutineBinding Ok(SpellCheckResponse(request.text, emptyList())).bind()
             }
 
-            val languageHint = if (request.language.tag != "auto")
-                "The text is written in '${request.language.tag}'."
-            else
+            // Use displayName to avoid the "it" pronoun bug
+            val languageInstruction = if (request.language == LanguageCode.AUTO) {
                 "Detect the language of the text automatically."
+            } else {
+                "The text is written in ${request.language.displayName} (BCP-47: '${request.language.tag}'). Use grammar and spelling rules specific to this language."
+            }
 
             val system = """
-                You are a precise spell-checking and grammar assistant.
-                $languageHint
-                Analyse the user's text for spelling, grammar, style, and punctuation errors.
-                You MUST respond with a single valid JSON object and NOTHING else — no markdown, no prose.
-                Schema:
+            You are a precise spell-checking and grammar assistant.
+            
+            Instruction:
+            $languageInstruction
+            
+            Analyze the user's text for spelling, grammar, style, and punctuation errors.
+            You MUST respond with a single valid JSON object and NOTHING else. No markdown wrapping.
+            
+            Schema:
+            {
+              "corrected_text": "full text with corrections applied",
+              "corrections": [
                 {
-                  "corrected_text": "<full text with ALL corrections applied>",
-                  "corrections": [
-                    {
-                      "original":     "<incorrect span as it appears in the source text>",
-                      "corrected":    "<best replacement>",
-                      "start_index":  <0-based character offset in SOURCE text>,
-                      "end_index":    <exclusive end offset in SOURCE text>,
-                      "type":         "<SPELLING | GRAMMAR | STYLE | PUNCTUATION>",
-                      "message":      "<short explanation or null>"
-                    }
-                  ]
+                  "original": "incorrect span",
+                  "corrected": "replacement",
+                  "start_index": 0,
+                  "end_index": 5,
+                  "type": "SPELLING",
+                  "message": "explanation"
                 }
-                If no errors found: return empty array for corrections and the original text for corrected_text.
-                IMPORTANT: start_index and end_index must reference positions in the ORIGINAL input text.
-            """.trimIndent()
+              ]
+            }
+            
+            Note: If no errors are found, return an empty array for 'corrections' and the original text for 'corrected_text'.
+            IMPORTANT: 'start_index' and 'end_index' must reference the character offsets in the ORIGINAL input string.
+        """.trimIndent()
 
             val raw = client.complete(system, request.text, jsonMode = true).bind()
             parseSpellCheckResponse(raw, request.text).bind()

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISummarizerService.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISummarizerService.kt
@@ -27,15 +27,23 @@ class AISummarizerService(
         }
 
         val system = """
-            You are an expert at summarizing text clearly and accurately.
-            Summarize the user's text in the SAME LANGUAGE as the input.
-            $lengthInstruction
-            Output ONLY the summary — no preamble, no labels, no quotes.
-            Preserve the original meaning faithfully. Do not add opinions or external information.
-        """.trimIndent()
+        You are a professional editor. 
+        
+        TASK:
+        Summarize the text provided by the user. 
+        The summary MUST be written in the same language as the source text itself.
+        
+        CONSTRAINTS:
+        - $lengthInstruction
+        - Output ONLY the summarized text.
+        - Do not include any introductory text, labels, quotes, or conversational filler (e.g., do NOT say "Here is a summary").
+        
+        The user's text to be summarized starts after the '---' delimiter below.
+        ---
+    """.trimIndent()
 
         return client.complete(system, request.text, jsonMode = false).map { summary ->
-            SummarizeResponse(summary = summary.trim())
+            SummarizeResponse(summary = summary.trim().removeSurrounding("\""))
         }
     }
 }

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AITranslatorService.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AITranslatorService.kt
@@ -11,6 +11,11 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.coroutines.coroutineBinding
 import com.github.michaelbull.result.map
+import java.util.Locale
+
+val LanguageCode.displayName: String
+    get() = if (tag == "auto") "Auto-detect"
+    else Locale.forLanguageTag(tag).getDisplayLanguage(Locale.ENGLISH)
 
 class AITranslatorService(
     private val client: AIServiceClient,
@@ -33,11 +38,14 @@ class AITranslatorService(
         }
 
     private suspend fun translateDirect(request: TranslationRequest): Result<TranslationResponse, ServiceError> {
+        val source = request.sourceLanguage.displayName
+        val target = request.targetLanguage.displayName
+
         val system = """
             You are a professional translator.
-            Translate the user's text from ${request.sourceLanguage.tag} to ${request.targetLanguage.tag}.
+            Translate the user's text from $source to $target.
             Output ONLY the translated text — no labels, no explanations, no quotes.
-            Preserve the original formatting, line breaks, and punctuation style.
+            Preserve the original formatting and line breaks.
         """.trimIndent()
 
         return client.complete(system, request.text, jsonMode = false).map { translatedText ->
@@ -47,16 +55,23 @@ class AITranslatorService(
 
     private suspend fun translateWithAutoDetect(request: TranslationRequest): Result<TranslationResponse, ServiceError> =
         coroutineBinding {
+
+            val targetName = request.targetLanguage.displayName
+            val targetTag = request.targetLanguage.tag
+
             val system = """
                 You are a professional translator.
-                Detect the language of the user's text and translate it to ${request.targetLanguage.tag}.
-                You MUST respond with a valid JSON object and nothing else — no markdown fences, no prose.
+                Your task: Detect the source language and translate the text into $targetName (BCP-47 tag: '$targetTag').
+                
+                Strict Rule: You must output ONLY a valid JSON object. No markdown formatting.
+                
                 Schema:
                 {
-                  "translation": "<translated text>",
-                  "detected_language": "<BCP-47 tag of source language, e.g. en, fr, zh-Hans>"
+                  "translation": "translated text here",
+                  "detected_language": "BCP-47 tag of source"
                 }
-                Preserve original formatting and line breaks inside the translation value.
+                
+                Preserve formatting, line breaks, and punctuation.
             """.trimIndent()
 
             val raw = client.complete(system, request.text, jsonMode = true).bind()


### PR DESCRIPTION
## What does this PR do?

This PR fixes a systemic instruction ambiguity bug where the LLM (Gemini) would misinterpret the BCP-47 language tag `it` (Italian) as an English pronoun ("it"). This caused the model to ignore the target language and instead "anchor" to example languages (like French) provided in the JSON schema or system instructions.

Key changes:
- **LanguageCode Enhancement**: Added a `displayName` property that resolves tags to full English names (e.g., `it` -> `Italian`) using `java.util.Locale`.
- **Translator & Spellcheck Fix**: Prompts now use full language names and quoted tags (e.g., `'it'`) to ensure the LLM treats them as literal identifiers rather than pronouns.
- **Prompt Isolation**: Implemented the `---` delimiter across `Summarize` and `Rewrite` services to clearly separate system instructions from user-provided text, preventing "instruction leakage."
- **Output Sanitization**: Added logic to strip leading/trailing quotes and conversational filler from AI responses.

## Related issues

Closes #10

## Type of change

- [x] Bug fix
- [x] Refactor (no behaviour change)

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)
N/A (Logic/Prompt fix)