### PR TITLE
fix(app): await plugin loading before showing main window

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
@@ -5,7 +5,6 @@ import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.SettingsRepository
 import com.github.ahatem.qtranslate.core.shared.AppConstants
 import com.github.ahatem.qtranslate.ui.swing.main.MainAppFrame
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
@@ -61,12 +60,10 @@ fun main() = runBlocking {
     )
     AppUiSetup.apply(initialConfig, deps.themeManager)
 
-    deps.appScope.launch {
-        logger.info("Loading plugins...")
-        runCatching { deps.pluginManager.loadAndProcessPlugins() }
-            .onSuccess { logger.info("Plugins loaded successfully") }
-            .onFailure { e -> logger.error("Failed to load plugins", e) }
-    }
+    logger.info("Loading plugins...")
+    runCatching { deps.pluginManager.loadAndProcessPlugins() }
+        .onSuccess { logger.info("Plugins loaded successfully") }
+        .onFailure { e -> logger.error("Failed to load plugins", e) }
 
     val savedLanguage = if (initialConfig.interfaceLanguage == LanguageCode.ENGLISH.tag) {
         OsLanguageDetector.detect(deps.localizationManager.availableLanguages)


### PR DESCRIPTION
## What does this PR do?

The main window was being shown immediately after plugin loading was fired as a
background job (`appScope.launch`). This caused a race condition where the window
opened before plugins finished loading, so `activeServices` was still empty on the
first `combine` emission in `SelectActiveServiceUseCase`.

As a result:
- The saved translator ID was found in the preset config ✅
- But `services[selectedTranslatorId]` returned `null` (plugins not loaded yet) ❌
- Language dropdowns were empty ❌
- `ActiveServiceManager` fell back to the first available service after plugins
  loaded, which happened to be Arabic ❌

The fix removes the `appScope.launch` wrapper around `loadAndProcessPlugins()` so
plugin loading completes sequentially before the main window is shown. By the time
`combine` emits its first value, `activeServices` is fully populated and the correct
translator and languages are resolved immediately.

## Related issues

Closes #19

## Type of change

- [x] Bug fix

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No UI changes — behaviour only.