### PR TITLE
feat(ui): persist main window size and position across restarts

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -216,6 +216,8 @@ data class Configuration(
     val clearHistoryOnExit: Boolean,
 
     // ---- UI — Main Window ----
+    val mainWindowSize: Size? = null,
+    val mainWindowPosition: Position? = null,
     val uiFontConfig: FontConfig,
     val uiScale: Int,
     val themeId: String,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -13,6 +13,8 @@ import com.github.ahatem.qtranslate.core.plugin.PluginManager
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.CloseButtonBehavior
 import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputType
+import com.github.ahatem.qtranslate.core.settings.data.Position
+import com.github.ahatem.qtranslate.core.settings.data.Size
 import com.github.ahatem.qtranslate.core.settings.data.TextSource
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsIntent
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsStore
@@ -146,15 +148,25 @@ class MainAppFrame(
                 (AppConstants.MIN_WINDOW_WIDTH * scale).toInt(),
                 (AppConstants.MIN_WINDOW_HEIGHT * scale).toInt()
             )
-            preferredSize = Dimension(
-                (AppConstants.DEFAULT_WINDOW_WIDTH * scale).toInt(),
-                (AppConstants.DEFAULT_WINDOW_HEIGHT * scale).toInt()
-            )
+            val savedSize = config.mainWindowSize
+            preferredSize = if (savedSize != null) {
+                Dimension(savedSize.width, savedSize.height)
+            } else {
+                Dimension(
+                    (AppConstants.DEFAULT_WINDOW_WIDTH * scale).toInt(),
+                    (AppConstants.DEFAULT_WINDOW_HEIGHT * scale).toInt()
+                )
+            }
+
+            val savedPosition = config.mainWindowPosition
+            if (savedPosition != null) {
+                setLocation(savedPosition.x, savedPosition.y)
+            }
             iconImages = loadIcons()
 
             mainContentView.render(mainStore.state.value, settingsStore.state.value)
             pack()
-            setLocationRelativeTo(null)
+            if (config.mainWindowPosition == null) setLocationRelativeTo(null)
 
             setupWindowListeners()
             setupMenuBar()
@@ -596,16 +608,19 @@ class MainAppFrame(
     }
 
     private fun setupWindowListeners() {
+
         addWindowListener(object : WindowAdapter() {
             override fun windowOpened(e: WindowEvent?) {
                 mainContentView.requestFocusOnInput()
             }
 
             override fun windowClosing(e: WindowEvent?) {
+                saveWindowBounds()
                 handleCloseButton()
             }
 
             override fun windowIconified(e: WindowEvent?) {
+                saveWindowBounds()
                 isVisible = false
             }
 
@@ -621,6 +636,19 @@ class MainAppFrame(
                 exitProcess(0)
             }
         })
+    }
+
+    private fun saveWindowBounds() {
+        val s = size
+        val p = location
+        settingsStore.dispatch(
+            SettingsIntent.ToggleSetting {
+                it.copy(
+                    mainWindowSize     = Size(s.width, s.height),
+                    mainWindowPosition = Position(p.x.coerceAtLeast(0), p.y.coerceAtLeast(0))
+                )
+            }
+        )
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

The main window size and position were not persisted across restarts — the window
always opened at the default size centered on screen.

Two new nullable fields are added to `Configuration`:
- `mainWindowSize` — persists the window's width and height
- `mainWindowPosition` — persists the window's x/y screen position

Both default to `null` (meaning "not yet saved — use defaults"). On first launch
the window opens at the default size centered on screen as before. On subsequent
launches it restores the last saved size and position.

Size and position are saved in `windowClosing` and `windowIconified` — only when
the user is done interacting, not continuously during resize/move.

## Related issues

Closes #14

## Type of change

- [x] New feature

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No visual changes — behaviour only.