### PR TITLE
docs: add support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ Clean Architecture + MVI. Nothing leaks between layers:
 
 ---
 
+## Support
+
+If QTranslate saves you from Alt-Tabbing to Google Translate a dozen times a day, a coffee is always appreciated!
+
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ahmedhatem-FFDD00?style=flat&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/ahmedhatem)
+
+---
+
 ## Contributing
 
 Bug fixes, features, translations, docs, and plugins all welcome. Look for [`good first issue`](https://github.com/ahatem/QTranslate/labels/good%20first%20issue) for well-scoped starting points.


### PR DESCRIPTION
## What does this PR do?

Adds a Support section to the README with a "Buy Me a Coffee" link for users who want to support the project.

## Related issues

N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [ ] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

N/A