### PR TITLE
feat(i18n): add Bengali (bn-BD) to common languages list

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/TranslationPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/TranslationPanel.kt
@@ -280,7 +280,7 @@ class TranslationPanel(
             "en", "ar", "zh", "zh-TW", "hi", "es", "fr", "de", "ja", "ko",
             "pt", "ru", "it", "nl", "pl", "tr", "uk", "vi", "th", "fa",
             "he", "id", "ms", "sv", "da", "fi", "no", "cs", "ro", "hu",
-            "bg", "el", "sk", "hr", "ca", "sr"
+            "bg", "el", "sk", "hr", "ca", "sr", "bn-BD"
         )
     }
 }


### PR DESCRIPTION
## What does this PR do?

Adds Bengali (bn-BD) to the `COMMON_LANGUAGES` list so it appears among the quick-access / commonly used languages.

## Related issues

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [ ] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

N/A