### PR TITLE
feat(core): add translation rules for automatic target language selection

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
@@ -12,6 +12,7 @@ import com.github.ahatem.qtranslate.core.settings.data.ActiveServiceManager
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputSource
 import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputType
+import com.github.ahatem.qtranslate.core.settings.data.TranslationRule
 import com.github.ahatem.qtranslate.core.shared.AppConstants
 import com.github.ahatem.qtranslate.core.shared.arch.ServiceType
 import com.github.ahatem.qtranslate.core.shared.logging.LoggerFactory
@@ -31,6 +32,16 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * If the architecture ever requires recreating use cases, move [translationJob] onto
  * the [MainStore] and pass it in as a parameter.
+ *
+ * ### Translation Rules
+ * When translation rules are configured, the use case resolves the correct target
+ * language before translating. If the source is Auto Detect, the detected language
+ * from the first translation response is used to check for a matching rule — if one
+ * is found, a second translation is performed with the correct target automatically.
+ * This second call only happens when:
+ * 1. Source is set to Auto Detect
+ * 2. A rule matches the detected language
+ * 3. The rule's target differs from the current target
  */
 class TranslateTextUseCase(
     private val scope: CoroutineScope,
@@ -77,10 +88,28 @@ class TranslateTextUseCase(
                 updateState { copy(isLoading = true, translatedText = "", extraOutputText = "") }
 
                 val currentState = getState()
+                val rules        = settingsState.value.translationRules
+                val isAutoDetect = currentState.sourceLanguage == LanguageCode.AUTO
+
+                // When source is explicitly set, we already know the language — apply
+                // the rule immediately without needing a first-pass translation.
+                val preResolvedTarget = if (!isAutoDetect) {
+                    val detectedOrSelected = currentState.detectedSourceLanguage
+                        ?: currentState.sourceLanguage
+                    resolveTargetFromRules(detectedOrSelected, rules)
+                } else null
+
+                val initialTarget = preResolvedTarget ?: currentState.targetLanguage
+
+                // Update UI immediately if rule changed the target before translating
+                if (preResolvedTarget != null && preResolvedTarget != currentState.targetLanguage) {
+                    updateState { copy(targetLanguage = preResolvedTarget) }
+                }
+
                 val request = TranslationRequest(
                     text           = textToTranslate,
                     sourceLanguage = currentState.sourceLanguage,
-                    targetLanguage = currentState.targetLanguage
+                    targetLanguage = initialTarget
                 )
 
                 logger.debug(
@@ -102,21 +131,50 @@ class TranslateTextUseCase(
                 result.fold(
                     success = { response ->
                         logger.info("Translation successful: '${response.translatedText.take(50)}...'")
-                        onStatusUpdate("Translation complete.", NotificationType.SUCCESS, true)
 
                         val detectedLanguage = response.detectedLanguage
-                            .takeIf { currentState.sourceLanguage == LanguageCode.AUTO }
+                            .takeIf { isAutoDetect }
+
+                        // Re-translate if Auto Detect revealed a rule match
+                        // Only triggers when:
+                        // 1. Source was Auto Detect
+                        // 2. A language was detected from the response
+                        // 3. A rule matches the detected language
+                        // 4. The rule target differs from what we just translated to
+                        if (isAutoDetect && detectedLanguage != null) {
+                            val ruleTarget = resolveTargetFromRules(detectedLanguage, rules)
+                            if (ruleTarget != null && ruleTarget != initialTarget) {
+                                logger.debug(
+                                    "Rule matched detected '${detectedLanguage.tag}' → " +
+                                            "re-translating to '${ruleTarget.tag}'"
+                                )
+                                handleReTranslation(
+                                    textToTranslate  = textToTranslate,
+                                    sourceLanguage   = currentState.sourceLanguage,
+                                    ruleTarget       = ruleTarget,
+                                    detectedLanguage = detectedLanguage,
+                                    currentState     = currentState,
+                                    translator       = translator,
+                                    updateState      = updateState,
+                                    onStatusUpdate   = onStatusUpdate
+                                )
+                                return@launch
+                            }
+                        }
+
+                        // ---- Normal path — no re-translation needed ----
+                        onStatusUpdate("Translation complete.", NotificationType.SUCCESS, true)
 
                         val (newHistory, newHistoryIndex) = buildHistory(
                             currentState, textToTranslate, response.translatedText, translator.id
                         )
 
                         val extraOutput = handleExtraOutput(
-                            targetText          = response.translatedText,
-                            sourceForBackward   = detectedLanguage ?: currentState.sourceLanguage,
-                            targetForBackward   = currentState.targetLanguage,
-                            translator          = translator,
-                            onStatusUpdate      = onStatusUpdate
+                            targetText        = response.translatedText,
+                            sourceForBackward = detectedLanguage ?: currentState.sourceLanguage,
+                            targetForBackward = initialTarget,
+                            translator        = translator,
+                            onStatusUpdate    = onStatusUpdate
                         )
 
                         updateState {
@@ -153,6 +211,89 @@ class TranslateTextUseCase(
 
         translationJob?.join()
     }
+
+    /**
+     * Performs a second translation when Auto Detect revealed a rule match.
+     * Updates state with the final result and correct target language.
+     */
+    private suspend fun handleReTranslation(
+        textToTranslate: String,
+        sourceLanguage: LanguageCode,
+        ruleTarget: LanguageCode,
+        detectedLanguage: LanguageCode,
+        currentState: MainState,
+        translator: Translator,
+        updateState: (MainState.() -> MainState) -> Unit,
+        onStatusUpdate: suspend (message: String, type: NotificationType, isTemporary: Boolean) -> Unit
+    ) {
+        val retryRequest = TranslationRequest(
+            text           = textToTranslate,
+            sourceLanguage = sourceLanguage,
+            targetLanguage = ruleTarget
+        )
+
+        val retryResult = withTimeoutOrNull(AppConstants.TRANSLATION_TIMEOUT_MS) {
+            translator.translate(retryRequest)
+        }
+
+        if (retryResult == null) {
+            logger.error("Re-translation timed out")
+            updateState { copy(isLoading = false) }
+            onStatusUpdate("Translation timed out. Please try again.", NotificationType.ERROR, true)
+            return
+        }
+
+        retryResult.fold(
+            success = { retryResponse ->
+                logger.info("Re-translation successful: '${retryResponse.translatedText.take(50)}...'")
+                onStatusUpdate("Translation complete.", NotificationType.SUCCESS, true)
+
+                val (newHistory, newHistoryIndex) = buildHistory(
+                    currentState, textToTranslate, retryResponse.translatedText, translator.id
+                )
+
+                val extraOutput = handleExtraOutput(
+                    targetText        = retryResponse.translatedText,
+                    sourceForBackward = detectedLanguage,
+                    targetForBackward = ruleTarget,
+                    translator        = translator,
+                    onStatusUpdate    = onStatusUpdate
+                )
+
+                updateState {
+                    copy(
+                        isLoading              = false,
+                        translatedText         = retryResponse.translatedText,
+                        detectedSourceLanguage = detectedLanguage,
+                        targetLanguage         = ruleTarget,
+                        history                = newHistory,
+                        historyIndex           = newHistoryIndex,
+                        extraOutputText        = extraOutput
+                    )
+                }
+
+                if (settingsState.value.isHistoryEnabled) {
+                    historyRepository.saveHistory(newHistory)
+                }
+            },
+            failure = { error ->
+                logger.error("Re-translation failed: ${error.message}", error.cause)
+                updateState { copy(isLoading = false) }
+                onStatusUpdate("Translation failed: ${error.message}", NotificationType.ERROR, true)
+            }
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Rules
+    // -------------------------------------------------------------------------
+
+    private fun resolveTargetFromRules(
+        detectedSource: LanguageCode,
+        rules: List<TranslationRule>
+    ): LanguageCode? =
+        rules.firstOrNull { it.sourceLanguage == detectedSource.tag }
+            ?.let { LanguageCode(it.targetLanguage) }
 
     // -------------------------------------------------------------------------
     // History

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -166,6 +166,13 @@ data class ServicePreset(
     }
 }
 
+
+@Serializable
+data class TranslationRule(
+    val sourceLanguage: String,
+    val targetLanguage: String
+)
+
 // -------------------------------------------------------------------------
 // Root configuration
 // -------------------------------------------------------------------------
@@ -199,6 +206,7 @@ data class Configuration(
      * Mohamed's request.
      */
     val isRemoveLineBreaksEnabled: Boolean = false,
+    val translationRules: List<TranslationRule> = emptyList(),
 
     // ---- Language Filtering ----
     /**

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/mvi/SettingsIntent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/mvi/SettingsIntent.kt
@@ -1,6 +1,7 @@
 package com.github.ahatem.qtranslate.core.settings.mvi
 
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
+import com.github.ahatem.qtranslate.core.settings.data.TranslationRule
 import com.github.ahatem.qtranslate.core.shared.arch.ServiceType
 import com.github.ahatem.qtranslate.core.shared.arch.UiIntent
 
@@ -103,4 +104,10 @@ sealed interface SettingsIntent : UiIntent {
      * Renames the preset identified by [presetId] to [newName] and immediately saves.
      */
     data class RenamePreset(val presetId: String, val newName: String) : SettingsIntent
+
+    /** Adds a new translation rule and immediately saves. */
+    data class AddTranslationRule(val rule: TranslationRule) : SettingsIntent
+
+    /** Removes an existing translation rule and immediately saves. */
+    data class RemoveTranslationRule(val rule: TranslationRule) : SettingsIntent
 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/mvi/SettingsStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/mvi/SettingsStore.kt
@@ -141,6 +141,22 @@ class SettingsStore(
             is SettingsIntent.RenamePreset ->
                 presetManager.renamePreset(_state.value.workingConfiguration, intent.presetId, intent.newName)
                     .also { launchSave() }
+
+            is SettingsIntent.AddTranslationRule -> {
+                val updated = _state.value.workingConfiguration.copy(
+                    translationRules = _state.value.workingConfiguration.translationRules + intent.rule
+                )
+                applyWorkingUpdate(updated)
+                launchSave()
+            }
+
+            is SettingsIntent.RemoveTranslationRule -> {
+                val updated = _state.value.workingConfiguration.copy(
+                    translationRules = _state.value.workingConfiguration.translationRules - intent.rule
+                )
+                applyWorkingUpdate(updated)
+                launchSave()
+            }
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/TranslationPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/TranslationPanel.kt
@@ -1,14 +1,20 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
-import com.github.ahatem.qtranslate.core.localization.LocalizationManager
+import com.github.ahatem.qtranslate.api.language.LanguageCode
 import com.github.ahatem.qtranslate.api.rewriter.RewriteStyle
 import com.github.ahatem.qtranslate.api.summarizer.SummaryLength
+import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputSource
 import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputType
+import com.github.ahatem.qtranslate.core.settings.data.TranslationRule
+import com.github.ahatem.qtranslate.core.settings.mvi.SettingsIntent
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsState
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsStore
+import com.github.ahatem.qtranslate.ui.swing.shared.util.GridBag
 import java.awt.*
 import javax.swing.*
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.table.DefaultTableModel
 
 class TranslationPanel(
     private val store: SettingsStore,
@@ -17,37 +23,70 @@ class TranslationPanel(
 
     private val summaryLengths by lazy {
         listOf(
-            SummaryLengthInfo(SummaryLength.SHORT,  localizationManager.getString("settings_translation.summary_length_short")),
-            SummaryLengthInfo(SummaryLength.MEDIUM, localizationManager.getString("settings_translation.summary_length_medium")),
-            SummaryLengthInfo(SummaryLength.LONG,   localizationManager.getString("settings_translation.summary_length_long"))
+            SummaryLengthInfo(
+                SummaryLength.SHORT,
+                localizationManager.getString("settings_translation.summary_length_short")
+            ),
+            SummaryLengthInfo(
+                SummaryLength.MEDIUM,
+                localizationManager.getString("settings_translation.summary_length_medium")
+            ),
+            SummaryLengthInfo(
+                SummaryLength.LONG,
+                localizationManager.getString("settings_translation.summary_length_long")
+            )
         )
     }
 
     private val rewriteStyles by lazy {
         listOf(
-            RewriteStyleInfo(RewriteStyle.FORMAL,     localizationManager.getString("settings_translation.rewrite_style_formal")),
-            RewriteStyleInfo(RewriteStyle.CASUAL,     localizationManager.getString("settings_translation.rewrite_style_casual")),
-            RewriteStyleInfo(RewriteStyle.CONCISE,    localizationManager.getString("settings_translation.rewrite_style_concise")),
-            RewriteStyleInfo(RewriteStyle.DETAILED,   localizationManager.getString("settings_translation.rewrite_style_detailed")),
-            RewriteStyleInfo(RewriteStyle.SIMPLIFIED, localizationManager.getString("settings_translation.rewrite_style_simplified"))
+            RewriteStyleInfo(
+                RewriteStyle.FORMAL,
+                localizationManager.getString("settings_translation.rewrite_style_formal")
+            ),
+            RewriteStyleInfo(
+                RewriteStyle.CASUAL,
+                localizationManager.getString("settings_translation.rewrite_style_casual")
+            ),
+            RewriteStyleInfo(
+                RewriteStyle.CONCISE,
+                localizationManager.getString("settings_translation.rewrite_style_concise")
+            ),
+            RewriteStyleInfo(
+                RewriteStyle.DETAILED,
+                localizationManager.getString("settings_translation.rewrite_style_detailed")
+            ),
+            RewriteStyleInfo(
+                RewriteStyle.SIMPLIFIED,
+                localizationManager.getString("settings_translation.rewrite_style_simplified")
+            )
         )
     }
 
     private val types by lazy {
         listOf(
-            ExtraOutputTypeInfo(ExtraOutputType.None,             localizationManager.getString("settings_translation.type_none")),
-            ExtraOutputTypeInfo(ExtraOutputType.BackwardTranslate,localizationManager.getString("settings_translation.type_backward")),
-            ExtraOutputTypeInfo(ExtraOutputType.Summarize,        localizationManager.getString("settings_translation.type_summarize")),
-            ExtraOutputTypeInfo(ExtraOutputType.Rewrite,          localizationManager.getString("settings_translation.type_rewrite"))
+            ExtraOutputTypeInfo(ExtraOutputType.None, localizationManager.getString("settings_translation.type_none")),
+            ExtraOutputTypeInfo(
+                ExtraOutputType.BackwardTranslate,
+                localizationManager.getString("settings_translation.type_backward")
+            ),
+            ExtraOutputTypeInfo(
+                ExtraOutputType.Summarize,
+                localizationManager.getString("settings_translation.type_summarize")
+            ),
+            ExtraOutputTypeInfo(
+                ExtraOutputType.Rewrite,
+                localizationManager.getString("settings_translation.type_rewrite")
+            )
         )
     }
 
-    private lateinit var instantCheck:          JCheckBox
-    private lateinit var spellCheck:            JCheckBox
+    private lateinit var instantCheck: JCheckBox
+    private lateinit var spellCheck: JCheckBox
     private lateinit var removeLineBreaksCheck: JCheckBox
-    private lateinit var typeCombo:             JComboBox<ExtraOutputTypeInfo>
-    private lateinit var useTranslated:         JRadioButton
-    private lateinit var useInput:              JRadioButton
+    private lateinit var typeCombo: JComboBox<ExtraOutputTypeInfo>
+    private lateinit var useTranslated: JRadioButton
+    private lateinit var useInput: JRadioButton
 
     // Conditional setting rows — shown only for the relevant extra output type
     private lateinit var summaryLengthRow: JPanel
@@ -71,27 +110,39 @@ class TranslationPanel(
     // ActionListener checks isUpdatingFromState synchronously in the same call.
     private val languageCheckBoxes = mutableListOf<Pair<String, JCheckBox>>()
 
-    init { buildUI() }
+    // Translation rules table
+    private lateinit var rulesTable: JTable
+    private lateinit var rulesTableModel: DefaultTableModel
+    private lateinit var removeRuleBtn: JButton
+
+    init {
+        buildUI()
+    }
+
+    // -------------------------------------------------------------------------
+    // UI construction
+    // -------------------------------------------------------------------------
 
     private fun buildUI() {
+
         // ---- Behaviour ----
         addSeparator(localizationManager.getString("settings_translation.behavior_group"))
 
         instantCheck = addCheckbox(
-            text     = localizationManager.getString("settings_translation.instant_translation"),
+            text = localizationManager.getString("settings_translation.instant_translation"),
             selected = false,
             onChange = { enabled -> applyDraft(store) { it.copy(isInstantTranslationEnabled = enabled) } }
         )
         addHint(localizationManager.getString("settings_translation.instant_hint"))
 
         spellCheck = addCheckbox(
-            text     = localizationManager.getString("settings_translation.spell_check_input"),
+            text = localizationManager.getString("settings_translation.spell_check_input"),
             selected = false,
             onChange = { enabled -> applyDraft(store) { it.copy(isSpellCheckingEnabled = enabled) } }
         )
 
         removeLineBreaksCheck = addCheckbox(
-            text     = localizationManager.getString("settings_translation.remove_line_breaks"),
+            text = localizationManager.getString("settings_translation.remove_line_breaks"),
             selected = false,
             onChange = { enabled -> applyDraft(store) { it.copy(isRemoveLineBreaksEnabled = enabled) } }
         )
@@ -126,9 +177,12 @@ class TranslationPanel(
             }
         }
         summaryLengthRow = JPanel(java.awt.BorderLayout(8, 0)).apply {
-            isOpaque  = false
+            isOpaque = false
             isVisible = false  // hidden until type = Summarize
-            add(JLabel(localizationManager.getString("settings_translation.summary_length")), java.awt.BorderLayout.LINE_START)
+            add(
+                JLabel(localizationManager.getString("settings_translation.summary_length")),
+                java.awt.BorderLayout.LINE_START
+            )
             add(summaryLengthCombo, java.awt.BorderLayout.CENTER)
         }
         gb.nextRow().spanLine().weightX(1.0).fill(GridBagConstraints.HORIZONTAL)
@@ -145,20 +199,24 @@ class TranslationPanel(
             }
         }
         rewriteStyleRow = JPanel(java.awt.BorderLayout(8, 0)).apply {
-            isOpaque  = false
+            isOpaque = false
             isVisible = false  // hidden until type = Rewrite
-            add(JLabel(localizationManager.getString("settings_translation.rewrite_style")), java.awt.BorderLayout.LINE_START)
+            add(
+                JLabel(localizationManager.getString("settings_translation.rewrite_style")),
+                java.awt.BorderLayout.LINE_START
+            )
             add(rewriteStyleCombo, java.awt.BorderLayout.CENTER)
         }
         gb.nextRow().spanLine().weightX(1.0).fill(GridBagConstraints.HORIZONTAL)
             .insets(4, 0, 0, 0).add(rewriteStyleRow)
 
-        useTranslated = JRadioButton(localizationManager.getString("settings_translation.source_use_translated")).apply {
-            addActionListener {
-                if (isSelected && !isUpdatingFromState)
-                    applyDraft(store) { it.copy(extraOutputSource = ExtraOutputSource.Output) }
+        useTranslated =
+            JRadioButton(localizationManager.getString("settings_translation.source_use_translated")).apply {
+                addActionListener {
+                    if (isSelected && !isUpdatingFromState)
+                        applyDraft(store) { it.copy(extraOutputSource = ExtraOutputSource.Output) }
+                }
             }
-        }
         useInput = JRadioButton(localizationManager.getString("settings_translation.source_use_input")).apply {
             addActionListener {
                 if (isSelected && !isUpdatingFromState)
@@ -168,7 +226,7 @@ class TranslationPanel(
         ButtonGroup().apply { add(useTranslated); add(useInput) }
 
         val radioPanel = JPanel().apply {
-            layout   = BoxLayout(this, BoxLayout.Y_AXIS)
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
             add(useTranslated)
             add(Box.createVerticalStrut(4))
@@ -177,26 +235,111 @@ class TranslationPanel(
         gb.nextRow().add(JLabel(localizationManager.getString("settings_translation.extra_output_source")))
         gb.weightX(1.0).fill(GridBagConstraints.HORIZONTAL).anchor(GridBagConstraints.LINE_START).add(radioPanel)
 
+        // ---- Translation Rules ----
+        addSeparator(localizationManager.getString("settings_translation.rules_group"))
+        addHint(localizationManager.getString("settings_translation.rules_hint"))
+
+        // Table model — stores raw language codes, renderer shows localized names
+        rulesTableModel = object : DefaultTableModel(
+            arrayOf(
+                localizationManager.getString("settings_translation.rules_col_source"),
+                localizationManager.getString("settings_translation.rules_col_target")
+            ), 0
+        ) {
+            override fun isCellEditable(row: Int, column: Int) = false
+        }
+
+        // Custom renderer — displays localized name but raw code is stored in model
+        val localizedRenderer = object : DefaultTableCellRenderer() {
+            override fun setValue(value: Any?) {
+                text = localizedName(value as? String ?: "")
+            }
+        }
+
+        rulesTable = JTable(rulesTableModel).apply {
+            setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+            tableHeader.reorderingAllowed = false
+            tableHeader.resizingAllowed = true
+            rowHeight = 28
+            showHorizontalLines = true
+            showVerticalLines = false
+            intercellSpacing = Dimension(0, 1)
+            fillsViewportHeight = true
+
+            // Apply localized renderer to both columns
+            columnModel.getColumn(0).cellRenderer = localizedRenderer
+            columnModel.getColumn(1).cellRenderer = localizedRenderer
+
+            // Enable/disable Remove button based on row selection
+            selectionModel.addListSelectionListener {
+                if (!it.valueIsAdjusting) {
+                    removeRuleBtn.isEnabled = selectedRow >= 0
+                }
+            }
+        }
+
+        gb.nextRow()
+            .spanLine()
+            .weightX(1.0)
+            .fill(GridBagConstraints.HORIZONTAL)
+            .insets(4, 0, 4, 0)
+            .add(JScrollPane(rulesTable).apply {
+                preferredSize = Dimension(580, 150)
+                verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
+                horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+                border = BorderFactory.createLineBorder(
+                    UIManager.getColor("Component.borderColor") ?: Color.GRAY
+                )
+            })
+
+        // Add Rule / Remove Rule buttons
+        val addRuleBtn = JButton(localizationManager.getString("settings_translation.rules_add_btn")).apply {
+            addActionListener { showAddRuleDialog() }
+        }
+
+        removeRuleBtn = JButton(localizationManager.getString("settings_translation.rules_remove_btn")).apply {
+            isEnabled = false // disabled until a row is selected
+            addActionListener {
+                val selectedRow = rulesTable.selectedRow
+                if (selectedRow < 0) return@addActionListener
+                // Read raw codes from model — NOT localized display names
+                val source = rulesTableModel.getValueAt(selectedRow, 0) as? String ?: return@addActionListener
+                val target = rulesTableModel.getValueAt(selectedRow, 1) as? String ?: return@addActionListener
+                store.dispatch(SettingsIntent.RemoveTranslationRule(TranslationRule(source, target)))
+            }
+        }
+
+        gb.nextRow()
+            .spanLine()
+            .weightX(1.0)
+            .fill(GridBagConstraints.HORIZONTAL)
+            .insets(0, 0, 0, 0)
+            .add(JPanel(FlowLayout(FlowLayout.LEADING, 4, 0)).apply {
+                isOpaque = false
+                add(addRuleBtn)
+                add(removeRuleBtn)
+            })
+
         // ---- Pinned languages ----
         addSeparator(localizationManager.getString("settings_translation.pinned_languages_group"))
         addHint(localizationManager.getString("settings_translation.pinned_languages_hint"))
 
         val checkBoxPanel = JPanel().apply {
-            layout   = BoxLayout(this, BoxLayout.Y_AXIS)
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
-            border   = BorderFactory.createEmptyBorder(4, 8, 4, 4)
+            border = BorderFactory.createEmptyBorder(4, 8, 4, 4)
         }
 
         COMMON_LANGUAGES.forEach { code ->
             val name = localizedName(code)
-            val cb   = JCheckBox("$name  ($code)").apply {
+            val cb = JCheckBox("$name  ($code)").apply {
                 isOpaque = false
                 addActionListener {
                     if (!isUpdatingFromState) {
                         // Collect ALL checked codes and save at once
                         val selected = languageCheckBoxes
                             .filter { (_, box) -> box.isSelected }
-                            .map    { (c, _)   -> c }
+                            .map { (c, _) -> c }
                         applyDraft(store) { it.copy(pinnedLanguages = selected) }
                     }
                 }
@@ -209,8 +352,8 @@ class TranslationPanel(
         gb.nextRow().spanLine().weightX(1.0).fill(GridBagConstraints.HORIZONTAL)
             .insets(4, 0, 0, 0)
             .add(JScrollPane(checkBoxPanel).apply {
-                preferredSize             = Dimension(580, 200)
-                verticalScrollBarPolicy   = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
+                preferredSize = Dimension(580, 200)
+                verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
                 horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
                 border = BorderFactory.createLineBorder(
                     UIManager.getColor("Component.borderColor") ?: Color.GRAY
@@ -234,27 +377,101 @@ class TranslationPanel(
         finishLayout()
     }
 
+    // -------------------------------------------------------------------------
+    // Add Rule dialog
+    // -------------------------------------------------------------------------
+
+    private fun showAddRuleDialog() {
+        val sourceCombo = JComboBox<String>(COMMON_LANGUAGES).apply {
+            setRenderer { _, value, _, _, _ -> JLabel(localizedName(value ?: "")) }
+        }
+        val targetCombo = JComboBox<String>(COMMON_LANGUAGES).apply {
+            setRenderer { _, value, _, _, _ -> JLabel(localizedName(value ?: "")) }
+        }
+
+        val panel = JPanel(GridBagLayout()).apply {
+            val g = GridBag(this, horizontalGap = 8, verticalGap = 8)
+            g.nextRow().add(JLabel(localizationManager.getString("settings_translation.rules_dialog_source")))
+            g.weightX(1.0).fill(GridBagConstraints.HORIZONTAL).add(sourceCombo)
+            g.nextRow().add(JLabel(localizationManager.getString("settings_translation.rules_dialog_target")))
+            g.weightX(1.0).fill(GridBagConstraints.HORIZONTAL).add(targetCombo)
+        }
+
+        val result = JOptionPane.showConfirmDialog(
+            this,
+            panel,
+            localizationManager.getString("settings_translation.rules_dialog_title"),
+            JOptionPane.OK_CANCEL_OPTION,
+            JOptionPane.PLAIN_MESSAGE
+        )
+
+        if (result != JOptionPane.OK_OPTION) return
+
+        val source = sourceCombo.selectedItem as? String ?: return
+        val target = targetCombo.selectedItem as? String ?: return
+
+        if (source == target) {
+            JOptionPane.showMessageDialog(
+                this,
+                localizationManager.getString("settings_translation.rules_error_same"),
+                localizationManager.getString("settings_translation.rules_error_same_title"),
+                JOptionPane.WARNING_MESSAGE
+            )
+            return
+        }
+
+        val existing = store.state.value.workingConfiguration.translationRules
+        if (existing.any { it.sourceLanguage == source }) {
+            JOptionPane.showMessageDialog(
+                this,
+                localizationManager.getString("settings_translation.rules_error_duplicate", localizedName(source)),
+                localizationManager.getString("settings_translation.rules_error_duplicate_title"),
+                JOptionPane.WARNING_MESSAGE
+            )
+            return
+        }
+
+        store.dispatch(SettingsIntent.AddTranslationRule(TranslationRule(source, target)))
+    }
+
+    // -------------------------------------------------------------------------
+    // Render
+    // -------------------------------------------------------------------------
+
     override fun render(state: SettingsState) {
         val c = state.workingConfiguration
         withoutTrigger {
-            instantCheck.isSelected          = c.isInstantTranslationEnabled
-            spellCheck.isSelected            = c.isSpellCheckingEnabled
+            instantCheck.isSelected = c.isInstantTranslationEnabled
+            spellCheck.isSelected = c.isSpellCheckingEnabled
             removeLineBreaksCheck.isSelected = c.isRemoveLineBreaksEnabled
-            typeCombo.selectedItem           = types.find { it.type == c.extraOutputType }
+            typeCombo.selectedItem = types.find { it.type == c.extraOutputType }
 
             when (c.extraOutputSource) {
                 ExtraOutputSource.Output -> useTranslated.isSelected = true
-                ExtraOutputSource.Input  -> useInput.isSelected      = true
+                ExtraOutputSource.Input -> useInput.isSelected = true
             }
             val extraEnabled = c.extraOutputType != ExtraOutputType.None
             useTranslated.isEnabled = extraEnabled
-            useInput.isEnabled      = extraEnabled
+            useInput.isEnabled = extraEnabled
 
             // Sync and show/hide conditional settings
             summaryLengthCombo.selectedItem = summaryLengths.find { it.length == c.summaryLength }
-            rewriteStyleCombo.selectedItem  = rewriteStyles.find  { it.style  == c.rewriteStyle  }
+            rewriteStyleCombo.selectedItem = rewriteStyles.find { it.style == c.rewriteStyle }
             summaryLengthRow.isVisible = c.extraOutputType == ExtraOutputType.Summarize
-            rewriteStyleRow.isVisible  = c.extraOutputType == ExtraOutputType.Rewrite
+            rewriteStyleRow.isVisible = c.extraOutputType == ExtraOutputType.Rewrite
+
+            // Sync translation rules table
+            // Store raw codes — renderer handles localized display
+            val selectedRow = rulesTable.selectedRow
+            rulesTableModel.rowCount = 0
+            c.translationRules.forEach { rule ->
+                rulesTableModel.addRow(arrayOf(rule.sourceLanguage, rule.targetLanguage))
+            }
+            // Restore selection if still valid after re-population
+            if (selectedRow >= 0 && selectedRow < rulesTableModel.rowCount) {
+                rulesTable.setRowSelectionInterval(selectedRow, selectedRow)
+            }
+            removeRuleBtn.isEnabled = rulesTable.selectedRow >= 0
 
             // Sync checkboxes — direct assignment, no selection model, no events fired
             // (isUpdatingFromState = true, so ActionListeners are all guarded)
@@ -265,9 +482,13 @@ class TranslationPanel(
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
     private fun localizedName(code: String): String {
         val locale = runCatching { java.util.Locale.forLanguageTag(code) }.getOrNull()
-        val name   = locale?.getDisplayLanguage(java.util.Locale.ENGLISH)
+        val name = locale?.getDisplayLanguage(java.util.Locale.ENGLISH)
         return if (!name.isNullOrBlank() && name != code) name else code
     }
 
@@ -276,11 +497,81 @@ class TranslationPanel(
     private data class RewriteStyleInfo(val style: RewriteStyle, val displayName: String)
 
     companion object {
-        private val COMMON_LANGUAGES = listOf(
-            "en", "ar", "zh", "zh-TW", "hi", "es", "fr", "de", "ja", "ko",
-            "pt", "ru", "it", "nl", "pl", "tr", "uk", "vi", "th", "fa",
-            "he", "id", "ms", "sv", "da", "fi", "no", "cs", "ro", "hu",
-            "bg", "el", "sk", "hr", "ca", "sr", "bn-BD"
-        )
+        private val COMMON_LANGUAGES = LanguageCode.all().toTypedArray()
     }
 }
+
+fun LanguageCode.Companion.all(): List<String> = listOf(
+    ENGLISH,
+    CHINESE_SIMPLIFIED,
+    CHINESE_TRADITIONAL,
+    HINDI,
+    SPANISH,
+    FRENCH,
+    ARABIC,
+    BENGALI,
+    RUSSIAN,
+    PORTUGUESE,
+    INDONESIAN,
+    URDU,
+    GERMAN,
+    JAPANESE,
+    SWAHILI,
+    MARATHI,
+    TELUGU,
+    TURKISH,
+    TAMIL,
+    VIETNAMESE,
+    KOREAN,
+    ITALIAN,
+    THAI,
+    GUJARATI,
+    JAVANESE,
+    FARSI,
+    HAUSA,
+    BURMESE,
+    POLISH,
+    UKRAINIAN,
+    YORUBA,
+    DUTCH,
+    GREEK,
+    HEBREW,
+    HUNGARIAN,
+    CZECH,
+    SWEDISH,
+    ROMANIAN,
+    DANISH,
+    FINNISH,
+    BULGARIAN,
+    NORWEGIAN,
+    SLOVAK,
+    SLOVENIAN,
+    CATALAN,
+    SERBIAN,
+    CROATIAN,
+    MALAY,
+    NEPALI,
+    SINHALA,
+    KHMER,
+    LAO,
+    AMHARIC,
+    SOMALI,
+    ZULU,
+    AFRIKAANS,
+    ALBANIAN,
+    ARMENIAN,
+    AZERBAIJANI,
+    BASQUE,
+    BELARUSIAN,
+    BOSNIAN,
+    ESTONIAN,
+    GEORGIAN,
+    ICELANDIC,
+    IRISH,
+    LATVIAN,
+    LITHUANIAN,
+    MACEDONIAN,
+    MALTESE,
+    MONGOLIAN,
+    WELSH
+).map { it.tag }


### PR DESCRIPTION
## What does this PR do?

Adds a Translation Rules system that automatically selects the target language
based on the detected source language, removing the need to manually switch
the target language when translating between two or more languages frequently.

Rules are configured as a simple table in Settings → Translation:

| Source Language | Target Language |
|---|---|
| English | Japanese |
| Japanese | English |

**How it works:**
- If the source language is explicitly set, the rule is applied immediately
  before translation — single API call, UI updates right away.
- If the source is set to Auto Detect, the first translation runs normally
  to detect the language. If a rule matches the detected language, a second
  translation is performed automatically with the correct target (Option C).
  The second call only happens when a rule actually matches — no unnecessary
  API calls otherwise.
- If no rule matches, the manually selected target language is used as normal.

## Related issues

Closes #16

## Type of change

- [x] New feature

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [ ] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Attach a screenshot of the Translation Rules table in Settings -->