### PR TITLE
fix(ui): localize Auto-Detect and Default preset name, redesign close dialog

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LanguageDisplayNameProvider.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LanguageDisplayNameProvider.kt
@@ -3,8 +3,11 @@ package com.github.ahatem.qtranslate.core.localization
 import com.github.ahatem.qtranslate.api.language.LanguageCode
 import java.util.*
 
-fun LanguageCode.getDisplayName(uiLocale: Locale = Locale.getDefault()): String {
-    if (this == LanguageCode.AUTO) return "Auto-Detect"
+fun LanguageCode.getDisplayName(
+    uiLocale: Locale = Locale.getDefault(),
+    autoDetectLabel: String = "Auto-Detect"
+): String {
+    if (this == LanguageCode.AUTO) return autoDetectLabel
 
     return runCatching {
         val locale = Locale.forLanguageTag(tag)

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -145,6 +145,9 @@ data class ServicePreset(
     val selectedServices: Map<ServiceType, String?>
 ) {
     companion object {
+
+        const val DEFAULT_PRESET_NAME = "__default__" // internal sentinel, never shown to user
+
         private const val DEFAULT_TRANSLATOR    = "google-translator"
         private const val DEFAULT_TTS           = "google-tts"
         private const val DEFAULT_SPELL_CHECKER = "google-spell-checker"
@@ -152,7 +155,7 @@ data class ServicePreset(
         private const val DEFAULT_DICTIONARY    = "google-dictionary"
 
         @OptIn(ExperimentalUuidApi::class)
-        fun createDefault(name: String = "Default"): ServicePreset = ServicePreset(
+        fun createDefault(name: String = DEFAULT_PRESET_NAME): ServicePreset = ServicePreset(
             id = Uuid.random().toString(),
             name = name,
             selectedServices = mapOf(

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -45,6 +45,7 @@ delete = "Delete"
 rename = "Rename..."
 new = "New..."
 configure = "Configure"
+auto_detect = "Auto-Detect"
 
 # ===================================================================
 # MAIN APPLICATION WINDOW
@@ -172,6 +173,7 @@ font_preview_text = "The quick brown fox jumps over the lazy dog — 大きな�
 presets_group = "Active Preset"
 current_preset = "Current Preset:"
 preset_hint = "Presets let you save different service combinations and switch between them quickly."
+default_preset_name = "Default"
 new_preset_btn = "@common.new"
 rename_preset_btn = "@common.rename"
 delete_preset_btn = "@common.delete"

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialog.kt
@@ -73,7 +73,7 @@ class InfoDialog(owner: Frame) : JDialog(owner, true) {
         titleLabel.text = state.appName
         versionLabel.text = state.versionText
         iconLabel.icon = state.icon
-        descriptionLabel.text = "<html><div style='text-align: center;'>${state.descriptionHtml}</div></html>"
+        descriptionLabel.text = "<html><div style='text-align: center;'>${state.descriptionHtml.replace("\n", "<br>")}</div></html>"
 
         if (state.websiteUrl.isNotBlank()) {
             linkLabel.text = "<html><a href=''>${state.websiteUrl}</a></html>"

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -10,12 +10,7 @@ import com.github.ahatem.qtranslate.core.main.mvi.MainIntent
 import com.github.ahatem.qtranslate.core.main.mvi.MainState
 import com.github.ahatem.qtranslate.core.main.mvi.MainStore
 import com.github.ahatem.qtranslate.core.plugin.PluginManager
-import com.github.ahatem.qtranslate.core.settings.data.Configuration
-import com.github.ahatem.qtranslate.core.settings.data.CloseButtonBehavior
-import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputType
-import com.github.ahatem.qtranslate.core.settings.data.Position
-import com.github.ahatem.qtranslate.core.settings.data.Size
-import com.github.ahatem.qtranslate.core.settings.data.TextSource
+import com.github.ahatem.qtranslate.core.settings.data.*
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsIntent
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsStore
 import com.github.ahatem.qtranslate.core.shared.AppConstants
@@ -644,7 +639,7 @@ class MainAppFrame(
         settingsStore.dispatch(
             SettingsIntent.ToggleSetting {
                 it.copy(
-                    mainWindowSize     = Size(s.width, s.height),
+                    mainWindowSize = Size(s.width, s.height),
                     mainWindowPosition = Position(p.x.coerceAtLeast(0), p.y.coerceAtLeast(0))
                 )
             }
@@ -663,46 +658,104 @@ class MainAppFrame(
     private fun handleCloseButton() {
         when (settingsStore.state.value.originalConfiguration.closeButtonBehavior) {
             CloseButtonBehavior.MINIMIZE_TO_TRAY -> isVisible = false
-            CloseButtonBehavior.EXIT             -> dispose()
-            CloseButtonBehavior.ASK              -> showCloseDialog()
+            CloseButtonBehavior.EXIT -> dispose()
+            CloseButtonBehavior.ASK -> showCloseDialog()
         }
     }
 
     private fun showCloseDialog() {
-        val rememberCheck = JCheckBox(localizer.getString("close_dialog.remember_choice"))
+        val dialog = JDialog(this, localizer.getString("close_dialog.title"), true)
+        dialog.defaultCloseOperation = JDialog.DISPOSE_ON_CLOSE
 
-        val panel = JPanel().apply {
-            layout = BoxLayout(this, BoxLayout.Y_AXIS)
-            add(JLabel(localizer.getString("close_dialog.message")))
-            add(Box.createVerticalStrut(12))
+        val iconLabel = JLabel(UIManager.getIcon("OptionPane.questionIcon"))
+        val messageLabel = JLabel(localizer.getString("close_dialog.message")).apply {
+            font = font.deriveFont(Font.BOLD, font.size + 1f)
+        }
+
+        val rememberCheck = JCheckBox(localizer.getString("close_dialog.remember_choice")).apply {
+            isOpaque = false
+            font = font.deriveFont(font.size - 1f)
+            foreground = UIManager.getColor("Label.disabledForeground")
+        }
+
+        var result: CloseButtonBehavior? = null
+
+        val minimizeBtn = JButton(localizer.getString("close_dialog.minimize_to_tray")).apply {
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+            addActionListener {
+                result = CloseButtonBehavior.MINIMIZE_TO_TRAY
+                dialog.dispose()
+            }
+        }
+        val exitBtn = JButton(localizer.getString("close_dialog.exit")).apply {
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+            addActionListener {
+                result = CloseButtonBehavior.EXIT
+                dialog.dispose()
+            }
+        }
+        val cancelBtn = JButton(localizer.getString("common.cancel")).apply {
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+            addActionListener { dialog.dispose() }
+        }
+
+        val topPanel = JPanel(BorderLayout(16, 0)).apply {
+            isOpaque = false
+            border = BorderFactory.createEmptyBorder(20, 20, 12, 20)
+            add(iconLabel, BorderLayout.LINE_START)
+            add(messageLabel, BorderLayout.CENTER)
+        }
+
+        val checkPanel = JPanel(FlowLayout(FlowLayout.LEADING, 0, 0)).apply {
+            isOpaque = false
+            border = BorderFactory.createEmptyBorder(0, 20, 12, 20)
             add(rememberCheck)
         }
 
-        val minimizeOption = localizer.getString("close_dialog.minimize_to_tray")
-        val exitOption     = localizer.getString("close_dialog.exit")
-        val cancelOption   = localizer.getString("common.cancel")
+        val btnPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+            border = BorderFactory.createEmptyBorder(0, 20, 20, 20)
+            add(minimizeBtn)
+            add(Box.createVerticalStrut(8))
+            add(exitBtn)
+            add(Box.createVerticalStrut(8))
+            add(cancelBtn)
+        }
 
-        val result = JOptionPane.showOptionDialog(
-            this,
-            panel,
-            localizer.getString("close_dialog.title"),
-            JOptionPane.DEFAULT_OPTION,
-            JOptionPane.QUESTION_MESSAGE,
-            null,
-            arrayOf(minimizeOption, exitOption, cancelOption),
-            minimizeOption  // default button
+        dialog.contentPane.apply {
+            layout = BorderLayout()
+            add(topPanel, BorderLayout.NORTH)
+            add(checkPanel, BorderLayout.CENTER)
+            add(btnPanel, BorderLayout.SOUTH)
+        }
+
+        dialog.rootPane.defaultButton = minimizeBtn
+
+        dialog.rootPane.registerKeyboardAction(
+            { dialog.dispose() },
+            KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+            JComponent.WHEN_IN_FOCUSED_WINDOW
         )
 
+        dialog.pack()
+        dialog.minimumSize = Dimension(320, dialog.height)
+        dialog.setLocationRelativeTo(this)
+        dialog.isVisible = true
+
         when (result) {
-            0 -> { // Minimize to tray
+            CloseButtonBehavior.MINIMIZE_TO_TRAY -> {
                 if (rememberCheck.isSelected) saveClosePreference(CloseButtonBehavior.MINIMIZE_TO_TRAY)
                 isVisible = false
             }
-            1 -> { // Exit
+
+            CloseButtonBehavior.EXIT -> {
                 if (rememberCheck.isSelected) saveClosePreference(CloseButtonBehavior.EXIT)
                 dispose()
             }
-            // 2 = Cancel, -1 = dialog dismissed — do nothing
+
+            CloseButtonBehavior.ASK -> {}
+            null -> {}
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -64,6 +64,7 @@ class MainContentView(
 
     private val languageSelectionBar = LanguageSelectionBar(
         iconManager = iconManager,
+        localizer = localizer,
         onClear = { dispatch(MainIntent.UpdateInputText("")) },
         onSourceLanguageSelected = { lang -> dispatch(MainIntent.SelectSourceLanguage(lang)) },
         onSwap = { dispatch(MainIntent.SwapLanguages) },
@@ -147,8 +148,8 @@ class MainContentView(
         val statusText = localizer.getString(
             "main_window.status_format",
             selectedTranslator?.name ?: localizer.getString("main_window.no_translator"),
-            mainState.sourceLanguage.getDisplayName(),
-            mainState.targetLanguage.getDisplayName()
+            mainState.sourceLanguage.getDisplayName(autoDetectLabel = localizer.getString("common.auto_detect")),
+            mainState.targetLanguage.getDisplayName(autoDetectLabel = localizer.getString("common.auto_detect"))
         )
 
         translationHistoryBar.render(
@@ -259,18 +260,18 @@ class MainContentView(
 
         extraOutputPanel.render(
             ExtraOutputState(
-                text               = mainState.extraOutputText,
-                isVisible          = config.extraOutputType != ExtraOutputType.None,
-                isLoading          = mainState.isLoading,
-                fontConfig         = config.scaledEditorFont,
+                text = mainState.extraOutputText,
+                isVisible = config.extraOutputType != ExtraOutputType.None,
+                isLoading = mainState.isLoading,
+                fontConfig = config.scaledEditorFont,
                 fallbackFontConfig = config.scaledEditorFallbackFont,
-                activeType         = config.extraOutputType,
-                summaryLength      = config.summaryLength,
-                rewriteStyle       = config.rewriteStyle,
+                activeType = config.extraOutputType,
+                summaryLength = config.summaryLength,
+                rewriteStyle = config.rewriteStyle,
 
                 labelBackward = localizer.getString("extra_output.label_backward"),
-                labelSummary  = localizer.getString("extra_output.label_summary"),
-                labelRewrite  = localizer.getString("extra_output.label_rewrite"),
+                labelSummary = localizer.getString("extra_output.label_summary"),
+                labelRewrite = localizer.getString("extra_output.label_rewrite"),
 
                 labelConfigure = localizer.getString("common.configure"),
 
@@ -288,21 +289,27 @@ class MainContentView(
                 ),
 
                 onTypeChanged = { type ->
-                    dispatchSettings(SettingsIntent.UpdateDraft(
-                        config.copy(extraOutputType = type)
-                    ))
+                    dispatchSettings(
+                        SettingsIntent.UpdateDraft(
+                            config.copy(extraOutputType = type)
+                        )
+                    )
                     dispatch(MainIntent.Translate())
                 },
                 onSummaryLengthChanged = { length ->
-                    dispatchSettings(SettingsIntent.UpdateDraft(
-                        config.copy(summaryLength = length)
-                    ))
+                    dispatchSettings(
+                        SettingsIntent.UpdateDraft(
+                            config.copy(summaryLength = length)
+                        )
+                    )
                     dispatch(MainIntent.Translate())
                 },
                 onRewriteStyleChanged = { style ->
-                    dispatchSettings(SettingsIntent.UpdateDraft(
-                        config.copy(rewriteStyle = style)
-                    ))
+                    dispatchSettings(
+                        SettingsIntent.UpdateDraft(
+                            config.copy(rewriteStyle = style)
+                        )
+                    )
                     dispatch(MainIntent.Translate())
                 },
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/languagebar/LanguageSelectionBar.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/languagebar/LanguageSelectionBar.kt
@@ -1,6 +1,7 @@
 package com.github.ahatem.qtranslate.ui.swing.main.languagebar
 
 import com.github.ahatem.qtranslate.api.language.LanguageCode
+import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.GridBag
 import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
@@ -13,6 +14,7 @@ import javax.swing.JPanel
 
 class LanguageSelectionBar(
     private val iconManager: IconManager,
+    private val localizer: LocalizationManager,
     private val onClear: () -> Unit,
     private val onSourceLanguageSelected: (LanguageCode) -> Unit,
     private val onSwap: () -> Unit,
@@ -21,9 +23,15 @@ class LanguageSelectionBar(
 ) : JPanel(GridBagLayout()), Renderable<LanguageSelectionBarState> {
 
     private val clearButton = createButtonWithIcon(iconManager, "icons/lucide/trash.svg", 16)
-    private val sourceLanguageComboBox = LanguageComboBox { lang -> onSourceLanguageSelected(lang) }
+    private val sourceLanguageComboBox = LanguageComboBox(
+        onLanguageSelected = { lang -> onSourceLanguageSelected(lang) },
+        localizer = localizer
+    )
     private val swapButton = createButtonWithIcon(iconManager, "icons/lucide/swap.svg", 16)
-    private val targetLanguageComboBox = LanguageComboBox { lang -> onTargetLanguageSelected(lang) }
+    private val targetLanguageComboBox = LanguageComboBox(
+        onLanguageSelected = { lang -> onTargetLanguageSelected(lang) },
+        localizer = localizer
+    )
     private val translateButton = JButton()
 
     init {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/ServicesPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/ServicesPanel.kt
@@ -3,6 +3,7 @@ package com.github.ahatem.qtranslate.ui.swing.settings.panels
 import com.github.ahatem.qtranslate.api.plugin.Service
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.plugin.PluginManager
+import com.github.ahatem.qtranslate.core.settings.data.ServicePreset
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsIntent
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsState
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsStore
@@ -89,7 +90,7 @@ class ServicesPanel(
 
             val combo = JComboBox<ServiceOption>().apply {
                 setRenderer { _, value, _, _, _ ->
-                    JLabel(value?.name ?: "None")
+                    JLabel(value?.name ?: localizationManager.getString("common.none"))
                 }
 
                 addActionListener {
@@ -189,7 +190,7 @@ class ServicesPanel(
         val c = state.workingConfiguration
         withoutTrigger {
             presetCombo.removeAllItems()
-            c.servicePresets.forEach { presetCombo.addItem(PresetInfo(it.id, it.name)) }
+            c.servicePresets.forEach { presetCombo.addItem(PresetInfo(it.id, localizedPresetName(it.name))) }
 
             val active = c.servicePresets.find { it.id == c.activeServicePresetId }
             active?.let { presetCombo.selectedItem = PresetInfo(it.id, it.name) }
@@ -265,6 +266,11 @@ class ServicesPanel(
         if (result == JOptionPane.YES_OPTION)
             store.dispatch(SettingsIntent.DeletePreset(selected.id))
     }
+
+    private fun localizedPresetName(name: String): String =
+        if (name == ServicePreset.DEFAULT_PRESET_NAME)
+            localizationManager.getString("settings_services.default_preset_name")
+        else name
 
     private data class PresetInfo(val id: String, val name: String)
     private data class ServiceOption(val id: String, val name: String)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/LanguageComboBox.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/LanguageComboBox.kt
@@ -1,7 +1,7 @@
 package com.github.ahatem.qtranslate.ui.swing.shared.widgets
 
-
 import com.github.ahatem.qtranslate.api.language.LanguageCode
+import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.localization.getDisplayName
 import com.github.ahatem.qtranslate.ui.swing.shared.util.isRTL
 import java.awt.Component
@@ -12,7 +12,8 @@ import java.awt.event.KeyEvent
 import javax.swing.*
 
 class LanguageComboBox(
-    private val onLanguageSelected: (language: LanguageCode) -> Unit
+    private val onLanguageSelected: (language: LanguageCode) -> Unit,
+    private val localizer: LocalizationManager
 ) : JComboBox<LanguageCode>() {
 
     private var isRendering = false
@@ -32,7 +33,7 @@ class LanguageComboBox(
     }
 
     init {
-        renderer = LanguageRenderer(this)
+        renderer = LanguageRenderer(this, localizer)
         addActionListener(actionListener)
 
         addKeyListener(object : KeyAdapter() {
@@ -44,7 +45,6 @@ class LanguageComboBox(
         })
     }
 
-
     private fun handleKeyTyped(key: Char) {
         searchResetTimer.stop()
         searchStringBuilder.append(key)
@@ -53,7 +53,9 @@ class LanguageComboBox(
         val model = this.model
         for (i in 0 until model.size) {
             val item = model.getElementAt(i)
-            val displayString = item?.getDisplayName() ?: item.toString()
+            val displayString = item?.getDisplayName(
+                autoDetectLabel = localizer.getString("common.auto_detect")
+            ) ?: item.toString()
 
             if (displayString.startsWith(searchString, ignoreCase = true)) {
                 this.selectedIndex = i
@@ -64,7 +66,6 @@ class LanguageComboBox(
 
         searchStringBuilder.clear()
     }
-
 
     fun render(
         availableLanguages: List<LanguageCode>,
@@ -87,23 +88,30 @@ class LanguageComboBox(
         }
     }
 
+    private class LanguageRenderer(
+        private val comboBox: JComboBox<LanguageCode>,
+        private val localizer: LocalizationManager
+    ) : DefaultListCellRenderer() {
 
-    private class LanguageRenderer(private val comboBox: JComboBox<LanguageCode>) : DefaultListCellRenderer() {
         override fun getListCellRendererComponent(
             list: JList<*>?, value: Any?, index: Int,
             isSelected: Boolean, cellHasFocus: Boolean
         ): Component {
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
             if (value is LanguageCode) {
+                val autoDetectLabel = localizer.getString("common.auto_detect")
                 val autoDetectedLanguage = comboBox.getClientProperty("autoDetectedLanguage") as? LanguageCode
+
                 val displayName: String =
                     if (index == -1 && autoDetectedLanguage != null && value == LanguageCode.AUTO) {
-                        "${autoDetectedLanguage.getDisplayName()} (Auto-Detect)"
+                        "${autoDetectedLanguage.getDisplayName()} ($autoDetectLabel)"
                     } else {
-                        value.getDisplayName()
+                        value.getDisplayName(autoDetectLabel = autoDetectLabel)
                     }
+
                 text = displayName
-                componentOrientation = if (displayName.isRTL()) ComponentOrientation.RIGHT_TO_LEFT else ComponentOrientation.LEFT_TO_RIGHT
+                componentOrientation = if (displayName.isRTL()) ComponentOrientation.RIGHT_TO_LEFT
+                else ComponentOrientation.LEFT_TO_RIGHT
             }
             return this
         }


### PR DESCRIPTION
## What does this PR do?

A collection of localization fixes and UI improvements based on contributor 
feedback from the Italian translation review.

**Localization fixes:**
- `Auto-Detect` label in language combo boxes is now fully localized —
  previously hardcoded in English regardless of interface language
- `Default` preset name now uses a sentinel value `__default__` internally
  and is resolved through the localization system at render time —
  previously stored as a raw English string in the config file
- Both fixes update dynamically when the user switches the interface
  language at runtime

**Close dialog redesign:**
- Buttons are now stacked vertically instead of horizontally — fixes the
  dialog becoming too wide in languages with longer button text (reported
  by @bovirus for Italian)
- Escape key closes the dialog
- Minimize to Tray is the default button

**`LanguageComboBox` improvements:**
- `LocalizationManager` is now injected directly instead of a static
  string — ensures the Auto-Detect label always reflects the current
  interface language without requiring a restart

## Related issues

Closes #13

## Type of change

- [x] Bug fix
- [x] UI/UX improvement

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Attach before/after screenshots of the close dialog -->