### PR TITLE
feat(ui): drag-and-drop and Ctrl+V clipboard image paste for OCR translation

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -34,6 +34,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.copyToClipboard
 import com.github.ahatem.qtranslate.ui.swing.shared.util.scaledEditorFallbackFont
 import com.github.ahatem.qtranslate.ui.swing.shared.util.scaledEditorFont
+import com.github.ahatem.qtranslate.ui.swing.shared.util.toImageData
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
@@ -80,7 +81,8 @@ class MainContentView(
         onTranslateRequest = { text -> dispatch(MainIntent.Translate(text)) },
         onCorrectionApplied = { original, suggestion ->
             dispatch(MainIntent.ApplyCorrection(original, suggestion))
-        }
+        },
+        onImageDropped = { image -> dispatch(MainIntent.OcrAndTranslateImage(image.toImageData("png"))) },
     )
 
     private val outputTextPanel = OutputTextPanel(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
@@ -9,6 +9,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.widgets.AdvancedTextPane
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.BorderLayout
 import java.awt.Point
+import java.awt.image.BufferedImage
 import javax.swing.*
 
 class InputTextPanel(
@@ -17,13 +18,15 @@ class InputTextPanel(
     private val onTextChanged: (String) -> Unit,
     private val onListen: (String) -> Unit,
     private val onTranslateRequest: (String) -> Unit,
-    private val onCorrectionApplied: (original: String, suggestion: String) -> Unit
+    private val onCorrectionApplied: (original: String, suggestion: String) -> Unit,
+    private val onImageDropped: ((BufferedImage) -> Unit)? = null,
 ) : JPanel(BorderLayout()), Renderable<InputTextState> {
 
     private val textPane = AdvancedTextPane(
         onTextChanged = onTextChanged,
         onListenRequest = onListen,
-        onTranslateRequest = onTranslateRequest
+        onTranslateRequest = onTranslateRequest,
+        onImageDropped = onImageDropped,
     )
     private val actionsPanel = TextActionsPanel(iconManager)
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -3,9 +3,13 @@ package com.github.ahatem.qtranslate.ui.swing.shared.widgets
 import com.github.ahatem.qtranslate.api.spellchecker.Correction
 import com.github.ahatem.qtranslate.ui.swing.shared.util.isRTL
 import java.awt.*
+import java.awt.datatransfer.DataFlavor
 import java.awt.event.*
 import java.awt.font.FontRenderContext
 import java.awt.geom.AffineTransform
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
 import javax.swing.*
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
@@ -373,10 +377,25 @@ class FontFallbackDocumentListener(
     }
 }
 
+private fun toBufferedImage(image: Image): BufferedImage {
+    if (image is BufferedImage) return image
+    val buffered = BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB)
+    val g = buffered.createGraphics()
+    g.drawImage(image, 0, 0, null)
+    g.dispose()
+    return buffered
+}
+
+private fun File.isImageFile(): Boolean {
+    val ext = extension.lowercase()
+    return ext in setOf("png", "jpg", "jpeg", "bmp", "gif", "tiff", "tif", "webp")
+}
+
 class AdvancedTextPane(
     private val onTextChanged: (text: String) -> Unit,
     private val onTranslateRequest: (text: String) -> Unit,
     private val onListenRequest: (text: String) -> Unit,
+    private val onImageDropped: ((BufferedImage) -> Unit)? = null,
 ) : JTextPane() {
 
     private val undoManager by lazy { UndoManager() }
@@ -434,6 +453,7 @@ class AdvancedTextPane(
 
         setupKeyBindings()
         setupMouseListeners()
+        setupTransferHandler()
     }
 
 
@@ -563,6 +583,71 @@ class AdvancedTextPane(
         inputMap.put(redoAction.getValue(Action.ACCELERATOR_KEY) as KeyStroke, "redo")
 
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.CTRL_DOWN_MASK), "none")
+
+        if (onImageDropped != null) {
+            val pasteAction = createAction(
+                "PasteImageOrText",
+                KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.CTRL_DOWN_MASK)
+            ) {
+                val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+                val image = runCatching {
+                    if (clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor))
+                        clipboard.getData(DataFlavor.imageFlavor) as? Image
+                    else null
+                }.getOrNull()
+                if (image != null) {
+                    onImageDropped.invoke(toBufferedImage(image))
+                } else {
+                    paste()
+                }
+            }
+            actionMap.put("paste-image-or-text", pasteAction)
+            inputMap.put(pasteAction.getValue(Action.ACCELERATOR_KEY) as KeyStroke, "paste-image-or-text")
+        }
+    }
+
+    private fun setupTransferHandler() {
+        if (onImageDropped == null) return
+        val original = transferHandler
+        transferHandler = object : TransferHandler() {
+            override fun canImport(support: TransferSupport): Boolean {
+                if (isEditable) {
+                    if (support.isDataFlavorSupported(DataFlavor.imageFlavor)) return true
+                    if (support.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) return true
+                }
+                return original?.canImport(support) ?: false
+            }
+
+            override fun importData(support: TransferSupport): Boolean {
+                if (isEditable) {
+                    if (support.isDataFlavorSupported(DataFlavor.imageFlavor)) {
+                        val image = runCatching {
+                            support.transferable.getTransferData(DataFlavor.imageFlavor) as? java.awt.Image
+                        }.getOrNull()
+                        if (image != null) {
+                            onImageDropped.invoke(toBufferedImage(image))
+                            return true
+                        }
+                    }
+                    if (support.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+                        @Suppress("UNCHECKED_CAST")
+                        val files = runCatching {
+                            support.transferable.getTransferData(DataFlavor.javaFileListFlavor) as? List<File>
+                        }.getOrNull()
+                        val imageFile = files?.firstOrNull { it.isImageFile() }
+                        if (imageFile != null) {
+                            val image = runCatching { ImageIO.read(imageFile) }.getOrNull()
+                            if (image != null) {
+                                onImageDropped.invoke(image)
+                                return true
+                            }
+                        }
+                    }
+                }
+                return original?.importData(support) ?: false
+            }
+        }
+        dropTarget?.isActive = true
     }
 
     private fun setupMouseListeners() {
@@ -653,7 +738,7 @@ class AdvancedTextPane(
 
     override fun updateUI() {
         super.updateUI()
-        putClientProperty(HONOR_DISPLAY_PROPERTIES, true);
+        putClientProperty(HONOR_DISPLAY_PROPERTIES, true)
     }
 
     override fun getScrollableTracksViewportWidth(): Boolean {


### PR DESCRIPTION
## What does this PR do?
Adds image input to the main window input area for OCR translation without needing the snipping tool.

- **Drag and drop** an image file (PNG, JPG, JPEG, BMP, GIF, TIFF, WebP) or a raw image onto the input text pane to trigger OCR and translation.
- **Ctrl+V** now checks the clipboard for an image before falling back to normal text paste — copy a screenshot and paste it directly into the input field.

A custom `TransferHandler` is installed on `AdvancedTextPane` only when an `onImageDropped` callback is provided, so the output pane and all other read-only instances are completely unaffected. The Ctrl+V override is similarly scoped. Image data is converted to `ImageData` in `MainContentView` and dispatched as the existing `MainIntent.OcrAndTranslateImage` intent.

## Related issues
Closes #20

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist
- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [ ] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)