### PR TITLE
feat(core): improve instant translate UX — clear on blank, min-char guard, cancel in-flight

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
@@ -56,6 +56,11 @@ class TranslateTextUseCase(
     private val logger: Logger = loggerFactory.getLogger("TranslateTextUseCase")
     private var translationJob: Job? = null
 
+    fun cancel() {
+        translationJob?.cancel(CancellationException("Input cleared"))
+        translationJob = null
+    }
+
     // Stored so handleExtraOutput can access current input text for ExtraOutputSource.Input
     private var currentGetState: (() -> MainState)? = null
 

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -94,12 +94,34 @@ class MainStore(
 
     @OptIn(FlowPreview::class)
     private fun observeInstantTranslation() {
+        // Immediately clear output when the user erases all input — no debounce.
+        scope.launch {
+            state.map { it.inputText }
+                .distinctUntilChanged()
+                .collect { text ->
+                    if (settingsState.value.isInstantTranslationEnabled && text.isBlank()) {
+                        translateTextUseCase.cancel()
+                        _state.update {
+                            it.copy(
+                                translatedText = "",
+                                extraOutputText = "",
+                                detectedSourceLanguage = null,
+                                isLoading = false
+                            )
+                        }
+                    }
+                }
+        }
+
+        // Debounced translation — only fires when there is enough text to translate.
         scope.launch {
             state.map { it.inputText }
                 .debounce(AppConstants.INSTANT_TRANSLATION_DEBOUNCE_MS)
                 .distinctUntilChanged()
                 .collect { text ->
-                    if (settingsState.value.isInstantTranslationEnabled && text.isNotBlank()) {
+                    if (settingsState.value.isInstantTranslationEnabled
+                        && text.length >= AppConstants.INSTANT_TRANSLATE_MIN_CHARS
+                    ) {
                         translateText()
                     }
                 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
@@ -22,7 +22,10 @@ object AppConstants {
     // ============================================================
 
     /** Debounce delay for instant translation. */
-    const val INSTANT_TRANSLATION_DEBOUNCE_MS = 500L
+    const val INSTANT_TRANSLATION_DEBOUNCE_MS = 700L
+
+    /** Minimum input length before instant translation fires. */
+    const val INSTANT_TRANSLATE_MIN_CHARS = 2
 
     /** Debounce delay for spell checking. */
     const val SPELL_CHECK_DEBOUNCE_MS = 750L


### PR DESCRIPTION
## What does this PR do?
Improves the instant translation experience with three targeted fixes:

- **Clear output immediately on blank** — when the user erases all input, translated text, extra output, and detected language are cleared instantly (no debounce wait) instead of staying stale on screen
- **Cancel in-flight translation on clear** — a new `TranslateTextUseCase.cancel()` method is called when input goes blank, preventing a finishing translation job from overwriting the just-cleared state
- **Minimum character guard** — added `INSTANT_TRANSLATE_MIN_CHARS = 2` to `AppConstants`; single-character input (accidental keystrokes, punctuation) no longer triggers a real API call

## Related issues
<!-- Link issues this PR closes or is related to. Use "Closes #123" to auto-close. -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist
- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)
<!-- N/A — behaviour change only -->