### PR TITLE
fix(ui): wire Settings action in tray menu

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -643,7 +643,16 @@ class MainAppFrame(
             onShowDictionary = { /* TODO */ },
             onRecognizeText = { openSnippingTool() },
             onShowHistory = { showHistoryDialog() },
-            onShowSettings = { /* TODO */ },
+            onShowSettings = {
+                runOnUi {
+                    val dialog = createSettingsDialog()
+                    dialog.applyComponentOrientation(
+                        if (localizer.isRtl) ComponentOrientation.RIGHT_TO_LEFT
+                        else ComponentOrientation.LEFT_TO_RIGHT
+                    )
+                    dialog.isVisible = true
+                }
+            },
             onToggleHotkeys = { enabled ->
                 settingsStore.dispatch(
                     SettingsIntent.ToggleSetting { it.copy(isGlobalHotkeysEnabled = enabled) }


### PR DESCRIPTION
## What does this PR do?
The Settings option in the system tray menu was a no-op (`/* TODO */`). It now opens the same `SettingsDialog` as the main options menu, with the correct RTL orientation applied and the call dispatched on the Swing thread via `runOnUi`.

## Related issues
<!-- Link issues this PR closes or is related to. Use "Closes #123" to auto-close. -->

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist
- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)
<!-- N/A — behaviour fix, no visual change -->