### PR TITLE
fix(statusbar): replace loading spinner with thin progress bar

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/StatusBar.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/StatusBar.kt
@@ -5,10 +5,8 @@ import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.*
-import java.awt.geom.Arc2D
 import java.awt.geom.RoundRectangle2D
 import javax.swing.*
-import javax.swing.Timer
 import javax.swing.border.MatteBorder
 
 class StatusBar(
@@ -17,7 +15,18 @@ class StatusBar(
 ) : JPanel(BorderLayout()), Renderable<StatusBarState> {
 
     private val chip = StatusChip()
-    private val spinner = LoadingSpinner(14)
+
+    /** Thin indeterminate bar that hugs the bottom edge while a translation is in progress. */
+    private val progressBar = object : JProgressBar() {
+        override fun getPreferredSize() = Dimension(super.getPreferredSize().width, 3)
+        override fun getMinimumSize()   = Dimension(0, 3)
+        override fun getMaximumSize()   = Dimension(Int.MAX_VALUE, 3)
+    }.apply {
+        isIndeterminate  = true
+        isVisible        = false
+        isBorderPainted  = false
+        isOpaque         = false
+    }
 
     private val notificationButton = createButtonWithIcon(iconManager, "icons/lucide/notification.svg", 14).apply {
         putClientProperty("JButton.buttonType", "toolBarButton")
@@ -28,28 +37,23 @@ class StatusBar(
     init {
         border = MatteBorder(1, 0, 0, 0, UIManager.getColor("Component.borderColor"))
 
-        val leftPanel = JPanel(BorderLayout(4, 0)).apply {
-            isOpaque = false
-            add(spinner, BorderLayout.LINE_START)
-            add(chip, BorderLayout.CENTER)
-        }
-
         val contentPanel = JPanel(BorderLayout(4, 0)).apply {
             border = BorderFactory.createEmptyBorder(4, 8, 4, 8)
             isOpaque = false
-            add(leftPanel, BorderLayout.CENTER)
+            add(chip, BorderLayout.CENTER)
             add(notificationButton, BorderLayout.LINE_END)
         }
 
         add(contentPanel, BorderLayout.CENTER)
+        add(progressBar,  BorderLayout.SOUTH)
     }
 
     override fun render(state: StatusBarState) {
         border = MatteBorder(1, 0, 0, 0, UIManager.getColor("Component.borderColor"))
         chip.update(state.message, state.type)
-        spinner.setLoading(state.isLoading)
+        progressBar.isVisible = state.isLoading
         notificationButton.toolTipText = state.notificationTooltip
-        notificationButton.isEnabled = state.isNotificationButtonEnabled
+        notificationButton.isEnabled   = state.isNotificationButtonEnabled
     }
 
     fun text(): String = chip.currentText
@@ -64,9 +68,7 @@ class StatusBar(
             private set
         private var currentType: NotificationType = NotificationType.INFO
 
-        init {
-            isOpaque = false
-        }
+        init { isOpaque = false }
 
         fun update(text: String, type: NotificationType) {
             currentText = text
@@ -80,10 +82,10 @@ class StatusBar(
             if (currentText.isBlank()) return
 
             val g2 = g.create() as Graphics2D
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,      RenderingHints.VALUE_ANTIALIAS_ON)
             g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
 
-            val f = UIManager.getFont("Label.font") ?: font
+            val f  = UIManager.getFont("Label.font") ?: font
             g2.font = f
             val fm = g2.fontMetrics
 
@@ -98,7 +100,11 @@ class StatusBar(
 
             if (currentType != NotificationType.INFO) {
                 g2.color = Color(color.red, color.green, color.blue, 28)
-                g2.fill(RoundRectangle2D.Float(chipX.toFloat(), chipY.toFloat(), chipW.toFloat(), chipH.toFloat(), chipH.toFloat(), chipH.toFloat()))
+                g2.fill(RoundRectangle2D.Float(
+                    chipX.toFloat(), chipY.toFloat(),
+                    chipW.toFloat(), chipH.toFloat(),
+                    chipH.toFloat(), chipH.toFloat()
+                ))
             }
 
             g2.color = color
@@ -107,66 +113,17 @@ class StatusBar(
         }
 
         override fun getPreferredSize(): Dimension {
-            val f = UIManager.getFont("Label.font") ?: font
+            val f  = UIManager.getFont("Label.font") ?: font
             val fm = getFontMetrics(f)
-            val w = if (currentText.isNotEmpty()) fm.stringWidth(currentText) + 16 else 0
-            val h = fm.height + 8
-            return Dimension(maxOf(w, 0), h)
+            val w  = if (currentText.isNotEmpty()) fm.stringWidth(currentText) + 16 else 0
+            return Dimension(maxOf(w, 0), fm.height + 8)
         }
 
         private fun typeColor(): Color = when (currentType) {
-            NotificationType.SUCCESS -> UIManager.getColor("Actions.Green") ?: Color(0x59A869)
+            NotificationType.SUCCESS -> UIManager.getColor("Actions.Green")  ?: Color(0x59A869)
             NotificationType.WARNING -> UIManager.getColor("Actions.Yellow") ?: Color(0xE2A53A)
-            NotificationType.ERROR -> UIManager.getColor("Actions.Red") ?: Color(0xE05555)
-            NotificationType.INFO -> UIManager.getColor("Label.foreground") ?: Color.GRAY
-        }
-    }
-
-    /**
-     * A small circular spinner that rotates while [isLoading] is true.
-     * Renders a faint background ring and a brighter 80° arc that advances
-     * every 40 ms — about 375 RPM, consistent with system spinner conventions.
-     */
-    private class LoadingSpinner(private val size: Int) : JComponent() {
-        private var angle = 0
-        private val timer = Timer(40) {
-            angle = (angle + 15) % 360
-            repaint()
-        }
-
-        init {
-            val dim = Dimension(size, size)
-            preferredSize = dim
-            minimumSize = dim
-            maximumSize = dim
-            isVisible = false
-            isOpaque = false
-        }
-
-        fun setLoading(loading: Boolean) {
-            if (loading == isVisible) return
-            isVisible = loading
-            if (loading) timer.start() else timer.stop()
-            revalidate()
-        }
-
-        override fun paintComponent(g: Graphics) {
-            val g2 = g.create() as Graphics2D
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-
-            val pad = 2
-            val d = size - pad * 2
-            val base = UIManager.getColor("Label.foreground") ?: Color.GRAY
-
-            g2.stroke = BasicStroke(2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND)
-
-            g2.color = Color(base.red, base.green, base.blue, 40)
-            g2.drawOval(pad, pad, d, d)
-
-            g2.color = base
-            g2.draw(Arc2D.Float(pad.toFloat(), pad.toFloat(), d.toFloat(), d.toFloat(), angle.toFloat(), 80f, Arc2D.OPEN))
-
-            g2.dispose()
+            NotificationType.ERROR   -> UIManager.getColor("Actions.Red")    ?: Color(0xE05555)
+            NotificationType.INFO    -> UIManager.getColor("Label.foreground") ?: Color.GRAY
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

The 14 px circular spinner sat visually mismatched next to the taller status chip text. Replaced it with a 3 px indeterminate `JProgressBar` that spans the full bottom edge of the status bar — the same loading indicator pattern used by VS Code and IntelliJ IDEA.

- Idle state: completely invisible, no wasted space
- Loading state: a thin accent-coloured animated bar at the bottom edge
- Removed the custom `LoadingSpinner` inner class entirely (~45 lines deleted)

## Related issues

<!-- Link issues this PR closes or is related to. -->

## Type of change

- [x] Bug fix
- [x] UI/UX improvement

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Before: small spinner next to text. After: thin bar at bottom edge. -->