### PR TITLE
feat(ui): clickable error chip with full-message detail popup

### DIFF
--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -108,6 +108,10 @@ exit = "Exit"
 ready_message = "Ready"
 notifications_tooltip = "Notifications"
 notifications_empty_tooltip = "No new notifications"
+error_detail_error = "Error"
+error_detail_warning = "Warning"
+error_detail_copy = "Copy"
+error_detail_copied = "Copied!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -111,6 +111,10 @@ exit = "خروج"
 ready_message = "جاهز"
 notifications_tooltip = "الإشعارات"
 notifications_empty_tooltip = "لا توجد إشعارات جديدة"
+error_detail_error = "خطأ"
+error_detail_warning = "تحذير"
+error_detail_copy = "نسخ"
+error_detail_copied = "تم النسخ!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -111,6 +111,10 @@ exit = "প্রস্থান"
 ready_message = "প্রস্তুত"
 notifications_tooltip = "নোটিফিকেশন"
 notifications_empty_tooltip = "নতুন কোন নোটিফিকেশন নেই"
+error_detail_error = "ত্রুটি"
+error_detail_warning = "সতর্কতা"
+error_detail_copy = "কপি"
+error_detail_copied = "কপি হয়েছে!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -111,6 +111,10 @@ exit = "Beenden"
 ready_message = "Bereit"
 notifications_tooltip = "Benachrichtigungen"
 notifications_empty_tooltip = "Keine neuen Benachrichtigungen"
+error_detail_error = "Fehler"
+error_detail_warning = "Warnung"
+error_detail_copy = "Kopieren"
+error_detail_copied = "Kopiert!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -111,6 +111,10 @@ exit = "Exit"
 ready_message = "Ready"
 notifications_tooltip = "Notifications"
 notifications_empty_tooltip = "No new notifications"
+error_detail_error = "Error"
+error_detail_warning = "Warning"
+error_detail_copy = "Copy"
+error_detail_copied = "Copied!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -111,6 +111,10 @@ exit = "Salir"
 ready_message = "Listo"
 notifications_tooltip = "Notificaciones"
 notifications_empty_tooltip = "No hay notificaciones nuevas"
+error_detail_error = "Error"
+error_detail_warning = "Advertencia"
+error_detail_copy = "Copiar"
+error_detail_copied = "¡Copiado!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -111,6 +111,10 @@ exit = "Quitter"
 ready_message = "Prêt"
 notifications_tooltip = "Notifications"
 notifications_empty_tooltip = "Aucune nouvelle notification"
+error_detail_error = "Erreur"
+error_detail_warning = "Avertissement"
+error_detail_copy = "Copier"
+error_detail_copied = "Copié !"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -111,6 +111,10 @@ exit = "Kilépés"
 ready_message = "Kész"
 notifications_tooltip = "Értesítések"
 notifications_empty_tooltip = "Nincs új értesítés"
+error_detail_error = "Hiba"
+error_detail_warning = "Figyelmeztetés"
+error_detail_copy = "Másolás"
+error_detail_copied = "Másolva!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -111,6 +111,10 @@ exit = "Esci"
 ready_message = "Pronto"
 notifications_tooltip = "Notifiche"
 notifications_empty_tooltip = "Nessuna nuova notifica"
+error_detail_error = "Errore"
+error_detail_warning = "Avviso"
+error_detail_copy = "Copia"
+error_detail_copied = "Copiato!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -111,6 +111,10 @@ exit = "終了"
 ready_message = "準備完了"
 notifications_tooltip = "通知"
 notifications_empty_tooltip = "新しい通知はありません"
+error_detail_error = "エラー"
+error_detail_warning = "警告"
+error_detail_copy = "コピー"
+error_detail_copied = "コピーしました！"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -111,6 +111,10 @@ exit = "Sair"
 ready_message = "Pronto"
 notifications_tooltip = "Notificações"
 notifications_empty_tooltip = "Sem novas notificações"
+error_detail_error = "Erro"
+error_detail_warning = "Aviso"
+error_detail_copy = "Copiar"
+error_detail_copied = "Copiado!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -111,6 +111,10 @@ exit = "Выход"
 ready_message = "Готово"
 notifications_tooltip = "Уведомления"
 notifications_empty_tooltip = "Нет новых уведомлений"
+error_detail_error = "Ошибка"
+error_detail_warning = "Предупреждение"
+error_detail_copy = "Копировать"
+error_detail_copied = "Скопировано!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -111,6 +111,10 @@ exit = "Çıkış"
 ready_message = "Hazır"
 notifications_tooltip = "Bildirimler"
 notifications_empty_tooltip = "Yeni bildirim yok"
+error_detail_error = "Hata"
+error_detail_warning = "Uyarı"
+error_detail_copy = "Kopyala"
+error_detail_copied = "Kopyalandı!"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -111,6 +111,10 @@ exit = "退出"
 ready_message = "就绪"
 notifications_tooltip = "通知"
 notifications_empty_tooltip = "暂无新通知"
+error_detail_error = "错误"
+error_detail_warning = "警告"
+error_detail_copy = "复制"
+error_detail_copied = "已复制！"
 
 # ===================================================================
 # SYSTEM TRAY MENU

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -31,6 +31,7 @@ import com.github.ahatem.qtranslate.ui.swing.dictionary.QuickDictionaryStrings
 import com.github.ahatem.qtranslate.ui.swing.history.HistoryDialog
 import com.github.ahatem.qtranslate.ui.swing.history.HistoryDialogState
 import com.github.ahatem.qtranslate.ui.swing.history.HistoryEntryState
+import com.github.ahatem.qtranslate.ui.swing.main.statusbar.ErrorDetailPopup
 import com.github.ahatem.qtranslate.ui.swing.main.statusbar.NotificationPopover
 import com.github.ahatem.qtranslate.ui.swing.update.UpdateDialog
 import com.github.ahatem.qtranslate.ui.swing.update.UpdateDialogState
@@ -1338,7 +1339,26 @@ class MainAppFrame(
         private var isLoading: Boolean = false
         private var unreadCount: Int = 0
 
+        // -----------------------------------------------------------------------
+        // Error-detail popup
+        // -----------------------------------------------------------------------
+
+        private val errorDetailPopup = ErrorDetailPopup(iconManager)
+
+        /** Message currently shown in the popup, null when popup is hidden. */
+        private var shownDetailMessage: String? = null
+
         init {
+            errorDetailPopup.errorLabel   = localizer.getString("main_window_status_bar.error_detail_error")
+            errorDetailPopup.warningLabel = localizer.getString("main_window_status_bar.error_detail_warning")
+            errorDetailPopup.copyLabel    = localizer.getString("main_window_status_bar.error_detail_copy")
+            errorDetailPopup.copiedLabel  = localizer.getString("main_window_status_bar.error_detail_copied")
+
+            statusBar.onErrorClicked = { message ->
+                shownDetailMessage = message
+                errorDetailPopup.show(message, currentType, statusBar)
+            }
+
             render()
         }
 
@@ -1388,6 +1408,14 @@ class MainAppFrame(
         }
 
         private fun render() {
+            // Auto-dismiss the detail popup when the displayed message changes or
+            // when the type is no longer an error/warning.
+            val isErrorOrWarning = currentType == NotificationType.ERROR || currentType == NotificationType.WARNING
+            if (errorDetailPopup.isVisible && (!isErrorOrWarning || shownDetailMessage != currentMessage)) {
+                errorDetailPopup.dismiss()
+                shownDetailMessage = null
+            }
+
             statusBar.render(
                 StatusBarState(
                     message = currentMessage,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/ErrorDetailPopup.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/ErrorDetailPopup.kt
@@ -1,0 +1,245 @@
+package com.github.ahatem.qtranslate.ui.swing.main.statusbar
+
+import com.github.ahatem.qtranslate.api.plugin.NotificationType
+import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
+import com.github.ahatem.qtranslate.ui.swing.shared.util.copyToClipboard
+import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
+import java.awt.*
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.*
+import javax.swing.border.MatteBorder
+
+/**
+ * A lightweight, non-blocking popup anchored to the status-bar chip that
+ * displays the full error/warning message and lets the user copy it.
+ *
+ * Uses [JPopupMenu] so it auto-dismisses when the user clicks elsewhere —
+ * no modal dialogs, no stolen focus.
+ *
+ * Layout:
+ * ```
+ * ┌──────────────────────────────────────────┐
+ * │  Error                              [×]  │  ← header: bold colored type + close
+ * ├──────────────────────────────────────────┤
+ * │                                          │
+ * │  Full message text, word-wrapped…        │  ← scrollable body (12 px text padding)
+ * │                                          │
+ * ├──────────────────────────────────────────┤
+ * │                            [   Copy   ]  │  ← footer: primary action button
+ * └──────────────────────────────────────────┘
+ * ```
+ */
+class ErrorDetailPopup(private val iconManager: IconManager) {
+
+    companion object {
+        private const val H_PAD = 14   // horizontal padding used throughout
+        private const val V_PAD = 8    // vertical padding for header / footer
+        private const val TEXT_PAD = 12 // inner text-area padding (top/bottom)
+        private const val POPUP_WIDTH = 420
+        private const val BODY_HEIGHT = 110
+        private const val COPY_FEEDBACK_MS = 1200
+    }
+
+    // -----------------------------------------------------------------------
+    // Localizable labels — update before calling show()
+    // -----------------------------------------------------------------------
+
+    var errorLabel: String   = "Error"
+    var warningLabel: String = "Warning"
+    var copyLabel: String    = "Copy"
+    var copiedLabel: String  = "Copied!"
+
+    // -----------------------------------------------------------------------
+    // UI components
+    // -----------------------------------------------------------------------
+
+    private val typeLabel = JLabel().apply {
+        font = UIManager.getFont("Label.font")?.deriveFont(Font.BOLD) ?: font?.deriveFont(Font.BOLD)
+    }
+
+    private val closeButton = createButtonWithIcon(iconManager, "icons/lucide/close.svg", 14).apply {
+        putClientProperty("JButton.buttonType", "toolBarButton")
+        isFocusable = false
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseEntered(e: MouseEvent) {
+                background          = UIManager.getColor("InternalFrame.closeHoverBackground")
+                foreground          = UIManager.getColor("InternalFrame.closeHoverForeground")
+                isContentAreaFilled = true
+                isBorderPainted     = false
+            }
+            override fun mouseExited(e: MouseEvent) {
+                isContentAreaFilled = false
+                foreground          = null
+            }
+            override fun mousePressed(e: MouseEvent) {
+                background = UIManager.getColor("InternalFrame.closePressedBackground")
+                foreground = UIManager.getColor("InternalFrame.closePressedForeground")
+            }
+            override fun mouseReleased(e: MouseEvent) {
+                if (contains(e.point)) {
+                    background = UIManager.getColor("InternalFrame.closeHoverBackground")
+                    foreground = UIManager.getColor("InternalFrame.closeHoverForeground")
+                }
+            }
+        })
+    }
+
+    /**
+     * Primary action button — a standard [JButton] (not a toolbar icon button) so
+     * FlatLaf renders it with a visible border, making it read as the main action.
+     */
+    private val copyButton = JButton().apply { isFocusable = false }
+
+    /**
+     * Text area for the full error message.
+     *
+     * Padding note: we use [JTextArea.border] (an [EmptyBorder]) instead of
+     * [JTextComponent.margin] because FlatLaf's UI delegate may reset the margin
+     * when it installs its own compound border. An [EmptyBorder] set here survives
+     * the UI installation since it becomes part of the component's border chain.
+     */
+    private val textArea = JTextArea().apply {
+        isEditable    = false
+        lineWrap      = true
+        wrapStyleWord = true
+        rows          = 5
+        columns       = 38
+        // EmptyBorder provides reliable text-level padding regardless of LAF.
+        border = BorderFactory.createEmptyBorder(TEXT_PAD, H_PAD, TEXT_PAD, H_PAD)
+    }
+
+    private val popup = JPopupMenu()
+    private var copyFeedbackTimer: Timer? = null
+
+    val isVisible: Boolean get() = popup.isVisible
+
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    init {
+        closeButton.addActionListener { popup.isVisible = false }
+        copyButton.addActionListener {
+            textArea.text.copyToClipboard()
+            showCopyFeedback()
+        }
+
+        val content = JPanel(BorderLayout()).apply {
+            add(buildHeader(),  BorderLayout.NORTH)
+            add(buildBody(),    BorderLayout.CENTER)
+            add(buildFooter(),  BorderLayout.SOUTH)
+        }
+
+        popup.add(content)
+        popup.isFocusable = true
+    }
+
+    // -----------------------------------------------------------------------
+    // Section builders
+    // -----------------------------------------------------------------------
+
+    private fun buildHeader(): JPanel {
+        val borderColor = UIManager.getColor("Component.borderColor") ?: Color.GRAY
+        return JPanel(BorderLayout(H_PAD, 0)).apply {
+            isOpaque = false
+            border   = BorderFactory.createCompoundBorder(
+                // Bottom separator between header and body.
+                MatteBorder(0, 0, 1, 0, borderColor),
+                // Inner padding — symmetric H_PAD on both sides so it mirrors
+                // the text-area padding and looks even for both LTR and RTL.
+                BorderFactory.createEmptyBorder(V_PAD, H_PAD, V_PAD, H_PAD)
+            )
+            // LINE_END / LINE_START are RTL-aware unlike EAST / WEST.
+            add(typeLabel,   BorderLayout.CENTER)
+            add(closeButton, BorderLayout.LINE_END)
+        }
+    }
+
+    private fun buildBody(): JScrollPane {
+        return JScrollPane(textArea).apply {
+            preferredSize             = Dimension(POPUP_WIDTH, BODY_HEIGHT)
+            // Remove all scroll-pane chrome — padding lives on the text area itself.
+            border                    = null
+            viewport.border           = null
+            horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+            verticalScrollBarPolicy   = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
+        }
+    }
+
+    private fun buildFooter(): JPanel {
+        val borderColor = UIManager.getColor("Component.borderColor") ?: Color.GRAY
+        return JPanel(BorderLayout()).apply {
+            isOpaque = false
+            border   = BorderFactory.createCompoundBorder(
+                MatteBorder(1, 0, 0, 0, borderColor),
+                BorderFactory.createEmptyBorder(V_PAD, H_PAD, V_PAD, H_PAD)
+            )
+            // LINE_END so the button sits on the trailing edge (right in LTR, left in RTL).
+            add(copyButton, BorderLayout.LINE_END)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    /**
+     * Shows the popup anchored just above [anchorComponent].
+     * Colors and font are resolved from [UIManager] at call time so the popup
+     * always matches the current theme.
+     *
+     * [anchorComponent]'s [ComponentOrientation] is propagated to all children
+     * so text alignment and button placement flip correctly for RTL languages.
+     */
+    fun show(message: String, type: NotificationType, anchorComponent: Component) {
+        // Sync labels (may have been updated after construction).
+        typeLabel.text       = if (type == NotificationType.ERROR) errorLabel else warningLabel
+        typeLabel.foreground = typeColor(type)
+        if (copyButton.text != copiedLabel) copyButton.text = copyLabel
+
+        // Resolve live theme colors for the body so the popup matches the active LAF.
+        textArea.background = UIManager.getColor("Panel.background") ?: Color.WHITE
+        textArea.foreground = UIManager.getColor("Label.foreground") ?: Color.BLACK
+        textArea.font       = UIManager.getFont("Label.font")        ?: textArea.font
+
+        textArea.text          = message
+        textArea.caretPosition = 0
+
+        // Propagate the invoker's orientation so RTL locales get mirrored layout.
+        val orientation = anchorComponent.componentOrientation
+        popup.applyComponentOrientation(orientation)
+        textArea.componentOrientation = orientation
+
+        // Anchor above the chip: x=0 (leading edge), y = negative popup height.
+        popup.show(anchorComponent, 0, -popup.preferredSize.height)
+    }
+
+    /** Hides the popup. Safe to call when already hidden. */
+    fun dismiss() {
+        popup.isVisible = false
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private fun showCopyFeedback() {
+        copyFeedbackTimer?.stop()
+
+        copyButton.text       = copiedLabel
+        copyButton.foreground = UIManager.getColor("Button.successForeground") ?: Color(34, 197, 94)
+
+        copyFeedbackTimer = Timer(COPY_FEEDBACK_MS) {
+            copyButton.text      = copyLabel
+            copyButton.foreground = null
+            (it.source as Timer).stop()
+        }.apply { isRepeats = false; start() }
+    }
+
+    private fun typeColor(type: NotificationType): Color = when (type) {
+        NotificationType.ERROR   -> UIManager.getColor("Actions.Red")    ?: Color(0xE05555)
+        NotificationType.WARNING -> UIManager.getColor("Actions.Yellow") ?: Color(0xE2A53A)
+        else                     -> UIManager.getColor("Label.foreground") ?: Color.GRAY
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/StatusBar.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/StatusBar.kt
@@ -5,16 +5,25 @@ import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.*
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import java.awt.geom.RoundRectangle2D
 import javax.swing.*
 import javax.swing.border.MatteBorder
 
 class StatusBar(
     iconManager: IconManager,
-    private val onNotificationsClicked: () -> Unit
+    private val onNotificationsClicked: () -> Unit,
 ) : JPanel(BorderLayout()), Renderable<StatusBarState> {
 
-    private val chip = StatusChip()
+    /**
+     * Invoked when the user clicks an ERROR or WARNING chip.
+     * Receives the full message text so the caller can display it
+     * (e.g. in an [ErrorDetailPopup]).
+     */
+    var onErrorClicked: ((message: String) -> Unit)? = null
+
+    private val chip = StatusChip(onClicked = { message -> onErrorClicked?.invoke(message) })
 
     /** Thin indeterminate bar that hugs the bottom edge while a translation is in progress. */
     private val progressBar = object : JProgressBar() {
@@ -62,17 +71,41 @@ class StatusBar(
      * A pill-shaped label that draws a semi-transparent colored background for
      * WARNING/ERROR/SUCCESS types and uses the type color for the text.
      * INFO type renders as plain text with no background fill.
+     *
+     * When [onClicked] is set and the current type is ERROR or WARNING the chip
+     * shows a hand cursor and fires [onClicked] on click; it also sets a tooltip
+     * with the full message text so long strings are readable on hover.
      */
-    private class StatusChip : JComponent() {
+    private class StatusChip(private val onClicked: (message: String) -> Unit) : JComponent() {
         var currentText: String = ""
             private set
         private var currentType: NotificationType = NotificationType.INFO
 
-        init { isOpaque = false }
+        init {
+            isOpaque = false
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    if (isClickable()) onClicked(currentText)
+                }
+                override fun mouseEntered(e: MouseEvent) {
+                    cursor = if (isClickable()) Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                             else Cursor.getDefaultCursor()
+                }
+                override fun mouseExited(e: MouseEvent) {
+                    cursor = Cursor.getDefaultCursor()
+                }
+            })
+        }
+
+        private fun isClickable() =
+            currentText.isNotBlank() &&
+            (currentType == NotificationType.ERROR || currentType == NotificationType.WARNING)
 
         fun update(text: String, type: NotificationType) {
             currentText = text
             currentType = type
+            // Full text as tooltip so even truncated messages are fully readable on hover.
+            toolTipText = if (text.isNotBlank() && type != NotificationType.INFO) text else null
             revalidate()
             repaint()
         }


### PR DESCRIPTION
## What does this PR do?

ERROR and WARNING chips in the status bar are now interactive. Clicking one opens a non-modal popup anchored just above the chip, showing the full message — useful when the error text is too long to fit in the status bar.

**Clickable chip** — ERROR and WARNING chips show a hand cursor on hover and a full-message tooltip. INFO and SUCCESS chips remain non-interactive.

**`ErrorDetailPopup`** — a `JPopupMenu`-based popup (non-modal, no stolen focus, auto-dismisses on outside click) with three clearly separated sections:
- **Header** — bold type label ("Error" / "Warning") in the theme's error/warning color + an icon close button with the standard `InternalFrame` hover/press colors
- **Body** — scrollable `JTextArea` with `12 px` vertical / `14 px` horizontal padding via `EmptyBorder` (set directly on the component so FlatLaf's UI installation doesn't reset it), word-wrapped, read-only
- **Footer** — standard `JButton` ("Copy") as the primary action, right-aligned; turns green with "Copied!" text for 1.2 s after clicking, then reverts

**Auto-dismiss** — the popup closes when: the user clicks outside (JPopupMenu default), the status bar message changes, or the type changes to non-error/warning.

**RTL support** — `ComponentOrientation` is propagated from the invoker to the popup and text area, so button placement and text alignment flip correctly for RTL locales.

**Localization** — four new keys (`error_detail_error`, `error_detail_warning`, `error_detail_copy`, `error_detail_copied`) added to `embedded_en.toml` and all 13 language files with proper translations.

## Related issues

<!-- Link issues this PR closes or is related to. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Attach before/after screenshots for any visual change. -->