### PR TITLE
fix(ui): add hint text to output panel

### DIFF
--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Spell Check"
 find_in_dictionary = "Find in Dictionary"
 input_hint = "Enter text to translate..."
+output_hint = "Translation will appear here…"
 
 
 [main_window_main_menu]

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "تدقيق إملائي"
 find_in_dictionary = "ابحث في القاموس"
 input_hint = "Enter text to translate..."
+output_hint = "ستظهر نتيجة الترجمة هنا…"
 
 
 [main_window_main_menu]

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "বানান যাচাই"
 find_in_dictionary = "অভিধানে খুঁজুন"
 input_hint = "Enter text to translate..."
+output_hint = "অনুবাদের ফলাফল এখানে দেখাবে…"
 
 
 [main_window_main_menu]

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Rechtschreibprüfung"
 find_in_dictionary = "Im Wörterbuch suchen"
 input_hint = "Enter text to translate..."
+output_hint = "Übersetzung erscheint hier…"
 
 
 [main_window_main_menu]

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Spell Check"
 find_in_dictionary = "Find in Dictionary"
 input_hint = "Enter text to translate..."
+output_hint = "Translation will appear here…"
 
 
 [main_window_main_menu]

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Corrector ortográfico"
 find_in_dictionary = "Buscar en el diccionario"
 input_hint = "Enter text to translate..."
+output_hint = "La traducción aparecerá aquí…"
 
 
 [main_window_main_menu]

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Vérification orthographique"
 find_in_dictionary = "Rechercher dans le dictionnaire"
 input_hint = "Enter text to translate..."
+output_hint = "La traduction apparaîtra ici…"
 
 
 [main_window_main_menu]

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Helyesírás-ellenőrzés"
 find_in_dictionary = "Keresés a szótárban"
 input_hint = "Enter text to translate..."
+output_hint = "A fordítás itt jelenik meg…"
 
 
 [main_window_main_menu]

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Controllo ortografico"
 find_in_dictionary = "Cerca nel dizionario"
 input_hint = "Enter text to translate..."
+output_hint = "La traduzione apparirà qui…"
 
 
 [main_window_main_menu]

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "スペルチェック"
 find_in_dictionary = "辞書で検索"
 input_hint = "Enter text to translate..."
+output_hint = "翻訳結果がここに表示されます…"
 
 
 [main_window_main_menu]

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Corretor Ortográfico"
 find_in_dictionary = "Buscar no dicionário"
 input_hint = "Enter text to translate..."
+output_hint = "A tradução aparecerá aqui…"
 
 
 [main_window_main_menu]

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Проверка орфографии"
 find_in_dictionary = "Найти в словаре"
 input_hint = "Enter text to translate..."
+output_hint = "Перевод появится здесь…"
 
 
 [main_window_main_menu]

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "Yazım Denetimi"
 find_in_dictionary = "Sözlükte bul"
 input_hint = "Enter text to translate..."
+output_hint = "Çeviri burada görünecek…"
 
 
 [main_window_main_menu]

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -80,6 +80,7 @@ listen = "@common.listen"
 spell_check = "拼写检查"
 find_in_dictionary = "在词典中查找"
 input_hint = "Enter text to translate..."
+output_hint = "翻译结果将在此处显示…"
 
 
 [main_window_main_menu]

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -36,6 +36,7 @@ class OutputTextPanel(
     init {
         add(readOnlyPanel, BorderLayout.CENTER)
 
+        textPane.hintText = localizationManager.getString("main_window_editor_context_menu.output_hint")
         textPane.getContextMenuLabel = { key ->
             localizationManager.getString("main_window_editor_context_menu.$key")
         }


### PR DESCRIPTION
## What does this PR do?

`OutputTextPanel` was blank when empty, giving no visual cue that a translation was pending. This adds a localized `hintText` placeholder to the output pane, mirroring what the input panel already shows — so users always know the panel is ready and waiting.

Localized across all 14 supported locales (embedded EN + 13 language files).

## Related issues

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Before: output panel empty with no hint -->
<!-- After: output panel shows "Translation will appear here…" when idle -->