### PR TITLE
fix(ui): keep input editable during translation

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -376,7 +376,7 @@ class MainContentView(
                 corrections = mainState.spellCheckCorrections,
                 fontConfig = config.scaledEditorFont,
                 fallbackFontConfig = config.scaledEditorFallbackFont,
-                isEditable = !mainState.isLoading,
+                isEditable = true,
                 isLoading = mainState.isLoading,
                 actionsState = inputActionsState
             )


### PR DESCRIPTION
## What does this PR do?

The input field was set to `isEditable = !isLoading`, which locked typing for the entire duration of every translation request. This is a regression — users should be able to keep typing while a translation runs in the background.

The fix is a single-line change: `isEditable = true`. The 3 px progress bar already communicates that a translation is in flight; disabling the input on top of that adds friction with no benefit.

## Related issues

Closes #53

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No visual change — the input field simply stays editable while the progress bar runs.