### PR TITLE
fix(ui): keyboard-accessible output panels + configurable translate shortcut

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -80,7 +80,8 @@ enum class HotkeyAction {
     OPEN_OCR,
     REPLACE_WITH_TRANSLATION,  // Rob #2 / Davide — translate and replace selected text
     CYCLE_TARGET_LANGUAGE,     // Yan #3 — cycle through available target languages
-    SHOW_DICTIONARY            // open floating dictionary popup
+    SHOW_DICTIONARY,           // open floating dictionary popup
+    TRANSLATE                  // trigger translation (default: Ctrl+Enter, LOCAL)
 }
 
 /**
@@ -147,6 +148,7 @@ data class HotkeyBinding(
             HotkeyBinding(HotkeyAction.REPLACE_WITH_TRANSLATION, keyCode = java.awt.event.KeyEvent.VK_T,               modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK, scope = HotkeyScope.GLOBAL),
             HotkeyBinding(HotkeyAction.CYCLE_TARGET_LANGUAGE,    keyCode = java.awt.event.KeyEvent.VK_L,               modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK,  scope = HotkeyScope.LOCAL),
             HotkeyBinding(HotkeyAction.SHOW_DICTIONARY,          keyCode = java.awt.event.KeyEvent.VK_D,               modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK,  scope = HotkeyScope.GLOBAL),
+            HotkeyBinding(HotkeyAction.TRANSLATE,                keyCode = java.awt.event.KeyEvent.VK_ENTER,            modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK,  scope = HotkeyScope.LOCAL),
         )
     }
 }

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -250,6 +250,7 @@ action_ocr = "OCR from Screen"
 action_replace = "Replace Selection with Translation (experimental)"
 action_cycle_language = "Cycle Target Language"
 action_show_dictionary = "Show Dictionary"
+action_translate = "Translate"
 scope_toggle_hint = "Click to toggle between Global and Local"
 
 # Default Actions Descriptions

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -253,6 +253,7 @@ action_ocr = "التعرف على النص من الشاشة"
 action_replace = "استبدال المحدد بالترجمة (تجريبي)"
 action_cycle_language = "تبديل لغة الهدف"
 action_show_dictionary = "فتح القاموس"
+action_translate = "ترجمة"
 scope_toggle_hint = "انقر للتبديل بين العالمي والمحلي"
 
 # Default Actions Descriptions

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -253,6 +253,7 @@ action_ocr = "স্ক্রিন থেকে OCR"
 action_replace = "অনুবাদ দিয়ে নির্বাচন প্রতিস্থাপন করুন (পরীক্ষামূলক)"
 action_cycle_language = "টার্গেট ভাষা পরিবর্তন (সাইকেল)"
 action_show_dictionary = "অভিধান দেখান"
+action_translate = "অনুবাদ করুন"
 scope_toggle_hint = "গ্লোবাল এবং লোকাল এর মধ্যে পরিবর্তন করতে ক্লিক করুন"
 
 # Default Actions Descriptions

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR vom Bildschirm"
 action_replace = "Auswahl durch Übersetzung ersetzen (exp.)"
 action_cycle_language = "Zielsprache wechseln"
 action_show_dictionary = "Wörterbuch anzeigen"
+action_translate = "Übersetzen"
 scope_toggle_hint = "Klicken, um zwischen Global und Lokal zu wechseln"
 
 # Default Actions Descriptions

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR from Screen"
 action_replace = "Replace Selection with Translation (experimental)"
 action_cycle_language = "Cycle Target Language"
 action_show_dictionary = "Show Dictionary"
+action_translate = "Translate"
 scope_toggle_hint = "Click to toggle between Global and Local"
 
 # Default Actions Descriptions

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR de Pantalla"
 action_replace = "Reemplazar Selección con Traducción (experimental)"
 action_cycle_language = "Ciclar Idioma de Destino"
 action_show_dictionary = "Mostrar diccionario"
+action_translate = "Traducir"
 scope_toggle_hint = "Haga clic para cambiar entre Global y Local"
 
 # Default Actions Descriptions

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR depuis l'écran"
 action_replace = "Remplacer la sélection par la traduction (expérimental)"
 action_cycle_language = "Changer la langue cible"
 action_show_dictionary = "Afficher le dictionnaire"
+action_translate = "Traduire"
 scope_toggle_hint = "Cliquez pour basculer entre Global et Local"
 
 # Default Actions Descriptions

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR a képernyőről"
 action_replace = "A kiválasztás lecserélése fordításra (kísérleti)"
 action_cycle_language = "Célnyelv váltása"
 action_show_dictionary = "Szótár megjelenítése"
+action_translate = "Fordítás"
 scope_toggle_hint = "Kattintson a Globális és a Helyi közötti váltáshoz"
 
 # Default Actions Descriptions

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR da schermo"
 action_replace = "Sostituisci selezione con traduzione (sperimentale)"
 action_cycle_language = "Cambia lingua destinazione"
 action_show_dictionary = "Mostra dizionario"
+action_translate = "Traduci"
 scope_toggle_hint = "Fai clic per cambiare da globale a locale"
 
 # Default Actions Descriptions

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -253,6 +253,7 @@ action_ocr = "画面から OCR"
 action_replace = "選択範囲を翻訳で置換 (試験的)"
 action_cycle_language = "ターゲット言語を切り替え"
 action_show_dictionary = "辞書を表示"
+action_translate = "翻訳"
 scope_toggle_hint = "クリックしてグローバルとローカルを切り替え"
 
 # Default Actions Descriptions

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR da Tela"
 action_replace = "Substituir Seleção pela Tradução (experimental)"
 action_cycle_language = "Alternar Idioma de Destino"
 action_show_dictionary = "Mostrar dicionário"
+action_translate = "Traduzir"
 scope_toggle_hint = "Clique para alternar entre Global e Local"
 
 # Default Actions Descriptions

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -253,6 +253,7 @@ action_ocr = "OCR с экрана"
 action_replace = "Заменить выделение переводом (экспер.)"
 action_cycle_language = "Переключить целевой язык"
 action_show_dictionary = "Показать словарь"
+action_translate = "Перевести"
 scope_toggle_hint = "Нажмите для переключения между Глобально и Локально"
 
 # Default Actions Descriptions

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -253,6 +253,7 @@ action_ocr = "Ekrandan OCR Yap"
 action_replace = "Seçileni Çeviri ile Değiştir (deneysel)"
 action_cycle_language = "Hedef Dili Değiştir"
 action_show_dictionary = "Sözlüğü Göster"
+action_translate = "Çevir"
 scope_toggle_hint = "Küresel ve Yerel arasında geçiş yapmak için tıklayın"
 
 # Default Actions Descriptions

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -253,6 +253,7 @@ action_ocr = "屏幕 OCR"
 action_replace = "用翻译替换选中文本 (实验性)"
 action_cycle_language = "循环切换目标语言"
 action_show_dictionary = "显示词典"
+action_translate = "翻译"
 scope_toggle_hint = "点击在全局和本地范围之间切换"
 
 # Default Actions Descriptions

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -588,13 +588,17 @@ class MainAppFrame(
      * whenever bindings change (Dinar's per-action scope request).
      */
     private fun registerLocalHotkeys() {
-        rootPane.inputMap.clear()
+        // WHEN_ANCESTOR_OF_FOCUSED_COMPONENT fires whenever any descendant has focus,
+        // which is always the case (text pane, buttons, etc.).
+        // WHEN_FOCUSED would only fire if rootPane itself held focus — which never happens.
+        val inputMap = rootPane.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+        inputMap.clear()
         rootPane.actionMap.clear()
 
         globalKeyListener.getLocalBindings().forEach { binding ->
             val keyStroke = binding.toKeyStroke() ?: return@forEach
             val actionKey = "localHotkey_${binding.action.name}"
-            rootPane.inputMap.put(keyStroke, actionKey)
+            inputMap.put(keyStroke, actionKey)
             rootPane.actionMap.put(actionKey, object : AbstractAction() {
                 override fun actionPerformed(e: ActionEvent) {
                     globalKeyListener.dispatchAction(binding.action)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -179,7 +179,8 @@ class MainAppFrame(
                 quickDictionaryPositionNearMouse = true   // hotkey — position near cursor
                 mainStore.dispatch(MainIntent.ShowQuickDictionary(selectedText, lang))
             }
-        }
+        },
+        onTranslate = { mainStore.dispatch(MainIntent.Translate()) }
     )
 
     private val statusBarController = StatusBarController(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -7,6 +7,7 @@ import com.github.ahatem.qtranslate.core.main.mvi.MainIntent
 import com.github.ahatem.qtranslate.core.main.mvi.MainState
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputType
+import com.github.ahatem.qtranslate.core.settings.data.HotkeyAction
 import com.github.ahatem.qtranslate.core.settings.data.TextSource
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsIntent
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsState
@@ -171,6 +172,7 @@ class MainContentView(
 
     private var lastState: Pair<MainState, SettingsState>? = null
     private var lastDictionaryKey: DictionaryKey? = null
+    private var currentTranslateKeyStroke: KeyStroke? = null
 
     private data class DictionaryKey(
         val isVisible: Boolean,
@@ -213,9 +215,26 @@ class MainContentView(
             layoutManager.updateVisibility(config)
         }
 
+        updateTranslateKeyStroke(config)
         renderDictionaryPanel(mainState, config)
         renderComponents(mainState, config)
         lastState = mainState to settingsState
+    }
+
+    /**
+     * Keeps the per-pane translate keystroke in sync with the user's configured binding.
+     * Binding lives on each AdvancedTextPane (WHEN_FOCUSED) so the pane can pass selected
+     * text to onTranslateRequest rather than always using the full input text.
+     */
+    private fun updateTranslateKeyStroke(config: Configuration) {
+        val binding = config.hotkeys.find { it.action == HotkeyAction.TRANSLATE }
+        val newStroke = binding?.takeIf { it.isEnabled }?.toKeyStroke()
+        if (newStroke == currentTranslateKeyStroke) return
+        val old = currentTranslateKeyStroke
+        currentTranslateKeyStroke = newStroke
+        inputTextPanel.setTranslateKeyStroke(old, newStroke)
+        outputTextPanel.setTranslateKeyStroke(old, newStroke)
+        extraOutputPanel.setTranslateKeyStroke(old, newStroke)
     }
 
     private fun renderDictionaryPanel(mainState: MainState, config: Configuration) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -39,7 +39,12 @@ import com.github.ahatem.qtranslate.ui.swing.shared.util.scaledEditorFont
 import com.github.ahatem.qtranslate.ui.swing.shared.util.toImageData
 import java.awt.BorderLayout
 import java.awt.Dimension
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.AbstractAction
+import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.KeyStroke
 import javax.swing.UIManager
 
 class MainContentView(
@@ -100,6 +105,7 @@ class MainContentView(
             dispatch(MainIntent.Translate(text))
         },
         onFindInDictionary = { word -> showDictionaryWithWord(word, currentTargetLanguage) },
+        onEscapePressed = { inputTextPanel.requestFocusOnText() },
     )
 
     private val extraOutputPanel = ExtraOutputPanel(
@@ -111,6 +117,7 @@ class MainContentView(
             dispatch(MainIntent.Translate(text))
         },
         onFindInDictionary = { word -> showDictionaryWithWord(word, currentExtraOutputLanguage) },
+        onEscapePressed = { inputTextPanel.requestFocusOnText() },
     )
 
     val statusBar: StatusBar = StatusBar(
@@ -179,6 +186,17 @@ class MainContentView(
 
     init {
         add(splitPane, BorderLayout.CENTER)
+
+        // Direct panel focus shortcuts — work from anywhere in the window.
+        // Alt+1 → input, Alt+2 → output, Alt+3 → extra-output.
+        val im = getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        val am = actionMap
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_1, InputEvent.ALT_DOWN_MASK), "focus-panel-input")
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_2, InputEvent.ALT_DOWN_MASK), "focus-panel-output")
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_3, InputEvent.ALT_DOWN_MASK), "focus-panel-extra")
+        am.put("focus-panel-input",  object : AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent) { inputTextPanel.requestFocusOnText() } })
+        am.put("focus-panel-output", object : AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent) { outputTextPanel.requestFocusOnText() } })
+        am.put("focus-panel-extra",  object : AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent) { extraOutputPanel.requestFocusOnText() } })
     }
 
     fun render(mainState: MainState, settingsState: SettingsState) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
@@ -46,7 +46,8 @@ class MainGlobalKeyListener(
     private val onOpenSnippingTool: () -> Unit,
     private val onReplaceWithTranslation: (String) -> Unit,
     private val onCycleTargetLanguage: () -> Unit,
-    private val onShowDictionary: (String) -> Unit = {}
+    private val onShowDictionary: (String) -> Unit = {},
+    private val onTranslate: () -> Unit = {}
 ) {
 
     private var provider: Provider? = null
@@ -159,6 +160,8 @@ class MainGlobalKeyListener(
                 onCycleTargetLanguage()
             HotkeyAction.SHOW_DICTIONARY ->
                 scope.launch { handleSelectedText(onShowDictionary) }
+            HotkeyAction.TRANSLATE ->
+                onTranslate()
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
@@ -39,7 +39,7 @@ class InputTextPanel(
     private var currentState: InputTextState? = null
 
     init {
-        val scrollPane = JScrollPane(textPane)
+        val scrollPane = JScrollPane(textPane).apply { isFocusable = false }
 
         val actionsWrapper = JPanel(BorderLayout()).apply {
             border = BorderFactory.createEmptyBorder(0, 4, 0, 0)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
@@ -78,6 +78,8 @@ class InputTextPanel(
     }
 
     fun requestFocusOnText() = textPane.requestFocusInWindow()
+    fun setTranslateKeyStroke(old: javax.swing.KeyStroke?, new: javax.swing.KeyStroke?) =
+        textPane.setTranslateKeyStroke(old, new)
 
     private fun customizeContextMenu(menu: JPopupMenu, clickPosition: Point) {
         spellingMenu?.let { menu.remove(it) }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
@@ -80,6 +80,8 @@ class ExtraOutputPanel(
     }
 
     fun requestFocusOnText() = textPane.requestFocusInWindow()
+    fun setTranslateKeyStroke(old: javax.swing.KeyStroke?, new: javax.swing.KeyStroke?) =
+        textPane.setTranslateKeyStroke(old, new)
 
     private var currentState: ExtraOutputState? = null
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
@@ -16,6 +16,8 @@ import java.awt.BorderLayout
 import java.awt.FlowLayout
 import java.awt.Insets
 import java.awt.Point
+import java.awt.event.ActionEvent
+import java.awt.event.KeyEvent
 import javax.swing.*
 
 /**
@@ -30,10 +32,11 @@ class ExtraOutputPanel(
     onListen: (text: String) -> Unit,
     onTranslateRequest: (text: String) -> Unit,
     private val onFindInDictionary: ((String) -> Unit)? = null,
+    private val onEscapePressed: (() -> Unit)? = null,
 ) : JPanel(BorderLayout()), Renderable<ExtraOutputState> {
 
     private val textPane = AdvancedTextPane(
-        onTextChanged = { /* Read-only */ },
+        onTextChanged = {},
         onListenRequest = onListen,
         onTranslateRequest = onTranslateRequest
     )
@@ -76,11 +79,20 @@ class ExtraOutputPanel(
         add(gearPanel, BorderLayout.LINE_END)
     }
 
+    fun requestFocusOnText() = textPane.requestFocusInWindow()
+
     private var currentState: ExtraOutputState? = null
 
     init {
         add(headerBar, BorderLayout.NORTH)
         add(readOnlyPanel, BorderLayout.CENTER)
+
+        onEscapePressed?.let { handler ->
+            textPane.inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "escape-to-input")
+            textPane.actionMap.put("escape-to-input", object : AbstractAction() {
+                override fun actionPerformed(e: ActionEvent) = handler()
+            })
+        }
 
         backwardBtn.addActionListener {
             if (backwardBtn.isSelected)
@@ -136,7 +148,8 @@ class ExtraOutputPanel(
                 isLoading = state.isLoading,
                 fontConfig = state.fontConfig,
                 fallbackFontConfig = state.fallbackFontConfig,
-                actionsState = state.actionsState
+                actionsState = state.actionsState,
+                isEditable = state.isEditable
             )
         )
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -9,10 +9,14 @@ import com.github.ahatem.qtranslate.ui.swing.shared.widgets.AdvancedTextPane
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.BorderLayout
 import java.awt.Point
+import java.awt.event.ActionEvent
+import java.awt.event.KeyEvent
+import javax.swing.AbstractAction
 import javax.swing.JMenuItem
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JSeparator
+import javax.swing.KeyStroke
 
 class OutputTextPanel(
     iconManager: IconManager,
@@ -20,10 +24,11 @@ class OutputTextPanel(
     onListen: (text: String) -> Unit,
     onTranslateRequest: (text: String) -> Unit,
     private val onFindInDictionary: ((String) -> Unit)? = null,
+    private val onEscapePressed: (() -> Unit)? = null,
 ) : JPanel(BorderLayout()), Renderable<OutputTextState> {
 
     private val textPane = AdvancedTextPane(
-        onTextChanged = { /* Read-only */ },
+        onTextChanged = {},
         onListenRequest = onListen,
         onTranslateRequest = onTranslateRequest
     )
@@ -33,10 +38,19 @@ class OutputTextPanel(
     private var dictMenuItem: JMenuItem? = null
     private var dictMenuSeparator: JSeparator? = null
 
+    fun requestFocusOnText() = textPane.requestFocusInWindow()
+
     init {
         add(readOnlyPanel, BorderLayout.CENTER)
 
         textPane.hintText = localizationManager.getString("main_window_editor_context_menu.output_hint")
+
+        onEscapePressed?.let { handler ->
+            textPane.inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "escape-to-input")
+            textPane.actionMap.put("escape-to-input", object : AbstractAction() {
+                override fun actionPerformed(e: ActionEvent) = handler()
+            })
+        }
         textPane.getContextMenuLabel = { key ->
             localizationManager.getString("main_window_editor_context_menu.$key")
         }
@@ -55,7 +69,8 @@ class OutputTextPanel(
                 isLoading = state.isLoading,
                 fontConfig = state.fontConfig,
                 fallbackFontConfig = state.fallbackFontConfig,
-                actionsState = state.actionsState
+                actionsState = state.actionsState,
+                isEditable = state.isEditable
             )
         )
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -39,6 +39,8 @@ class OutputTextPanel(
     private var dictMenuSeparator: JSeparator? = null
 
     fun requestFocusOnText() = textPane.requestFocusInWindow()
+    fun setTranslateKeyStroke(old: javax.swing.KeyStroke?, new: javax.swing.KeyStroke?) =
+        textPane.setTranslateKeyStroke(old, new)
 
     init {
         add(readOnlyPanel, BorderLayout.CENTER)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
@@ -12,7 +12,8 @@ data class OutputTextState(
     val fontConfig: FontConfig,
     val fallbackFontConfig: FontConfig,
     val isLoading: Boolean,
-    val actionsState: TextActionsState
+    val actionsState: TextActionsState,
+    val isEditable: Boolean = true
 ) : UiState
 
 data class ExtraOutputState(
@@ -22,6 +23,7 @@ data class ExtraOutputState(
     val isLoading: Boolean,
     val isVisible: Boolean,
     val actionsState: TextActionsState,
+    val isEditable: Boolean = true,
 
     val activeType: ExtraOutputType = ExtraOutputType.None,
     val summaryLength: SummaryLength = SummaryLength.MEDIUM,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/widgets/ReadOnlyTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/widgets/ReadOnlyTextPanel.kt
@@ -16,7 +16,8 @@ data class ReadOnlyTextPanelState(
     val isLoading: Boolean,
     val fontConfig: FontConfig,
     val fallbackFontConfig: FontConfig,
-    val actionsState: TextActionsState
+    val actionsState: TextActionsState,
+    val isEditable: Boolean = false
 ) : UiState
 
 class ReadOnlyTextPanel(
@@ -25,7 +26,7 @@ class ReadOnlyTextPanel(
 ) : JPanel(BorderLayout()), Renderable<ReadOnlyTextPanelState> {
 
     init {
-        val scrollPane = JScrollPane(textPane)
+        val scrollPane = JScrollPane(textPane).apply { isFocusable = false }
 
         val actionsWrapper = JPanel(BorderLayout()).apply {
             border = BorderFactory.createEmptyBorder(0, 4, 0, 0)
@@ -44,7 +45,7 @@ class ReadOnlyTextPanel(
         textPane.render(
             text = state.text,
             corrections = emptyList(),
-            isEditable = false
+            isEditable = state.isEditable
         )
 
         textPane.updateFontsAndRescanDocument(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
@@ -31,7 +31,8 @@ class KeyboardPanel(
         HotkeyAction.OPEN_OCR,
         HotkeyAction.REPLACE_WITH_TRANSLATION,
         HotkeyAction.CYCLE_TARGET_LANGUAGE,
-        HotkeyAction.SHOW_DICTIONARY
+        HotkeyAction.SHOW_DICTIONARY,
+        HotkeyAction.TRANSLATE
     )
 
     private val nonEditableActions = setOf(HotkeyAction.SHOW_MAIN_WINDOW)
@@ -242,6 +243,7 @@ class KeyboardPanel(
         HotkeyAction.REPLACE_WITH_TRANSLATION -> localizationManager.getString("settings_hotkeys.action_replace")
         HotkeyAction.CYCLE_TARGET_LANGUAGE    -> localizationManager.getString("settings_hotkeys.action_cycle_language")
         HotkeyAction.SHOW_DICTIONARY          -> localizationManager.getString("settings_hotkeys.action_show_dictionary")
+        HotkeyAction.TRANSLATE                -> localizationManager.getString("settings_hotkeys.action_translate")
     }
 
     private fun scopeLabel(scope: HotkeyScope): String = when (scope) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
@@ -350,6 +350,7 @@ object HotkeyRecorderDialog {
             HotkeyAction.REPLACE_WITH_TRANSLATION -> localizer.getString("settings_hotkeys.action_replace")
             HotkeyAction.CYCLE_TARGET_LANGUAGE    -> localizer.getString("settings_hotkeys.action_cycle_language")
             HotkeyAction.SHOW_DICTIONARY          -> localizer.getString("settings_hotkeys.action_show_dictionary")
+            HotkeyAction.TRANSLATE                -> localizer.getString("settings_hotkeys.action_translate")
         }
 
         val promptLabel = JLabel(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -512,8 +512,18 @@ class AdvancedTextPane(
             if (undoManager.canRedo()) undoManager.redo()
         }
 
+        // Translate action — keystroke is set dynamically via setTranslateKeyStroke() so the
+        // user-configured binding is always used; selected text is preferred over full pane text.
+        val translateAction = object : AbstractAction("Translate") {
+            override fun actionPerformed(e: ActionEvent) {
+                val textToTranslate = selectedText?.takeIf { it.isNotBlank() } ?: text
+                if (textToTranslate.isNotBlank()) onTranslateRequest(textToTranslate)
+            }
+        }
+
         actionMap.put("undo", undoAction)
         actionMap.put("redo", redoAction)
+        actionMap.put("translate", translateAction)
         inputMap.put(undoAction.getValue(Action.ACCELERATOR_KEY) as KeyStroke, "undo")
         inputMap.put(redoAction.getValue(Action.ACCELERATOR_KEY) as KeyStroke, "redo")
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.CTRL_DOWN_MASK), "none")
@@ -534,6 +544,16 @@ class AdvancedTextPane(
             actionMap.put("paste-image-or-text", pasteAction)
             inputMap.put(pasteAction.getValue(Action.ACCELERATOR_KEY) as KeyStroke, "paste-image-or-text")
         }
+    }
+
+    /**
+     * Swaps the keyboard shortcut that triggers the translate action.
+     * Called by the owning panel whenever the user changes the binding in Settings.
+     * [old] is removed, [new] is registered — both may be null (no-op for that half).
+     */
+    fun setTranslateKeyStroke(old: KeyStroke?, new: KeyStroke?) {
+        old?.let { inputMap.remove(it) }
+        new?.let { inputMap.put(it, "translate") }
     }
 
     // -----------------------------------------------------------------------

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -338,7 +338,7 @@ class AdvancedTextPane(
         highlighter  = WavyUnderlineHighlighter()
         editorKit    = WrappingEditorKit()
         caret        = AdvancedCaret()
-        focusTraversalKeysEnabled = false
+        focusTraversalKeysEnabled = true
         margin = Insets(6, 6, 6, 6)
 
         document.addUndoableEditListener(undoManager)


### PR DESCRIPTION
## What changed

Closes #54

### Keyboard navigation
- **TAB / Shift+TAB** now move naturally between input → output → extra-output and back. Three layers of blocking were removed:
  - `focusTraversalKeysEnabled` set back to `true` in `AdvancedTextPane`
  - `JScrollPane.isFocusable = false` in all three panel types so TAB skips the container and lands on the text pane
  - `ReadOnlyTextPanel` now honours `isEditable` from state instead of hardcoding `false`; output panels default to `isEditable = true`
- **Escape** from any output pane returns focus to the input pane
- **Alt+1 / Alt+2 / Alt+3** (WHEN_IN_FOCUSED_WINDOW) jump directly to input / output / extra-output from anywhere in the window

### Configurable translate shortcut
- `HotkeyAction.TRANSLATE` added — default binding **Ctrl+Enter**, scope LOCAL
- Routed through `MainGlobalKeyListener.onTranslate` → `MainIntent.Translate()`; registered automatically by the existing `registerLocalHotkeys()` machinery in `MainAppFrame`
- Hardcoded Ctrl+Enter removed from `AdvancedTextPane.setupKeyBindings()`; the shortcut now lives entirely in the hotkey system
- Appears in **Settings → Keyboard** as "Translate" and can be rebound or cleared by the user
- `action_translate` label added to `embedded_en.toml` and all 13 locale files

## Test plan
- [ ] TAB from input pane → lands in output pane; Shift+TAB goes back
- [ ] TAB from output pane → lands in extra-output pane (when visible)
- [ ] Escape from output / extra-output → focus returns to input
- [ ] Alt+1 / Alt+2 / Alt+3 jump to the correct panel from any focused component
- [ ] Ctrl+Enter in input pane → triggers translation
- [ ] Ctrl+Enter in output pane → triggers re-translation
- [ ] Settings → Keyboard shows "Translate" row with Ctrl+Enter binding
- [ ] Rebind translate to a different key → new key fires translation, old key does nothing
- [ ] Clear translate binding → Ctrl+Enter no longer triggers translation
- [ ] Verify no compilation errors (`./gradlew compileKotlin`)