### PR TITLE
fix(core): cancel in-flight translation immediately on new input (#53)

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -168,6 +168,15 @@ class MainStore(
                     intent.text.replace("\n", " ").replace("\r", "").replace("  ", " ").trim()
                 else intent.text
                 _state.update { it.copy(inputText = cleaned, detectedSourceLanguage = null) }
+                // With instant translate enabled, cancel any in-flight translation immediately
+                // so the loading indicator clears and the debounce can queue the next request.
+                // Without this, the collect coroutine in observeInstantTranslation stays
+                // suspended at join() until the current translation finishes — the user's new
+                // text effectively waits in line behind the old result.
+                if (settingsState.value.isInstantTranslationEnabled && _state.value.isLoading) {
+                    translateTextUseCase.cancel()
+                    _state.update { it.copy(isLoading = false) }
+                }
             }
 
             is MainIntent.SelectSourceLanguage ->


### PR DESCRIPTION
## Problem

When instant translate is enabled and a translation is in progress, `TranslateTextUseCase.invoke()` ends with `translationJob?.join()`. This suspends the `observeInstantTranslation` collector coroutine until the translation completes.

Any text the user types during that window is queued by the debounce flow, but the collector cannot call `cancel()` on the old job until the current `join()` returns — so the stale translation runs to its natural end before the next request fires. The user perceives this as the input being unresponsive / lagging.

## Fix

In `UpdateInputText` dispatch: if instant translate is enabled and `isLoading = true`, immediately call `translateTextUseCase.cancel()` and clear `isLoading`. The debounce then picks up the new text without waiting for the old result.

## Expected behaviour (with fix)
- User types "beh" → pause → translation starts
- User types "a" → translation for "beh" cancels instantly, loading indicator disappears
- Debounce fires → translation starts for "beha"

## Before / after
| | Before | After |
|---|---|---|
| Typing during translation | Old translation blocks until done | Cancelled immediately on first keystroke |
| Loading indicator while typing | Stays on until old job finishes | Clears instantly |

Closes #53