### PR TITLE
fix(ui): eliminate DictionaryResultView flicker by skipping redundant rebuilds

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
@@ -22,6 +22,14 @@ class DictionaryResultView : JScrollPane() {
         border = BorderFactory.createEmptyBorder(12, 16, 16, 16)
     }
 
+    // Cache the last rendered data. Both DictionaryPanel (embedded) and
+    // QuickDictionaryDialog use this view, and their parents call render()
+    // on every state emission even when the entries haven't changed.
+    // removeAll() + full rebuild causes the panel to flash blank for one
+    // frame before repainting — the equality guard prevents that entirely.
+    private var lastEntries: List<DictionaryEntry> = emptyList()
+    private var lastSynonymsLabel: String = ""
+
     init {
         setViewportView(content)
         border = null
@@ -35,6 +43,9 @@ class DictionaryResultView : JScrollPane() {
         synonymsLabel: String,
         onSynonymClicked: ((String) -> Unit)? = null
     ) {
+        if (entries == lastEntries && synonymsLabel == lastSynonymsLabel) return
+        lastEntries = entries
+        lastSynonymsLabel = synonymsLabel
         content.removeAll()
 
         if (entries.isEmpty()) {


### PR DESCRIPTION
## Problem

`DictionaryResultView.render()` called `content.removeAll()` unconditionally on every invocation, then rebuilt the entire component tree from scratch. Since both `DictionaryPanel` (embedded in the main window) and `QuickDictionaryDialog` (floating popup) call `render()` on every state emission — even when the dictionary entries haven't changed — the panel flashed blank for one frame on any unrelated state update (language switch, settings save, loading state toggle, etc.).

## Fix

Cache `lastEntries` and `lastSynonymsLabel`. Return early if neither changed. The `removeAll()` + rebuild only runs when the actual data changes.

The `onSynonymClicked` lambda is intentionally excluded from the equality check — lambda references are always new objects, so comparing them would always miss, and the callbacks close over stable constructor references anyway.

## Affected surfaces
- `DictionaryPanel` — embedded dictionary in the main window sidebar
- `QuickDictionaryDialog` — floating dictionary popup (Ctrl+D)