### PR TITLE
fix(ui): output panels read-only + 'Set as Input' context menu (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ logs/
 local.properties
 
 
-old-core/
+old-core/.claude/

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Spell Check"
 find_in_dictionary = "Find in Dictionary"
+set_as_input = "Set as Input"
 input_hint = "Enter text to translate..."
 output_hint = "Translation will appear here…"
 

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "تدقيق إملائي"
 find_in_dictionary = "ابحث في القاموس"
+set_as_input = "تعيين كإدخال"
 input_hint = "Enter text to translate..."
 output_hint = "ستظهر نتيجة الترجمة هنا…"
 

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "বানান যাচাই"
 find_in_dictionary = "অভিধানে খুঁজুন"
+set_as_input = "ইনপুট হিসেবে সেট করুন"
 input_hint = "Enter text to translate..."
 output_hint = "অনুবাদের ফলাফল এখানে দেখাবে…"
 

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Rechtschreibprüfung"
 find_in_dictionary = "Im Wörterbuch suchen"
+set_as_input = "Als Eingabe festlegen"
 input_hint = "Enter text to translate..."
 output_hint = "Übersetzung erscheint hier…"
 

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Spell Check"
 find_in_dictionary = "Find in Dictionary"
+set_as_input = "Set as Input"
 input_hint = "Enter text to translate..."
 output_hint = "Translation will appear here…"
 

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Corrector ortográfico"
 find_in_dictionary = "Buscar en el diccionario"
+set_as_input = "Establecer como entrada"
 input_hint = "Enter text to translate..."
 output_hint = "La traducción aparecerá aquí…"
 

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Vérification orthographique"
 find_in_dictionary = "Rechercher dans le dictionnaire"
+set_as_input = "Définir comme entrée"
 input_hint = "Enter text to translate..."
 output_hint = "La traduction apparaîtra ici…"
 

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Helyesírás-ellenőrzés"
 find_in_dictionary = "Keresés a szótárban"
+set_as_input = "Beállítás bemenetként"
 input_hint = "Enter text to translate..."
 output_hint = "A fordítás itt jelenik meg…"
 

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Controllo ortografico"
 find_in_dictionary = "Cerca nel dizionario"
+set_as_input = "Imposta come input"
 input_hint = "Enter text to translate..."
 output_hint = "La traduzione apparirà qui…"
 

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "スペルチェック"
 find_in_dictionary = "辞書で検索"
+set_as_input = "入力として設定"
 input_hint = "Enter text to translate..."
 output_hint = "翻訳結果がここに表示されます…"
 

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Corretor Ortográfico"
 find_in_dictionary = "Buscar no dicionário"
+set_as_input = "Definir como entrada"
 input_hint = "Enter text to translate..."
 output_hint = "A tradução aparecerá aqui…"
 

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Проверка орфографии"
 find_in_dictionary = "Найти в словаре"
+set_as_input = "Задать как источник"
 input_hint = "Enter text to translate..."
 output_hint = "Перевод появится здесь…"
 

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "Yazım Denetimi"
 find_in_dictionary = "Sözlükte bul"
+set_as_input = "Giriş Olarak Ayarla"
 input_hint = "Enter text to translate..."
 output_hint = "Çeviri burada görünecek…"
 

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -79,6 +79,7 @@ translate = "@main_window_language_bar.translate_button"
 listen = "@common.listen"
 spell_check = "拼写检查"
 find_in_dictionary = "在词典中查找"
+set_as_input = "设为输入"
 input_hint = "Enter text to translate..."
 output_hint = "翻译结果将在此处显示…"
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -106,6 +106,10 @@ class MainContentView(
             dispatch(MainIntent.Translate(text))
         },
         onFindInDictionary = { word -> showDictionaryWithWord(word, currentTargetLanguage) },
+        onSetAsInput = { text ->
+            dispatch(MainIntent.UpdateInputText(text))
+            inputTextPanel.requestFocusOnText()
+        },
         onEscapePressed = { inputTextPanel.requestFocusOnText() },
     )
 
@@ -118,6 +122,10 @@ class MainContentView(
             dispatch(MainIntent.Translate(text))
         },
         onFindInDictionary = { word -> showDictionaryWithWord(word, currentExtraOutputLanguage) },
+        onSetAsInput = { text ->
+            dispatch(MainIntent.UpdateInputText(text))
+            inputTextPanel.requestFocusOnText()
+        },
         onEscapePressed = { inputTextPanel.requestFocusOnText() },
     )
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
@@ -32,6 +32,7 @@ class ExtraOutputPanel(
     onListen: (text: String) -> Unit,
     onTranslateRequest: (text: String) -> Unit,
     private val onFindInDictionary: ((String) -> Unit)? = null,
+    private val onSetAsInput: ((String) -> Unit)? = null,
     private val onEscapePressed: (() -> Unit)? = null,
 ) : JPanel(BorderLayout()), Renderable<ExtraOutputState> {
 
@@ -116,15 +117,18 @@ class ExtraOutputPanel(
         textPane.getContextMenuLabel = { key ->
             localizationManager.getString("main_window_editor_context_menu.$key")
         }
-        if (onFindInDictionary != null) {
+        if (onFindInDictionary != null || onSetAsInput != null) {
             textPane.onBeforeContextMenuPopup = { menu, clickPosition ->
-                addFindInDictionaryItem(menu, clickPosition)
+                if (onFindInDictionary != null) addFindInDictionaryItem(menu, clickPosition)
+                if (onSetAsInput != null) addSetAsInputItem(menu)
             }
         }
     }
 
     private var dictMenuItem: JMenuItem? = null
     private var dictMenuSeparator: JSeparator? = null
+    private var setAsInputMenuItem: JMenuItem? = null
+    private var setAsInputSeparator: JSeparator? = null
 
     override fun render(state: ExtraOutputState) {
         isVisible = state.isVisible
@@ -202,6 +206,25 @@ class ExtraOutputPanel(
             menu.add(sep)
             menu.add(item)
         }
+    }
+
+    private fun addSetAsInputItem(menu: JPopupMenu) {
+        setAsInputMenuItem?.let { menu.remove(it) }
+        setAsInputSeparator?.let { menu.remove(it) }
+        setAsInputMenuItem = null
+        setAsInputSeparator = null
+
+        val text = (textPane.selectedText?.trim()?.takeIf { it.isNotBlank() }
+            ?: textPane.text?.trim()).takeIf { !it.isNullOrBlank() } ?: return
+
+        val sep = JSeparator()
+        val item = JMenuItem(localizationManager.getString("main_window_editor_context_menu.set_as_input")).apply {
+            addActionListener { onSetAsInput?.invoke(text) }
+        }
+        setAsInputSeparator = sep
+        setAsInputMenuItem = item
+        menu.add(sep)
+        menu.add(item)
     }
 
     private fun wordAtOffset(offset: Int): String {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -24,6 +24,7 @@ class OutputTextPanel(
     onListen: (text: String) -> Unit,
     onTranslateRequest: (text: String) -> Unit,
     private val onFindInDictionary: ((String) -> Unit)? = null,
+    private val onSetAsInput: ((String) -> Unit)? = null,
     private val onEscapePressed: (() -> Unit)? = null,
 ) : JPanel(BorderLayout()), Renderable<OutputTextState> {
 
@@ -37,6 +38,8 @@ class OutputTextPanel(
 
     private var dictMenuItem: JMenuItem? = null
     private var dictMenuSeparator: JSeparator? = null
+    private var setAsInputMenuItem: JMenuItem? = null
+    private var setAsInputSeparator: JSeparator? = null
 
     fun requestFocusOnText() = textPane.requestFocusInWindow()
     fun setTranslateKeyStroke(old: javax.swing.KeyStroke?, new: javax.swing.KeyStroke?) =
@@ -56,9 +59,10 @@ class OutputTextPanel(
         textPane.getContextMenuLabel = { key ->
             localizationManager.getString("main_window_editor_context_menu.$key")
         }
-        if (onFindInDictionary != null) {
+        if (onFindInDictionary != null || onSetAsInput != null) {
             textPane.onBeforeContextMenuPopup = { menu, clickPosition ->
-                addFindInDictionaryItem(menu, clickPosition)
+                if (onFindInDictionary != null) addFindInDictionaryItem(menu, clickPosition)
+                if (onSetAsInput != null) addSetAsInputItem(menu)
             }
         }
     }
@@ -97,6 +101,26 @@ class OutputTextPanel(
             menu.add(sep)
             menu.add(item)
         }
+    }
+
+    private fun addSetAsInputItem(menu: JPopupMenu) {
+        setAsInputMenuItem?.let { menu.remove(it) }
+        setAsInputSeparator?.let { menu.remove(it) }
+        setAsInputMenuItem = null
+        setAsInputSeparator = null
+
+        // Use selected text if available; fall back to entire pane content.
+        val text = (textPane.selectedText?.trim()?.takeIf { it.isNotBlank() }
+            ?: textPane.text?.trim()).takeIf { !it.isNullOrBlank() } ?: return
+
+        val sep = JSeparator()
+        val item = JMenuItem(localizationManager.getString("main_window_editor_context_menu.set_as_input")).apply {
+            addActionListener { onSetAsInput?.invoke(text) }
+        }
+        setAsInputSeparator = sep
+        setAsInputMenuItem = item
+        menu.add(sep)
+        menu.add(item)
     }
 
     private fun wordAtOffset(offset: Int): String {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
@@ -13,7 +13,7 @@ data class OutputTextState(
     val fallbackFontConfig: FontConfig,
     val isLoading: Boolean,
     val actionsState: TextActionsState,
-    val isEditable: Boolean = true
+    val isEditable: Boolean = false
 ) : UiState
 
 data class ExtraOutputState(
@@ -23,7 +23,7 @@ data class ExtraOutputState(
     val isLoading: Boolean,
     val isVisible: Boolean,
     val actionsState: TextActionsState,
-    val isEditable: Boolean = true,
+    val isEditable: Boolean = false,
 
     val activeType: ExtraOutputType = ExtraOutputType.None,
     val summaryLength: SummaryLength = SummaryLength.MEDIUM,


### PR DESCRIPTION
## Problem

Output panels (`OutputTextPanel`, `ExtraOutputPanel`) were accidentally editable (`isEditable = true`) but had `onTextChanged = {}` — so any edits the user made were silently discarded and the displayed text got corrupted with no feedback. With instant translate enabled this was especially confusing: typing in the output pane triggered no translation.

## Fix

**Read-only output (but still focusable)**
- `OutputTextState.isEditable` and `ExtraOutputState.isEditable` default to `false`
- Panels are now read-only but remain fully **focusable** — TAB navigation, text selection, Ctrl+A, Ctrl+C all work unchanged

**"Set as Input" right-click context menu**
- Added to both `OutputTextPanel` and `ExtraOutputPanel`
- Uses selected text if available; falls back to full pane content
- Dispatches `UpdateInputText` and refocuses the input field
- This is the correct implementation of the reporter's reverse-translation workflow: translate → right-click result → "Set as Input" → translate again

**Localization**
- `set_as_input` key added to `embedded_en.toml` and all 13 language files

Closes #54