### PR TITLE
feat(update-dialog): Markdown-rendered release notes + View on GitHub

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/CheckForUpdatesUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/CheckForUpdatesUseCase.kt
@@ -65,7 +65,8 @@ class CheckForUpdatesUseCase(
                                     newVersion = info.releaseName,
                                     currentVersion = currentVersion,
                                     releaseNotes = info.releaseNotes,
-                                    downloadUrl = info.downloadUrl
+                                    downloadUrl = info.downloadUrl,
+                                    releaseUrl = info.releaseUrl
                                 )
                             )
                         )

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainEvent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainEvent.kt
@@ -19,7 +19,8 @@ sealed interface MainEvent : UiEvent {
         val newVersion: String,
         val currentVersion: String,
         val releaseNotes: String,
-        val downloadUrl: String?
+        val downloadUrl: String?,
+        val releaseUrl: String? = null
     ) : MainEvent
 
     data class UpdateStatusBar(

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/notification/NotificationCode.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/notification/NotificationCode.kt
@@ -15,7 +15,8 @@ sealed class NotificationCode {
         val newVersion: String,
         val currentVersion: String,
         val releaseNotes: String,
-        val downloadUrl: String?
+        val downloadUrl: String?,
+        val releaseUrl: String? = null
     ) : NotificationCode()
 
     /** A service does not support the requested language. */

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/Updater.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/Updater.kt
@@ -105,7 +105,8 @@ class Updater(
                     versionTag   = response.tagName,
                     releaseName  = response.name,
                     releaseNotes = response.releaseNotes,
-                    downloadUrl  = response.assets.firstOrNull()?.downloadUrl
+                    downloadUrl  = response.assets.firstOrNull()?.downloadUrl,
+                    releaseUrl   = response.htmlUrl.takeIf { it.isNotBlank() }
                 )
             )
         } catch (e: io.ktor.serialization.JsonConvertException) {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/data/GitHubReleaseResponse.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/data/GitHubReleaseResponse.kt
@@ -15,6 +15,7 @@ internal data class GitHubReleaseResponse(
     @SerialName("tag_name") val tagName: String,
     @SerialName("name") val name: String,
     @SerialName("body") val releaseNotes: String,
+    @SerialName("html_url") val htmlUrl: String = "",
     @SerialName("assets") val assets: List<GitHubAsset> = emptyList()
 )
 

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/data/VersionInfo.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/data/VersionInfo.kt
@@ -14,12 +14,14 @@ package com.github.ahatem.qtranslate.core.updater.data
  *   in a changelog dialog.
  * @property downloadUrl Direct download URL for the release asset (e.g. the installer JAR),
  *   or `null` if the release has no attached assets.
+ * @property releaseUrl URL to the GitHub release page, suitable for a "View on GitHub" button.
  */
 data class VersionInfo(
     val versionTag: String,
     val releaseName: String,
     val releaseNotes: String,
-    val downloadUrl: String?
+    val downloadUrl: String?,
+    val releaseUrl: String? = null
 ) {
     /**
      * Returns `true` if this release is strictly newer than [currentVersion].

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -405,7 +405,8 @@ details_format = "Version %s is now available (you have %s). Would you like to u
 release_notes_label = "Release Notes:"
 skip_button = "Skip This Version"
 remind_later_button = "Remind Me Later"
-download_button = "Go to Download Page"
+download_button = "Download"
+view_on_github_button = "View on GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ jkeymaster = "1.3"
 
 jlayer = "1.0.3"
 jsoup = "1.22.2"
+commonmark = "0.24.0"
 jsvg = "2.0.0"
 miglayout = "11.4.3"
 swt = "3.133.0"
@@ -61,6 +62,7 @@ datastore-preferences = { module = "androidx.datastore:datastore-preferences-cor
 # Parsing
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 java-diff-utils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "diffUtils" }
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
 
 # Logging
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -438,7 +438,8 @@ details_format = "الإصدار %s متاح الآن (لديك %s). هل ترغ
 release_notes_label = "ملاحظات الإصدار:"
 skip_button = "تخطي هذا الإصدار"
 remind_later_button = "ذكرني لاحقًا"
-download_button = "الانتقال إلى صفحة التحميل"
+download_button = "تحميل"
+view_on_github_button = "عرض على GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -438,7 +438,8 @@ details_format = "ভার্সন %s এখন উপলব্ধ (আপন�
 release_notes_label = "রিলিজ নোটস:"
 skip_button = "এই ভার্সনটি এড়িয়ে যান"
 remind_later_button = "পরে মনে করিয়ে দিন"
-download_button = "ডাউনলোড পেজে যান"
+download_button = "ডাউনলোড"
+view_on_github_button = "GitHub-এ দেখুন"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -438,7 +438,8 @@ details_format = "Version %s ist verfügbar (installiert: %s). Möchten Sie aktu
 release_notes_label = "Versionshinweise:"
 skip_button = "Diese Version überspringen"
 remind_later_button = "Später erinnern"
-download_button = "Zur Download-Seite"
+download_button = "Herunterladen"
+view_on_github_button = "Auf GitHub ansehen"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -438,7 +438,8 @@ details_format = "Version %s is now available (you have %s). Would you like to u
 release_notes_label = "Release Notes:"
 skip_button = "Skip This Version"
 remind_later_button = "Remind Me Later"
-download_button = "Go to Download Page"
+download_button = "Download"
+view_on_github_button = "View on GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -438,7 +438,8 @@ details_format = "La versión %s ya está disponible (usted tiene la %s). ¿Dese
 release_notes_label = "Notas de la versión:"
 skip_button = "Omitir esta versión"
 remind_later_button = "Recordarme más tarde"
-download_button = "Ir a la página de descarga"
+download_button = "Descargar"
+view_on_github_button = "Ver en GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -438,7 +438,8 @@ details_format = "La version %s est disponible (vous avez la %s). Voulez-vous me
 release_notes_label = "Notes de version :"
 skip_button = "Ignorer cette version"
 remind_later_button = "Plus tard"
-download_button = "Aller à la page de téléchargement"
+download_button = "Télécharger"
+view_on_github_button = "Voir sur GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -438,7 +438,8 @@ details_format = "A(z) %s verzió most elérhető (jelenleg %s van). Szeretné f
 release_notes_label = "Kiadási megjegyzések:"
 skip_button = "Kihagyom ezt a verziót"
 remind_later_button = "Emlékeztessen később"
-download_button = "Ugrás a letöltési oldalra"
+download_button = "Letöltés"
+view_on_github_button = "Megtekintés GitHub-on"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -438,7 +438,8 @@ details_format = "È disponibile la versione %s (versione attuale %s).\nVuoi agg
 release_notes_label = "Note versione:"
 skip_button = "Salta questa versione"
 remind_later_button = "Ricordamelo più avanti"
-download_button = "Vai alla pagina download"
+download_button = "Scarica"
+view_on_github_button = "Visualizza su GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -438,7 +438,8 @@ details_format = "バージョン %s が利用可能です (現在 %s)。更新�
 release_notes_label = "リリースノート:"
 skip_button = "このバージョンをスキップ"
 remind_later_button = "後で通知"
-download_button = "ダウンロード ページへ"
+download_button = "ダウンロード"
+view_on_github_button = "GitHubで表示"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -438,7 +438,8 @@ details_format = "A versão %s está disponível (você tem a %s). Deseja atuali
 release_notes_label = "Notas da Versão:"
 skip_button = "Pular esta Versão"
 remind_later_button = "Lembrar mais tarde"
-download_button = "Ir para a Página de Download"
+download_button = "Baixar"
+view_on_github_button = "Ver no GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -438,7 +438,8 @@ details_format = "Версия %s уже доступна (у вас устан�
 release_notes_label = "Список изменений:"
 skip_button = "Пропустить эту версию"
 remind_later_button = "Напомнить позже"
-download_button = "Перейти к загрузке"
+download_button = "Скачать"
+view_on_github_button = "Открыть на GitHub"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -438,7 +438,8 @@ details_format = "Sürüm %s şu an indirilebilir (sizdeki sürüm: %s). Güncel
 release_notes_label = "Sürüm Notları:"
 skip_button = "Bu Sürümü Atla"
 remind_later_button = "Daha Sonra Hatırlat"
-download_button = "İndirme Sayfasına Git"
+download_button = "İndir"
+view_on_github_button = "GitHub'da Görüntüle"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -438,7 +438,8 @@ details_format = "版本 %s 现已发布 (当前版本为 %s)。是否要更新�
 release_notes_label = "更新日志："
 skip_button = "跳过此版本"
 remind_later_button = "稍后提醒我"
-download_button = "前往下载页面"
+download_button = "下载"
+view_on_github_button = "在 GitHub 上查看"
 
 # ===================================================================
 # CLOSE DIALOG

--- a/ui-swing/build.gradle.kts
+++ b/ui-swing/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
 
     implementation(libs.jnativehook)
     implementation(libs.jkeymaster)
+
+    implementation(libs.commonmark)
 }
 val compileKotlin: KotlinCompile by tasks
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -370,7 +370,8 @@ class MainAppFrame(
                             newVersion = event.newVersion,
                             currentVersion = event.currentVersion,
                             releaseNotes = event.releaseNotes,
-                            downloadUrl = event.downloadUrl
+                            downloadUrl = event.downloadUrl,
+                            releaseUrl = event.releaseUrl
                         ))
                     }
                 }
@@ -1143,7 +1144,9 @@ class MainAppFrame(
             skipButton = localizer.getString("update_dialog.skip_button"),
             remindLaterButton = localizer.getString("update_dialog.remind_later_button"),
             downloadButton = localizer.getString("update_dialog.download_button"),
+            viewOnGitHubButton = localizer.getString("update_dialog.view_on_github_button"),
             downloadUrl = code.downloadUrl,
+            releaseUrl = code.releaseUrl,
             onSkip = {},
             onRemindLater = {}
         )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/update/UpdateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/update/UpdateDialog.kt
@@ -1,67 +1,144 @@
 package com.github.ahatem.qtranslate.ui.swing.update
 
 import com.formdev.flatlaf.FlatClientProperties
+import com.formdev.flatlaf.util.UIScale
+import org.commonmark.node.Image
+import org.commonmark.node.Link
+import org.commonmark.node.Node
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.AttributeProvider
+import org.commonmark.renderer.html.HtmlRenderer
 import java.awt.BorderLayout
+import java.awt.Color
 import java.awt.Desktop
 import java.awt.Dimension
+import java.awt.Font
 import java.awt.Frame
-import javax.swing.*
+import java.net.URI
+import javax.swing.BorderFactory
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JButton
+import javax.swing.JDialog
+import javax.swing.JEditorPane
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.UIManager
+import javax.swing.event.HyperlinkEvent
 
-class UpdateDialog(owner: Frame) : JDialog(owner, true) {
+class UpdateDialog(owner: Frame) : JDialog(owner, false) {
 
-    private val headerLabel = JLabel()
-    private val detailsLabel = JLabel()
-    private val releaseNotesArea = JTextArea()
+    // ------------------------------------------------------------------ UI
+    private val versionBanner = JLabel().apply {
+        putClientProperty(FlatClientProperties.STYLE_CLASS, "h3")
+        horizontalAlignment = JLabel.CENTER
+    }
+    private val subLabel = JLabel().apply {
+        horizontalAlignment = JLabel.CENTER
+        foreground = UIManager.getColor("Label.disabledForeground")
+    }
+    private val notesPane = JEditorPane("text/html", "").apply {
+        isEditable = false
+        isOpaque = true
+        putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true)
+        font = UIManager.getFont("Label.font")
+        addHyperlinkListener { ev ->
+            if (ev.eventType == HyperlinkEvent.EventType.ACTIVATED) {
+                val uri = runCatching { ev.url?.toURI() }.getOrNull()
+                    ?: runCatching { URI(ev.description) }.getOrNull()
+                uri?.let { openUrl(it) }
+            }
+        }
+    }
     private val skipButton = JButton()
     private val remindLaterButton = JButton()
-    private val downloadButton = JButton()
+    private val downloadButton = JButton().apply {
+        putClientProperty("JButton.buttonType", "default")
+    }
+    private val viewOnGitHubButton = JButton()
 
+    // ------------------------------------------------------------------ state
     private var downloadUrl: String? = null
+    private var releaseUrl: String? = null
     private var onSkip: (() -> Unit)? = null
     private var onRemindLater: (() -> Unit)? = null
 
+    // ------------------------------------------------------------------ markdown parser (lazy, thread-local)
+    private val mdParser: Parser = Parser.builder().build()
+    private val mdRenderer: HtmlRenderer = HtmlRenderer.builder()
+        .attributeProviderFactory { _ ->
+            AttributeProvider { node: Node, _, attributes ->
+                when (node) {
+                    // Open links in system browser
+                    is Link -> attributes["target"] = "_blank"
+                    // Images: JEditorPane can't render remote images well —
+                    // replace the src with the destination URL (so HyperlinkListener fires),
+                    // keep the alt text visible, and set a border so it looks like a link.
+                    is Image -> {
+                        attributes["src"] = node.destination ?: ""
+                        val alt = attributes["alt"]?.takeIf { it.isNotBlank() }
+                            ?: node.title?.takeIf { it.isNotBlank() }
+                            ?: "image"
+                        attributes["alt"] = "[$alt]"
+                        attributes["title"] = node.destination ?: ""
+                    }
+                }
+            }
+        }
+        .build()
+
+    // ------------------------------------------------------------------ init
     init {
         defaultCloseOperation = HIDE_ON_CLOSE
         isResizable = true
 
-        headerLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "h3")
-
-        releaseNotesArea.apply {
-            isEditable = false
-            lineWrap = true
-            wrapStyleWord = true
-            font = UIManager.getFont("TextArea.font")
-            background = UIManager.getColor("Panel.background")
+        // Header panel
+        val headerPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+            border = BorderFactory.createEmptyBorder(8, 0, 12, 0)
+            add(versionBanner.also { it.alignmentX = JLabel.CENTER_ALIGNMENT })
+            add(Box.createVerticalStrut(4))
+            add(subLabel.also { it.alignmentX = JLabel.CENTER_ALIGNMENT })
         }
 
-        val notesScrollPane = JScrollPane(releaseNotesArea).apply {
-            preferredSize = Dimension(480, 200)
-            border = BorderFactory.createTitledBorder("")
+        // Notes scroll pane
+        val notesScroll = JScrollPane(notesPane).apply {
+            border = BorderFactory.createCompoundBorder(
+                BorderFactory.createTitledBorder(""),
+                BorderFactory.createEmptyBorder(4, 4, 4, 4)
+            )
+            preferredSize = Dimension(UIScale.scale(520), UIScale.scale(260))
         }
 
+        // Button row: [Skip] [Remind Later]  <glue>  [View on GitHub] [Download]
         val buttonPanel = JPanel().apply {
             layout = BoxLayout(this, BoxLayout.X_AXIS)
+            isOpaque = false
             add(skipButton)
-            add(Box.createHorizontalStrut(8))
+            add(Box.createHorizontalStrut(UIScale.scale(6)))
             add(remindLaterButton)
             add(Box.createHorizontalGlue())
+            add(viewOnGitHubButton)
+            add(Box.createHorizontalStrut(UIScale.scale(6)))
             add(downloadButton)
         }
-        downloadButton.putClientProperty("JButton.buttonType", "default")
 
-        val contentPanel = JPanel(BorderLayout(0, 12)).apply {
-            border = BorderFactory.createEmptyBorder(20, 24, 20, 24)
-            add(headerLabel, BorderLayout.NORTH)
-            add(JPanel(BorderLayout(0, 8)).apply {
-                isOpaque = false
-                add(detailsLabel, BorderLayout.NORTH)
-                add(notesScrollPane, BorderLayout.CENTER)
-            }, BorderLayout.CENTER)
+        // Root content
+        val content = JPanel(BorderLayout(0, UIScale.scale(10))).apply {
+            border = BorderFactory.createEmptyBorder(
+                UIScale.scale(20), UIScale.scale(24),
+                UIScale.scale(20), UIScale.scale(24)
+            )
+            add(headerPanel, BorderLayout.NORTH)
+            add(notesScroll, BorderLayout.CENTER)
             add(buttonPanel, BorderLayout.SOUTH)
         }
 
-        contentPane = contentPanel
+        contentPane = content
 
+        // Wire actions
         skipButton.addActionListener {
             onSkip?.invoke()
             isVisible = false
@@ -71,30 +148,104 @@ class UpdateDialog(owner: Frame) : JDialog(owner, true) {
             isVisible = false
         }
         downloadButton.addActionListener {
-            downloadUrl?.let { url ->
-                runCatching { Desktop.getDesktop().browse(java.net.URI(url)) }
-            }
+            downloadUrl?.let { openUrl(URI(it)) }
             isVisible = false
+        }
+        viewOnGitHubButton.addActionListener {
+            releaseUrl?.let { openUrl(URI(it)) }
         }
     }
 
+    // ------------------------------------------------------------------ public API
     fun show(state: UpdateDialogState) {
         title = state.title
-        headerLabel.text = state.header
-        detailsLabel.text = "<html>${state.details}</html>"
-        releaseNotesArea.text = state.releaseNotes
-        releaseNotesArea.caretPosition = 0
+        versionBanner.text = state.header
+        subLabel.text = "<html>${state.details}</html>"
+
+        notesPane.text = markdownToHtml(state.releaseNotes)
+        notesPane.caretPosition = 0
+
         skipButton.text = state.skipButton
         remindLaterButton.text = state.remindLaterButton
         downloadButton.text = state.downloadButton
-        downloadButton.isEnabled = state.downloadUrl != null
+        viewOnGitHubButton.text = state.viewOnGitHubButton
+
         downloadUrl = state.downloadUrl
+        releaseUrl = state.releaseUrl
         onSkip = state.onSkip
         onRemindLater = state.onRemindLater
 
-        pack()
-        minimumSize = Dimension(480, 360)
-        setLocationRelativeTo(owner)
+        downloadButton.isEnabled = state.downloadUrl != null
+        viewOnGitHubButton.isVisible = state.releaseUrl != null
+
+        if (!isVisible) {
+            pack()
+            minimumSize = Dimension(UIScale.scale(480), UIScale.scale(380))
+            setLocationRelativeTo(owner)
+        }
         isVisible = true
+        toFront()
+    }
+
+    // ------------------------------------------------------------------ Markdown → HTML
+    private fun markdownToHtml(markdown: String): String {
+        val document = mdParser.parse(markdown)
+        val body = mdRenderer.render(document)
+
+        val bg = colorToHex(UIManager.getColor("EditorPane.background") ?: Color.WHITE)
+        val fg = colorToHex(UIManager.getColor("EditorPane.foreground") ?: Color.BLACK)
+        val link = colorToHex(UIManager.getColor("Component.linkColor") ?: Color(0x2196F3))
+        val codeBg = colorToHex(
+            UIManager.getColor("TextField.disabledBackground")
+                ?: UIManager.getColor("Panel.background")
+                ?: Color.LIGHT_GRAY
+        )
+        val font = UIManager.getFont("Label.font") ?: Font("SansSerif", Font.PLAIN, 12)
+
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <style>
+              body {
+                font-family: '${font.family}', SansSerif;
+                font-size: ${font.size}pt;
+                color: $fg;
+                background-color: $bg;
+                margin: 0; padding: 4px 6px;
+                line-height: 1.5;
+              }
+              a { color: $link; }
+              code, pre {
+                font-family: monospace;
+                font-size: ${font.size - 1}pt;
+                background-color: $codeBg;
+                border-radius: 3px;
+                padding: 1px 4px;
+              }
+              pre { padding: 8px; overflow-x: auto; }
+              h1, h2, h3, h4 { margin-top: 12px; margin-bottom: 4px; }
+              ul, ol { padding-left: 20px; margin: 4px 0; }
+              li { margin-bottom: 2px; }
+              hr { border: none; border-top: 1px solid $codeBg; margin: 8px 0; }
+              blockquote { border-left: 3px solid $codeBg; margin: 8px 0 8px 12px; padding: 2px 8px; }
+              img { max-width: 100%; }
+              p { margin: 6px 0; }
+            </style>
+            </head>
+            <body>
+            $body
+            </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun colorToHex(c: Color): String =
+        "#%02x%02x%02x".format(c.red, c.green, c.blue)
+
+    private fun openUrl(uri: URI) {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            runCatching { Desktop.getDesktop().browse(uri) }
+        }
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/update/UpdateDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/update/UpdateDialogState.kt
@@ -8,7 +8,9 @@ data class UpdateDialogState(
     val skipButton: String,
     val remindLaterButton: String,
     val downloadButton: String,
+    val viewOnGitHubButton: String,
     val downloadUrl: String?,
+    val releaseUrl: String?,
     val onSkip: () -> Unit,
     val onRemindLater: () -> Unit,
 )


### PR DESCRIPTION
## Summary
- **Markdown rendering**: Replaces `JTextArea` (raw text) with `JEditorPane` rendering Markdown via `commonmark` (~220 KB JAR). Handles headers, lists, code blocks, links, images, blockquotes — everything GitHub release notes commonly use.
- **View on GitHub**: New secondary button that opens the GitHub release page directly in the browser. Threads `html_url` all the way from the GitHub API response through `VersionInfo` → `NotificationCode` → `UpdateDialogState`.
- **Non-modal dialog**: Changed `modal = true` → `false` so users can interact with the app while reading release notes.
- **Theme-aware CSS**: Background, foreground, link colour, and code block colour read from `UIManager` — adapts automatically to FlatLaf light/dark themes.
- **Images as clickable links**: Since `JEditorPane` can't fetch remote images, image nodes are rendered as a `[alt text]` hyperlink that opens in the browser.
- **Localisation**: `view_on_github_button` added in all 13 locales; `download_button` shortened to the concise form in all locales.
