### PR TITLE
fix: config deserialization safety, notification replay, TOML warning, multi-monitor popup

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDependencies.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDependencies.kt
@@ -159,7 +159,7 @@ suspend fun buildDependencies(
 
     val localizationManager = LocalizationManager(
         appDataDirectory = appData,
-        parser           = LanguageTomlParser(),
+        parser           = LanguageTomlParser(logger = loggerFactory.getLogger("LanguageTomlParser")),
         logger           = loggerFactory.getLogger("LocalizationManager")
     )
 

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LanguageTomlParser.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LanguageTomlParser.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.core.localization
 
+import com.github.ahatem.qtranslate.api.core.Logger
 import java.time.LocalDate
 
 /**
@@ -16,8 +17,11 @@ import java.time.LocalDate
  *
  * ### Special sections
  * - `[meta]` entries are parsed into [LocalizedLanguageMeta] rather than the entries map
+ *
+ * @param logger Optional logger. When provided, a [Logger.warn] is emitted whenever the
+ *   `@reference` depth limit is hit (indicating a likely circular reference in a TOML file).
  */
-class LanguageTomlParser {
+class LanguageTomlParser(private val logger: Logger? = null) {
 
     private companion object {
         /** Maximum number of `@reference` hops before giving up, preventing infinite loops. */
@@ -87,6 +91,13 @@ class LanguageTomlParser {
         while (result.startsWith("@") && depth < MAX_REFERENCE_DEPTH) {
             result = entries[result.removePrefix("@")] ?: break
             depth++
+        }
+        if (depth >= MAX_REFERENCE_DEPTH && result.startsWith("@")) {
+            logger?.warn(
+                "TOML reference depth limit ($MAX_REFERENCE_DEPTH) reached while resolving '$value'. " +
+                "This usually indicates a circular reference in the localization file. " +
+                "Returning the unresolved reference as-is."
+            )
         }
         return result
     }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
@@ -1,0 +1,57 @@
+package com.github.ahatem.qtranslate.core.settings.data
+
+import com.github.ahatem.qtranslate.api.core.Logger
+
+/**
+ * Upgrades persisted [Configuration] objects from older schema versions to the current one.
+ *
+ * ### How to add a migration
+ * 1. Increment [CURRENT_VERSION] in [Configuration] (the `configVersion` field default).
+ * 2. Add a `when` branch here that transforms the old shape into the new one and bumps
+ *    `configVersion` to the next number.
+ * 3. The branch runs automatically on next app launch for any user on the old version.
+ *
+ * ### Invariant
+ * [migrate] is idempotent — running it on an already-current config returns it unchanged.
+ */
+object ConfigMigrator {
+
+    /** Must match the default value of [Configuration.configVersion]. */
+    private const val CURRENT_VERSION = 1
+
+    /**
+     * Applies all pending migrations to [config] in order and returns the result.
+     * If the config is already at [CURRENT_VERSION] it is returned as-is.
+     */
+    fun migrate(config: Configuration, logger: Logger): Configuration {
+        var current = config
+        while (current.configVersion < CURRENT_VERSION) {
+            val from = current.configVersion
+            current = applyMigration(current, logger)
+            // Guard against a buggy migration that forgets to bump the version.
+            if (current.configVersion == from) {
+                logger.warn("ConfigMigrator: migration from v$from did not advance configVersion — stopping to prevent an infinite loop")
+                break
+            }
+        }
+        return current
+    }
+
+    // -------------------------------------------------------------------------
+    // Private migration steps
+    // -------------------------------------------------------------------------
+
+    private fun applyMigration(config: Configuration, logger: Logger): Configuration =
+        when (config.configVersion) {
+            // v1 is the initial schema — nothing to migrate yet.
+            // Future example:
+            //   1 -> {
+            //       logger.info("ConfigMigrator: migrating v1 → v2")
+            //       config.copy(configVersion = 2, newField = computedDefault)
+            //   }
+            else -> {
+                logger.warn("ConfigMigrator: unknown configVersion ${config.configVersion} — returning unchanged")
+                config
+            }
+        }
+}

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -206,23 +206,31 @@ data class TranslationRule(
 
 @Serializable
 data class Configuration(
+    // ---- Schema version — increment when a breaking change is made ----
+    /**
+     * Incremented whenever a breaking change requires a config migration.
+     * Old configs that predate this field deserialise as version 1 (the default).
+     * The [ConfigMigrator] upgrades older versions to the current schema.
+     */
+    val configVersion: Int = 1,
+
     // ---- Presets & Services ----
-    val servicePresets: List<ServicePreset>,
-    val activeServicePresetId: String?,
-    val disabledServices: Set<String>,
+    val servicePresets: List<ServicePreset> = emptyList(),
+    val activeServicePresetId: String? = null,
+    val disabledServices: Set<String> = emptySet(),
 
     // ---- Hotkeys ----
     val hotkeys: List<HotkeyBinding> = HotkeyBinding.DEFAULTS,
 
     // ---- General Behaviour ----
-    val launchOnSystemStartup: Boolean,
-    val autoCheckForUpdates: Boolean,
-    val isGlobalHotkeysEnabled: Boolean,
-    val interfaceLanguage: String,
-    val isInstantTranslationEnabled: Boolean,
-    val isSpellCheckingEnabled: Boolean,
-    val extraOutputType: ExtraOutputType,
-    val extraOutputSource: ExtraOutputSource,
+    val launchOnSystemStartup: Boolean = false,
+    val autoCheckForUpdates: Boolean = true,
+    val isGlobalHotkeysEnabled: Boolean = true,
+    val interfaceLanguage: String = "en",
+    val isInstantTranslationEnabled: Boolean = false,
+    val isSpellCheckingEnabled: Boolean = true,
+    val extraOutputType: ExtraOutputType = ExtraOutputType.None,
+    val extraOutputSource: ExtraOutputSource = ExtraOutputSource.Output,
     val summaryLength: SummaryLength = SummaryLength.MEDIUM,
     val rewriteStyle: RewriteStyle = RewriteStyle.FORMAL,
 
@@ -247,8 +255,8 @@ data class Configuration(
     val closeButtonBehavior: CloseButtonBehavior = CloseButtonBehavior.ASK,
 
     // ---- History ----
-    val isHistoryEnabled: Boolean,
-    val clearHistoryOnExit: Boolean,
+    val isHistoryEnabled: Boolean = true,
+    val clearHistoryOnExit: Boolean = false,
 
     // ---- UI — Main Window ----
     val showDictionaryPanel: Boolean = false,
@@ -256,22 +264,22 @@ data class Configuration(
     val isDictionaryAutoPopupEnabled: Boolean = true,
     val mainWindowSize: Size? = null,
     val mainWindowPosition: Position? = null,
-    val uiFontConfig: FontConfig,
-    val uiScale: Int,
-    val themeId: String,
-    val editorFontConfig: FontConfig,
-    val editorFallbackFontConfig: FontConfig,
-    val useUnifiedTitleBar: Boolean,
-    val layoutPresetId: String,
-    val toolbarVisibility: ToolbarVisibility,
+    val uiFontConfig: FontConfig = FontConfig(name = "Rubik", size = 13),
+    val uiScale: Int = 100,
+    val themeId: String = "builtin:hiberbee_dark",
+    val editorFontConfig: FontConfig = FontConfig(name = "Rubik", size = 15),
+    val editorFallbackFontConfig: FontConfig = FontConfig(name = "Rubik", size = 15),
+    val useUnifiedTitleBar: Boolean = true,
+    val layoutPresetId: String = "classic",
+    val toolbarVisibility: ToolbarVisibility = ToolbarVisibility.DEFAULT,
 
     // ---- UI — Quick Panel (Popup) ----
-    val isPopupAutoSizeEnabled: Boolean,
-    val isPopupAutoPositionEnabled: Boolean,
-    val popupTransparencyPercentage: Int,
+    val isPopupAutoSizeEnabled: Boolean = true,
+    val isPopupAutoPositionEnabled: Boolean = true,
+    val popupTransparencyPercentage: Int = 5,
     val popupIdleTimeoutSeconds: Int = 3,
-    val popupLastKnownSize: Size,
-    val popupLastKnownPosition: Position,
+    val popupLastKnownSize: Size = Size(width = 450, height = 250),
+    val popupLastKnownPosition: Position = Position(x = 0, y = 0),
 
     // ---- UI — Quick Dictionary Popup ----
     val quickDictionaryLastKnownSize: Size = Size(width = 420, height = 400),

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/SettingsRepository.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/SettingsRepository.kt
@@ -62,7 +62,7 @@ class SettingsRepository(
         .map { preferences ->
             preferences[Keys.CONFIG_JSON]?.let { json ->
                 try {
-                    json.let { this.json.decodeFromString<Configuration>(it) }
+                    ConfigMigrator.migrate(this.json.decodeFromString<Configuration>(json), logger)
                 } catch (e: SerializationException) {
                     logger.error("Failed to deserialize configuration, using default", e)
                     Configuration.DEFAULT

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/notification/AppNotification.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/notification/AppNotification.kt
@@ -5,5 +5,7 @@ import com.github.ahatem.qtranslate.api.plugin.NotificationType
 data class AppNotification(
     val type: NotificationType,
     val code: NotificationCode,
-    val sourcePluginId: String? = null
+    val sourcePluginId: String? = null,
+    /** Wall-clock time when this notification was posted, used to discard stale replays. */
+    val timestamp: Long = System.currentTimeMillis()
 )

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/notification/NotificationBus.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/notification/NotificationBus.kt
@@ -1,13 +1,30 @@
 package com.github.ahatem.qtranslate.core.shared.notification
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.filter
 
 class NotificationBus {
     private val _notifications = MutableSharedFlow<AppNotification>(replay = 10, extraBufferCapacity = 5)
-    val notifications = _notifications.asSharedFlow()
+
+    /**
+     * Stream of application notifications.
+     *
+     * Replayed entries older than [REPLAY_FRESHNESS_MS] are automatically discarded so
+     * that subscribers who join after a UI rebuild (e.g. after a theme change) do not
+     * see stale notifications from previous sessions.
+     */
+    val notifications: Flow<AppNotification> = _notifications
+        .asSharedFlow()
+        .filter { System.currentTimeMillis() - it.timestamp < REPLAY_FRESHNESS_MS }
 
     suspend fun post(notification: AppNotification) {
         _notifications.emit(notification)
+    }
+
+    companion object {
+        /** Notifications older than this are silently dropped on replay. */
+        private const val REPLAY_FRESHNESS_MS = 5_000L
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -388,7 +388,10 @@ class QuickTranslateDialog(
             return
         }
 
-        val screenBounds = graphicsConfiguration.bounds
+        // Use the monitor where the mouse cursor currently lives, not where the dialog
+        // happens to be placed — prevents wrong-monitor bounds on multi-monitor setups.
+        val gc = MouseInfo.getPointerInfo()?.device?.defaultConfiguration ?: graphicsConfiguration
+        val screenBounds = gc.bounds
         val maxWidth = (screenBounds.width * MAX_WIDTH_SCALE).toInt()
         val maxHeight = (screenBounds.height * MAX_HEIGHT_SCALE).toInt()
 
@@ -425,7 +428,10 @@ class QuickTranslateDialog(
                 return
             }
 
-            val screenBounds = graphicsConfiguration.bounds
+            // Derive screen bounds from the monitor the mouse is on, not the dialog's current
+            // monitor — ensures correct clamping on multi-monitor setups (A-10).
+            val gc = MouseInfo.getPointerInfo()?.device?.defaultConfiguration ?: graphicsConfiguration
+            val screenBounds = gc.bounds
             val dialogWidth = width
             val dialogHeight = height
             val offsetX = 10


### PR DESCRIPTION
## What does this PR do?

Four bugs discovered during the full codebase audit, all in the medium-priority bucket.

### A-7 / F-1 · Configuration deserialization safety + migration scaffold

`Configuration` had 26 constructor parameters with no default values. If any of those keys were missing from a stored config JSON (upgrading from an older version, or a field being added in a new release), `kotlinx.serialization` threw `SerializationException`, the repository caught it, logged an error, and silently returned `Configuration.DEFAULT` — wiping **all** of the user's settings.

**Fix:**
- Every field now has an explicit `= <default>` matching the values in `Configuration.DEFAULT`, so partial configs deserialise correctly instead of crashing.
- Added `configVersion: Int = 1` — old files without this field default to version 1, providing a stable hook for future migrations.
- Introduced `ConfigMigrator` (currently a no-op for v1) wired into `SettingsRepository.configuration`. When a future field needs a computed default or a rename, a single `when` branch here upgrades configs in-place without touching user data.

### F-4 · NotificationBus stale-replay filter

`MutableSharedFlow(replay = 10)` buffers the last 10 notifications so late subscribers catch up. The problem: when the UI is rebuilt (e.g. a theme change re-initialises frames), the new subscriber receives all 10 replayed entries regardless of age — users see old "Translation failed", "Update available", etc. notifications re-appear.

**Fix:**
- Added `val timestamp: Long = System.currentTimeMillis()` to `AppNotification`.
- `NotificationBus.notifications` now applies a `.filter { age < 5 s }` on the shared flow before exposing it. Replays older than 5 seconds are silently discarded.

### F-5 · LanguageTomlParser silent depth-limit hit

When a TOML file contains a circular `@reference` chain (e.g. `a = @b` and `b = @a`), `resolveReference()` bails out at `MAX_REFERENCE_DEPTH = 10` and returns the unresolved `@key` string — silently. Translators authoring language files get no feedback about the broken reference.

**Fix:**
- Added an optional `Logger?` parameter to `LanguageTomlParser` (default `null` — no call sites break).
- After the resolution loop, if the depth limit was the reason for stopping (result still starts with `@`), a `WARN` is logged with the original value and an explanation.
- `AppDependencies` now passes a dedicated logger instance (`"LanguageTomlParser"`).

### A-10 · Popup position/size wrong on secondary monitors

`applyPosition()` and `applySize()` in `QuickTranslateDialog` read `graphicsConfiguration.bounds` — the bounds of whichever monitor the dialog *currently lives on*. When the popup appears near the mouse on a secondary monitor while the dialog object happens to be associated with the primary, the screen bounds used for clamping are wrong, so the popup can be positioned partially or fully off-screen.

**Fix:**
- Both methods now derive `GraphicsConfiguration` from `MouseInfo.getPointerInfo()?.device?.defaultConfiguration`, falling back to `this.graphicsConfiguration` only if the pointer info is unavailable.
- This ensures size caps and position clamping always use the monitor where the mouse (and therefore the popup) actually appears.

## Related issues

A-7, F-1, F-4, F-5, A-10 from the post-audit roadmap.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No visual changes — all fixes are in data/logic layers.