### PR TITLE
feat(settings): plugin annotation system v2 — groups, SLIDER, showIf, inline validation

### DIFF
--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/settings/SettingType.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/settings/SettingType.kt
@@ -1,7 +1,7 @@
 package com.github.ahatem.qtranslate.api.settings
 
 /**
- * Defines the type of UI control to be rendered for a @Setting.
+ * Defines the type of UI control to be rendered for a [@Setting][Setting].
  */
 enum class SettingType {
     /** A single-line text input field. */
@@ -10,10 +10,16 @@ enum class SettingType {
     /** A single-line text input field that masks its content. */
     PASSWORD,
 
-    /** A multi-line text input area. */
+    /** A multi-line text input area. Respect [Setting.rows] for preferred height. */
     TEXTAREA,
 
-    /** A numerical input, typically a spinner or formatted field. */
+    /**
+     * A numerical spinner. The core auto-detects whether to use an integer or
+     * floating-point spinner based on the field's Kotlin type (`Int`/`Long` → integer;
+     * `Double`/`Float` → decimal).
+     *
+     * Constrain the range with [Setting.minValue], [Setting.maxValue], and [Setting.step].
+     */
     NUMBER,
 
     /** A checkbox for true/false values. */
@@ -26,5 +32,28 @@ enum class SettingType {
     FILE_PATH,
 
     /** A component for selecting a directory path. */
-    DIRECTORY_PATH
+    DIRECTORY_PATH,
+
+    /**
+     * A horizontal slider for bounded numeric ranges.
+     *
+     * **Requires** [Setting.minValue] and [Setting.maxValue] — falls back to [NUMBER] if
+     * either bound is missing. Use [Setting.step] to control tick granularity (default 0.01).
+     *
+     * Best suited for float fields (e.g. temperature 0.0–2.0). For integer sliders, use
+     * [NUMBER] with `minValue`/`maxValue` set, which renders as a bounded spinner.
+     */
+    SLIDER,
+
+    /**
+     * The plugin provides a full `JComponent` via a no-argument factory method on the
+     * settings class. The method name is specified in [Setting.actionMethod].
+     *
+     * Factory method signature: `fun createSettingPanel(): javax.swing.JComponent`
+     *
+     * This is the **last-resort escape hatch** for inputs that cannot be expressed with
+     * any other [SettingType]. Prefer standard types whenever possible — they get
+     * inline validation, group support, and conditional visibility for free.
+     */
+    CUSTOM_PANEL
 }

--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/settings/Settings.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/settings/Settings.kt
@@ -16,22 +16,22 @@ package com.github.ahatem.qtranslate.api.settings
  * to the backing field:
  *
  * ```kotlin
+ * @SettingGroups(
+ *     SettingGroup(key = "auth", title = "Authentication", order = 10),
+ *     SettingGroup(key = "advanced", title = "Advanced", order = 20, collapsible = true)
+ * )
  * data class MyPluginSettings(
- *     @field:Setting(
- *         label = "API Key",
- *         description = "Your personal API key.",
- *         type = SettingType.PASSWORD,
- *         isRequired = true,
- *         order = 1
- *     )
+ *     @field:Setting(label = "API Key", type = SettingType.PASSWORD, isRequired = true,
+ *                    group = "auth", order = 10)
  *     var apiKey: String = "",
  *
- *     @field:Setting(
- *         label = "Enable cache",
- *         type = SettingType.BOOLEAN,
- *         defaultValue = "true",
- *         order = 2
- *     )
+ *     @field:Setting(label = "Temperature", type = SettingType.SLIDER,
+ *                    group = "advanced", order = 10,
+ *                    minValue = 0.0, maxValue = 2.0, step = 0.05, defaultValue = "0.3")
+ *     var temperature: Double = 0.3,
+ *
+ *     @field:Setting(label = "Enable cache", type = SettingType.BOOLEAN,
+ *                    group = "advanced", order = 20, defaultValue = "true")
  *     var cacheEnabled: Boolean = true
  * ) : PluginSettings.Configurable()
  * ```
@@ -39,6 +39,10 @@ package com.github.ahatem.qtranslate.api.settings
  * ### Field order
  * Fields are sorted by [order] (ascending) before rendering. Use gaps (e.g. 10, 20, 30)
  * to leave room for future fields without renumbering existing ones.
+ *
+ * ### Backward compatibility
+ * All parameters added after the initial release have default values — existing `@Setting`
+ * usages without those parameters compile unchanged.
  */
 @Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
@@ -46,7 +50,7 @@ annotation class Setting(
     /** The human-readable label displayed next to the UI component. */
     val label: String,
 
-    /** Optional help text displayed as a tooltip or sub-label to the user. */
+    /** Optional help text displayed as a sub-label below the component. */
     val description: String = "",
 
     /** The type of UI component to render for this field. */
@@ -59,8 +63,8 @@ annotation class Setting(
     val order: Int = 0,
 
     /**
-     * If `true`, the core will visually mark this field as required and may prevent
-     * saving if the field is empty or unchanged from its default.
+     * If `true`, the core will visually mark this field as required and prevent saving
+     * if the field is empty or unchanged from its default.
      */
     val isRequired: Boolean = false,
 
@@ -84,5 +88,205 @@ annotation class Setting(
      * Used by the core to detect whether the user has changed a field and to populate
      * the field on first render if no stored value exists.
      */
-    val defaultValue: String = ""
+    val defaultValue: String = "",
+
+    // -------------------------------------------------------------------------
+    // Grouping
+    // -------------------------------------------------------------------------
+
+    /**
+     * The key of the [@SettingGroup][SettingGroup] this field belongs to.
+     * Empty string means the field is ungrouped and rendered at the top of the form.
+     */
+    val group: String = "",
+
+    // -------------------------------------------------------------------------
+    // Conditional visibility
+    // -------------------------------------------------------------------------
+
+    /**
+     * Makes this field visible only when another field has a specific value.
+     * Format: `"propertyName=value"` — the field is shown only when the referenced
+     * property's current value equals the given string.
+     *
+     * Example: `showIf = "useCustomEndpoint=true"` hides the field unless
+     * `useCustomEndpoint` is set to `"true"`.
+     *
+     * Empty string means the field is always visible.
+     */
+    val showIf: String = "",
+
+    // -------------------------------------------------------------------------
+    // Numeric constraints  (NUMBER and SLIDER types)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Minimum allowed value for [SettingType.NUMBER] and [SettingType.SLIDER].
+     * [Double.NaN] means no minimum is enforced.
+     */
+    val minValue: Double = Double.NaN,
+
+    /**
+     * Maximum allowed value for [SettingType.NUMBER] and [SettingType.SLIDER].
+     * [Double.NaN] means no maximum is enforced.
+     * **Required** for [SettingType.SLIDER] — a slider without bounds falls back to NUMBER.
+     */
+    val maxValue: Double = Double.NaN,
+
+    /**
+     * Step increment for [SettingType.NUMBER] and [SettingType.SLIDER].
+     * [Double.NaN] means the default step is used (1.0 for NUMBER, 0.01 for SLIDER).
+     */
+    val step: Double = Double.NaN,
+
+    // -------------------------------------------------------------------------
+    // Text constraints  (TEXT, PASSWORD, TEXTAREA types)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Maximum number of characters allowed in [SettingType.TEXT], [SettingType.PASSWORD],
+     * or [SettingType.TEXTAREA] fields.
+     *
+     * `0` means no limit. When set, a character counter `"n / max"` is shown below the
+     * field and the counter turns red when the limit is reached.
+     */
+    val maxLength: Int = 0,
+
+    // -------------------------------------------------------------------------
+    // Textarea-specific
+    // -------------------------------------------------------------------------
+
+    /**
+     * Preferred visible row count for [SettingType.TEXTAREA] fields.
+     * Defaults to 3.
+     */
+    val rows: Int = 3,
+
+    // -------------------------------------------------------------------------
+    // File path  (FILE_PATH type)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Comma-separated file extensions (without dots) used to filter the file chooser for
+     * [SettingType.FILE_PATH] fields. Example: `"json,yaml,toml"`.
+     * Empty string means all files are shown.
+     */
+    val fileExtensions: String = "",
+
+    /**
+     * When `true`, the file chooser allows selecting multiple files for
+     * [SettingType.FILE_PATH] fields. The selected paths are stored as a
+     * semicolon-separated string.
+     */
+    val allowMultiple: Boolean = false,
+
+    // -------------------------------------------------------------------------
+    // Inline action button
+    // -------------------------------------------------------------------------
+
+    /**
+     * Name of a no-argument suspend method on the [com.github.ahatem.qtranslate.api.plugin.PluginSettings.Configurable]
+     * class to invoke when an action button is clicked next to this field.
+     *
+     * Method signature must be: `suspend fun methodName(): String?`
+     * A non-null return value is shown as an informational message to the user.
+     * Empty string means no action button is shown.
+     */
+    val actionMethod: String = "",
+
+    /**
+     * Label for the action button shown next to this field.
+     * Defaults to `"Run"` when [actionMethod] is non-empty and this is blank.
+     */
+    val actionLabel: String = ""
+)
+
+// =============================================================================
+// Group annotations — organize fields into named sections
+// =============================================================================
+
+/**
+ * Declares a named section in the plugin settings panel.
+ *
+ * Apply multiple groups to a [com.github.ahatem.qtranslate.api.plugin.PluginSettings.Configurable]
+ * class using the [@SettingGroups][SettingGroups] container, then reference [key] in each
+ * [@Setting][Setting]'s `group` parameter:
+ *
+ * ```kotlin
+ * @SettingGroups(
+ *     SettingGroup(key = "connection", title = "Connection",   order = 10),
+ *     SettingGroup(key = "advanced",   title = "Advanced",     order = 20,
+ *                  collapsible = true, defaultCollapsed = true)
+ * )
+ * data class MySettings(...) : PluginSettings.Configurable()
+ * ```
+ *
+ * Fields whose `group` key does not match any [@SettingGroup][SettingGroup] are rendered
+ * at the top of the form without a section header.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SettingGroup(
+    /** Unique key referenced by [@Setting.group][Setting.group]. */
+    val key: String,
+    /** Human-readable section title rendered as a header above the group's fields. */
+    val title: String,
+    /** Optional subtitle shown beneath the section title. */
+    val description: String = "",
+    /** Display order relative to other groups (ascending). */
+    val order: Int = 0,
+    /** When `true`, the group can be collapsed by clicking its header. */
+    val collapsible: Boolean = false,
+    /** When `true`, the group starts collapsed on first render (requires [collapsible]). */
+    val defaultCollapsed: Boolean = false
+)
+
+/**
+ * Container for multiple [@SettingGroup][SettingGroup] annotations on a single class.
+ *
+ * ```kotlin
+ * @SettingGroups(
+ *     SettingGroup(key = "auth",     title = "Authentication", order = 10),
+ *     SettingGroup(key = "advanced", title = "Advanced",       order = 20)
+ * )
+ * data class MySettings(...) : PluginSettings.Configurable()
+ * ```
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SettingGroups(vararg val groups: SettingGroup)
+
+// =============================================================================
+// Plugin action — standalone buttons that invoke a method on the settings class
+// =============================================================================
+
+/**
+ * Marks a method on a [com.github.ahatem.qtranslate.api.plugin.PluginSettings.Configurable]
+ * class as an invokable action button in the settings panel.
+ *
+ * The annotated method must have the signature: `suspend fun methodName(): String?`
+ * A non-null return value is shown as an informational message to the user after execution.
+ * The method is called on the **live settings instance** (the values currently persisted —
+ * not the in-progress form values). Use this for actions like "Test Connection" or
+ * "Verify API Key" that operate on the saved configuration.
+ *
+ * ```kotlin
+ * @PluginAction(label = "Test Connection", group = "connection", tooltip = "Verifies the API key.")
+ * suspend fun testConnection(): String? {
+ *     // Use stored apiKey / baseUrl to make a test request
+ *     return "Connected successfully."
+ * }
+ * ```
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PluginAction(
+    /** Button label shown in the settings panel. */
+    val label: String,
+    /** Key of the [@SettingGroup][SettingGroup] this action appears in. Empty = top of form. */
+    val group: String = "",
+    /** Display order of this action button within its group's action strip. */
+    val order: Int = 0,
+    /** Tooltip shown on the button. */
+    val tooltip: String = ""
 )

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginManager.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginManager.kt
@@ -234,6 +234,19 @@ class PluginManager(
     }
 
     /**
+     * Returns the live settings instance for [pluginId], cast to
+     * [com.github.ahatem.qtranslate.api.plugin.PluginSettings.Configurable], or `null`
+     * if the plugin has no configurable settings.
+     *
+     * Used by the settings dialog to invoke `@PluginAction`-annotated methods on the live
+     * settings object.
+     */
+    suspend fun getPluginSettingsInstance(pluginId: String): com.github.ahatem.qtranslate.api.plugin.PluginSettings.Configurable? {
+        val container = registry.mutex.withLock { registry.get(pluginId) } ?: return null
+        return container.plugin.getSettings() as? com.github.ahatem.qtranslate.api.plugin.PluginSettings.Configurable
+    }
+
+    /**
      * Applies [settingsMap] to the plugin identified by [pluginId].
      * On success, rebuilds the plugin's service list and updates flows.
      */

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/settings/PluginSettingsManager.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/settings/PluginSettingsManager.kt
@@ -132,12 +132,18 @@ internal class PluginSettingsManager(
 
 /**
  * The UI-facing model for a plugin's settings panel.
- * Contains the class reference (for applying new settings) and the ordered schema list
- * (for rendering the panel).
+ *
+ * [schema] is the flat ordered list of all settings fields — kept for backward compatibility
+ * with any code that iterates all fields regardless of grouping.
+ *
+ * [groups] is the structured view used by the settings dialog to render named sections,
+ * action button strips, and conditional visibility. Always contains at least one group;
+ * plugins without `@SettingGroup` annotations get a single unnamed group that holds all fields.
  */
 data class PluginSettingsModel(
     val settingsClass: Class<*>,
-    val schema: List<SettingSchema>
+    val schema: List<SettingSchema>,
+    val groups: List<PluginSettingsGroup> = emptyList()
 ) {
     fun getSetting(propertyName: String): SettingSchema? =
         schema.find { it.propertyName == propertyName }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/settings/PluginSettingsSchemaBuilder.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/settings/PluginSettingsSchemaBuilder.kt
@@ -2,7 +2,10 @@ package com.github.ahatem.qtranslate.core.plugin.settings
 
 import com.github.ahatem.qtranslate.api.plugin.Plugin
 import com.github.ahatem.qtranslate.api.plugin.PluginSettings
+import com.github.ahatem.qtranslate.api.settings.PluginAction
 import com.github.ahatem.qtranslate.api.settings.Setting
+import com.github.ahatem.qtranslate.api.settings.SettingGroup
+import com.github.ahatem.qtranslate.api.settings.SettingGroups
 import com.github.ahatem.qtranslate.api.settings.SettingType
 import com.github.ahatem.qtranslate.core.plugin.storage.PluginKeyValueStore
 import com.github.ahatem.qtranslate.core.shared.logging.LoggerFactory
@@ -48,23 +51,26 @@ internal class PluginSettingsSchemaBuilder(
         val settingsClass = settingsInstance::class.java
 
         return try {
-            val schema = buildSchema(settingsClass, pluginId).sortedBy { it.order }
-            PluginSettingsModel(settingsClass, schema)
+            val schema  = buildSchema(settingsClass, pluginId).sortedBy { it.order }
+            val actions = readActions(settingsClass)
+            val groups  = buildGroups(settingsClass, schema, actions)
+            PluginSettingsModel(settingsClass, schema, groups)
         } catch (e: Exception) {
             logger.error("Failed to build settings schema for plugin '$pluginId': ${e.message}", e)
             null
         }
     }
 
-    private suspend fun buildSchema(settingsClass: Class<*>, pluginId: String): List<SettingSchema> {
-        // getDeclaredFields() sees @field:Setting annotations — memberProperties does not.
-        return settingsClass.declaredFields
-            .mapNotNull { field ->
-                field.isAccessible = true
-                val annotation = field.getAnnotation(Setting::class.java) ?: return@mapNotNull null
-                buildFieldSchema(field, annotation, pluginId)
-            }
-    }
+    // -------------------------------------------------------------------------
+    // Field schema construction
+    // -------------------------------------------------------------------------
+
+    private suspend fun buildSchema(settingsClass: Class<*>, pluginId: String): List<SettingSchema> =
+        settingsClass.declaredFields.mapNotNull { field ->
+            field.isAccessible = true
+            val annotation = field.getAnnotation(Setting::class.java) ?: return@mapNotNull null
+            buildFieldSchema(field, annotation, pluginId)
+        }
 
     private suspend fun buildFieldSchema(
         field: Field,
@@ -73,18 +79,41 @@ internal class PluginSettingsSchemaBuilder(
     ): SettingSchema? {
         val currentValue = pluginKeyValueStore.getValue(pluginId, field.name)
             ?: annotation.defaultValue.takeIf { it.isNotBlank() }
-            ?: ""   // Empty string — field will show blank, user must fill if isRequired
+            ?: ""
+
+        val showIf = if (annotation.showIf.isBlank()) null else {
+            val parts = annotation.showIf.split("=", limit = 2)
+            if (parts.size == 2) ShowIfRule(parts[0].trim(), parts[1].trim())
+            else {
+                logger.warn("Invalid showIf format on field '${field.name}': '${annotation.showIf}'. Expected 'propertyName=value'.")
+                null
+            }
+        }
+
+        val fileExtensions = if (annotation.fileExtensions.isBlank()) emptyList()
+            else annotation.fileExtensions.split(',').map { it.trim() }.filter { it.isNotBlank() }
 
         val args = SettingArgs(
-            propertyName = field.name,
-            label = annotation.label,
-            description = annotation.description,
-            order = annotation.order,
-            required = annotation.isRequired,
-            currentValue = currentValue,
-            defaultValue = annotation.defaultValue,
-            validation = annotation.validation,
-            options = annotation.options
+            propertyName   = field.name,
+            label          = annotation.label,
+            description    = annotation.description,
+            order          = annotation.order,
+            required       = annotation.isRequired,
+            currentValue   = currentValue,
+            defaultValue   = annotation.defaultValue,
+            validation     = annotation.validation,
+            options        = annotation.options,
+            group          = annotation.group,
+            showIf         = showIf,
+            minValue       = annotation.minValue.takeUnless { it.isNaN() },
+            maxValue       = annotation.maxValue.takeUnless { it.isNaN() },
+            step           = annotation.step.takeUnless { it.isNaN() },
+            maxLength      = annotation.maxLength,
+            rows           = annotation.rows,
+            fileExtensions = fileExtensions,
+            allowMultiple  = annotation.allowMultiple,
+            actionMethod   = annotation.actionMethod,
+            actionLabel    = annotation.actionLabel
         )
 
         return try {
@@ -97,6 +126,11 @@ internal class PluginSettingsSchemaBuilder(
                 SettingType.DROPDOWN       -> buildDropdownSetting(args)
                 SettingType.FILE_PATH      -> buildFilePathSetting(args)
                 SettingType.DIRECTORY_PATH -> buildDirectoryPathSetting(args)
+                SettingType.SLIDER         -> buildSliderSetting(args).also {
+                    if (it is NumberSetting)
+                        logger.warn("Field '${field.name}' uses SLIDER but is missing minValue/maxValue — falling back to NUMBER spinner.")
+                }
+                SettingType.CUSTOM_PANEL   -> buildCustomPanelSetting(args)
             }
         } catch (e: Exception) {
             logger.error("Failed to create schema for field '${field.name}': ${e.message}")
@@ -113,19 +147,99 @@ internal class PluginSettingsSchemaBuilder(
         }
 
     // -------------------------------------------------------------------------
+    // @PluginAction method scanning
+    // -------------------------------------------------------------------------
+
+    private fun readActions(settingsClass: Class<*>): List<PluginActionSchema> =
+        settingsClass.declaredMethods.mapNotNull { method ->
+            val ann = method.getAnnotation(PluginAction::class.java) ?: return@mapNotNull null
+            PluginActionSchema(
+                methodName = method.name,
+                label      = ann.label,
+                tooltip    = ann.tooltip,
+                order      = ann.order,
+                group      = ann.group
+            )
+        }
+
+    // -------------------------------------------------------------------------
+    // Group construction from @SettingGroup / @SettingGroups class annotations
+    // -------------------------------------------------------------------------
+
+    private fun readGroupAnnotations(settingsClass: Class<*>): List<SettingGroup> {
+        // @SettingGroups container (multiple groups)
+        val container = settingsClass.getAnnotation(SettingGroups::class.java)
+        if (container != null) return container.groups.toList()
+
+        // Single @SettingGroup
+        val single = settingsClass.getAnnotation(SettingGroup::class.java)
+        if (single != null) return listOf(single)
+
+        return emptyList()
+    }
+
+    private fun buildGroups(
+        settingsClass: Class<*>,
+        schema: List<SettingSchema>,
+        actions: List<PluginActionSchema>
+    ): List<PluginSettingsGroup> {
+        val groupDefs = readGroupAnnotations(settingsClass)
+
+        // Fields / actions with no group key (or orphaned keys) → ungrouped section
+        val knownKeys      = groupDefs.map { it.key }.toSet()
+        val ungroupedFields  = schema.filter { it.group.isEmpty() || it.group !in knownKeys }
+            .sortedBy { it.order }
+        val ungroupedActions = actions.filter { it.group.isEmpty() || it.group !in knownKeys }
+            .sortedBy { it.order }
+
+        val result = mutableListOf<PluginSettingsGroup>()
+
+        // Ungrouped fields always come first, with no header
+        if (ungroupedFields.isNotEmpty() || ungroupedActions.isNotEmpty()) {
+            result += PluginSettingsGroup(
+                key = "", title = "",
+                fields = ungroupedFields, actions = ungroupedActions
+            )
+        }
+
+        // Named groups in declared order
+        groupDefs.sortedBy { it.order }.forEach { def ->
+            val fields  = schema.filter { it.group == def.key }.sortedBy { it.order }
+            val grpActs = actions.filter { it.group == def.key }.sortedBy { it.order }
+            result += PluginSettingsGroup(
+                key              = def.key,
+                title            = def.title,
+                description      = def.description,
+                order            = def.order,
+                collapsible      = def.collapsible,
+                defaultCollapsed = def.defaultCollapsed,
+                fields           = fields,
+                actions          = grpActs
+            )
+        }
+
+        // If there are no groups at all (no ungrouped + no named), return a single catch-all
+        if (result.isEmpty()) {
+            result += PluginSettingsGroup(key = "", title = "", fields = schema, actions = actions)
+        }
+
+        return result
+    }
+
+    // -------------------------------------------------------------------------
     // Value conversion — used by PluginSettingsManager when applying settings
     // -------------------------------------------------------------------------
 
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     internal fun convertValue(raw: String, field: Field): Any? = runCatching {
         when (field.type) {
-            String::class.java                              -> raw
-            Int::class.java, java.lang.Integer::class.java -> raw.toIntOrNull()
-            Boolean::class.java, java.lang.Boolean::class.java -> raw.toBooleanStrictOrNull()
-            Double::class.java, java.lang.Double::class.java   -> raw.toDoubleOrNull()
-            Float::class.java, java.lang.Float::class.java     -> raw.toFloatOrNull()
-            Long::class.java, java.lang.Long::class.java       -> raw.toLongOrNull()
-            Path::class.java                                -> Paths.get(raw)
+            String::class.java                                          -> raw
+            Int::class.java, java.lang.Integer::class.java             -> raw.toIntOrNull()
+            Boolean::class.java, java.lang.Boolean::class.java         -> raw.toBooleanStrictOrNull()
+            Double::class.java, java.lang.Double::class.java           -> raw.toDoubleOrNull()
+            Float::class.java, java.lang.Float::class.java             -> raw.toFloatOrNull()
+            Long::class.java, java.lang.Long::class.java               -> raw.toLongOrNull()
+            Path::class.java                                           -> Paths.get(raw)
             else -> null.also { logger.warn("Unsupported field type for conversion: ${field.type}") }
         }
     }.getOrElse {
@@ -135,6 +249,7 @@ internal class PluginSettingsSchemaBuilder(
 
     internal fun validate(value: String, annotation: Setting): Boolean {
         if (annotation.isRequired && value.isBlank()) return false
+        if (annotation.maxLength > 0 && value.length > annotation.maxLength) return false
         if (annotation.validation.isNotBlank() && !Regex(annotation.validation).matches(value)) return false
         if (annotation.type == SettingType.DROPDOWN && annotation.options.isNotBlank()) {
             val options = annotation.options.split(',').map { it.trim() }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/settings/SettingSchema.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/settings/SettingSchema.kt
@@ -1,11 +1,67 @@
 package com.github.ahatem.qtranslate.core.plugin.settings
 
 /**
+ * Rule used for conditional field visibility.
+ *
+ * A field that carries this rule is hidden unless the field identified by
+ * [propertyName] currently has exactly [requiredValue] as its string value.
+ */
+data class ShowIfRule(
+    /** Java field name of the controlling field. */
+    val propertyName: String,
+    /** The string value the controlling field must have for this field to be visible. */
+    val requiredValue: String
+)
+
+// =============================================================================
+// Schema for a standalone action button declared with @PluginAction
+// =============================================================================
+
+data class PluginActionSchema(
+    val methodName: String,
+    val label: String,
+    val tooltip: String,
+    val order: Int,
+    val group: String
+)
+
+// =============================================================================
+// Group — a named section that contains a subset of fields and actions
+// =============================================================================
+
+/**
+ * Represents a named section in the plugin settings panel.
+ * Built by [PluginSettingsSchemaBuilder] from [@SettingGroup][com.github.ahatem.qtranslate.api.settings.SettingGroup]
+ * annotations on the settings class.
+ *
+ * The model always contains at least one group. When no `@SettingGroup` annotations are
+ * present, a single unnamed group (key `""`, title `""`) holds all fields — the UI
+ * renders it without a section header, preserving the flat appearance of simple plugins.
+ */
+data class PluginSettingsGroup(
+    /** Matches the `key` of the `@SettingGroup` annotation. Empty = ungrouped fields. */
+    val key: String,
+    /** Section title rendered as a bold header. Empty = no header rendered. */
+    val title: String,
+    val description: String = "",
+    val order: Int = 0,
+    val collapsible: Boolean = false,
+    val defaultCollapsed: Boolean = false,
+    /** Fields belonging to this group, sorted by [SettingSchema.order]. */
+    val fields: List<SettingSchema>,
+    /** Standalone action buttons for this group, sorted by [PluginActionSchema.order]. */
+    val actions: List<PluginActionSchema> = emptyList()
+)
+
+// =============================================================================
+// Sealed field schema hierarchy
+// =============================================================================
+
+/**
  * Sealed hierarchy describing a single configurable field in a plugin's settings panel.
  *
  * Each subclass corresponds to a [com.github.ahatem.qtranslate.api.settings.SettingType]
- * and carries the additional metadata specific to that UI control type (e.g. `maxLength`
- * for text fields, `options` for dropdowns, `minValue`/`maxValue` for numbers).
+ * and carries the additional metadata specific to that UI control type.
  *
  * Instances are produced by [PluginSettingsSchemaBuilder] and consumed by the UI layer
  * to render the settings panel — the UI does a `when` match on the subclass to decide
@@ -22,6 +78,18 @@ sealed class SettingSchema {
     abstract val isRequired: Boolean
     abstract val currentValue: String
     abstract val defaultValue: String
+
+    /**
+     * Key of the [@SettingGroup][com.github.ahatem.qtranslate.api.settings.SettingGroup]
+     * this field belongs to. Empty string = ungrouped.
+     */
+    abstract val group: String
+
+    /**
+     * Conditional visibility rule. `null` means always visible.
+     * When set, the field is hidden unless its controlling field has the required value.
+     */
+    abstract val showIf: ShowIfRule?
 }
 
 // ---- Text-based ----
@@ -34,8 +102,10 @@ data class TextSetting(
     override val isRequired: Boolean,
     override val currentValue: String,
     override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
     val validation: String = "",
-    val maxLength: Int? = null
+    val maxLength: Int = 0
 ) : SettingSchema()
 
 data class PasswordSetting(
@@ -46,8 +116,10 @@ data class PasswordSetting(
     override val isRequired: Boolean,
     override val currentValue: String,
     override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
     val validation: String = "",
-    val maxLength: Int? = null
+    val maxLength: Int = 0
 ) : SettingSchema()
 
 data class TextAreaSetting(
@@ -58,9 +130,11 @@ data class TextAreaSetting(
     override val isRequired: Boolean,
     override val currentValue: String,
     override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
     val validation: String = "",
     val rows: Int = 3,
-    val maxLength: Int? = null
+    val maxLength: Int = 0
 ) : SettingSchema()
 
 // ---- Numeric ----
@@ -73,6 +147,8 @@ data class NumberSetting(
     override val isRequired: Boolean,
     override val currentValue: String,
     override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
     val minValue: Double? = null,
     val maxValue: Double? = null,
     val step: Double? = null
@@ -86,9 +162,32 @@ data class IntegerSetting(
     override val isRequired: Boolean,
     override val currentValue: String,
     override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
     val minValue: Int? = null,
     val maxValue: Int? = null,
     val step: Int? = 1
+) : SettingSchema()
+
+/**
+ * A bounded horizontal slider for float values.
+ *
+ * [minValue] and [maxValue] are always present — the builder validates this and falls
+ * back to [NumberSetting] if either is missing.
+ */
+data class SliderSetting(
+    override val propertyName: String,
+    override val label: String,
+    override val description: String,
+    override val order: Int,
+    override val isRequired: Boolean,
+    override val currentValue: String,
+    override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
+    val minValue: Double,
+    val maxValue: Double,
+    val step: Double = 0.01
 ) : SettingSchema()
 
 // ---- Boolean ----
@@ -100,7 +199,9 @@ data class BooleanSetting(
     override val order: Int,
     override val isRequired: Boolean,
     override val currentValue: String,
-    override val defaultValue: String
+    override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null
 ) : SettingSchema()
 
 // ---- Selection ----
@@ -113,6 +214,8 @@ data class DropdownSetting(
     override val isRequired: Boolean,
     override val currentValue: String,
     override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
     val options: List<String>
 ) : SettingSchema()
 
@@ -126,6 +229,8 @@ data class FilePathSetting(
     override val isRequired: Boolean,
     override val currentValue: String,
     override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
     val fileExtensions: List<String> = emptyList(),
     val allowMultiple: Boolean = false
 ) : SettingSchema()
@@ -137,12 +242,31 @@ data class DirectoryPathSetting(
     override val order: Int,
     override val isRequired: Boolean,
     override val currentValue: String,
-    override val defaultValue: String
+    override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null
 ) : SettingSchema()
 
-// -------------------------------------------------------------------------
+/**
+ * The plugin provides a full `JComponent` via a no-arg factory method.
+ * [factoryMethod] is the method name to invoke on the live settings instance.
+ */
+data class CustomPanelSetting(
+    override val propertyName: String,
+    override val label: String,
+    override val description: String,
+    override val order: Int,
+    override val isRequired: Boolean,
+    override val currentValue: String,
+    override val defaultValue: String,
+    override val group: String = "",
+    override val showIf: ShowIfRule? = null,
+    val factoryMethod: String
+) : SettingSchema()
+
+// =============================================================================
 // Internal factory helpers — used only by PluginSettingsSchemaBuilder
-// -------------------------------------------------------------------------
+// =============================================================================
 
 internal data class SettingArgs(
     val propertyName: String,
@@ -153,51 +277,92 @@ internal data class SettingArgs(
     val currentValue: String,
     val defaultValue: String,
     val validation: String,
-    val options: String
+    val options: String,
+    // New
+    val group: String = "",
+    val showIf: ShowIfRule? = null,
+    val minValue: Double? = null,
+    val maxValue: Double? = null,
+    val step: Double? = null,
+    val maxLength: Int = 0,
+    val rows: Int = 3,
+    val fileExtensions: List<String> = emptyList(),
+    val allowMultiple: Boolean = false,
+    val actionMethod: String = "",
+    val actionLabel: String = ""
 )
 
 internal fun buildTextSetting(a: SettingArgs) = TextSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue, a.validation
+    a.currentValue, a.defaultValue, a.group, a.showIf,
+    a.validation, a.maxLength
 )
 
 internal fun buildPasswordSetting(a: SettingArgs) = PasswordSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue, a.validation
+    a.currentValue, a.defaultValue, a.group, a.showIf,
+    a.validation, a.maxLength
 )
 
 internal fun buildTextAreaSetting(a: SettingArgs) = TextAreaSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue, a.validation
+    a.currentValue, a.defaultValue, a.group, a.showIf,
+    a.validation, a.rows, a.maxLength
 )
 
 internal fun buildIntegerSetting(a: SettingArgs) = IntegerSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue
+    a.currentValue, a.defaultValue, a.group, a.showIf,
+    minValue = a.minValue?.toInt(), maxValue = a.maxValue?.toInt(),
+    step = a.step?.toInt() ?: 1
 )
 
 internal fun buildNumberSetting(a: SettingArgs) = NumberSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue
+    a.currentValue, a.defaultValue, a.group, a.showIf,
+    a.minValue, a.maxValue, a.step
 )
+
+internal fun buildSliderSetting(a: SettingArgs): SettingSchema {
+    val min = a.minValue
+    val max = a.maxValue
+    return if (min == null || max == null) {
+        // Bounds are required — fall back to a plain number spinner
+        buildNumberSetting(a)
+    } else {
+        SliderSetting(
+            a.propertyName, a.label, a.description, a.order, a.required,
+            a.currentValue, a.defaultValue, a.group, a.showIf,
+            minValue = min, maxValue = max,
+            step = if (a.step != null && !a.step.isNaN()) a.step else 0.01
+        )
+    }
+}
 
 internal fun buildBooleanSetting(a: SettingArgs) = BooleanSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue
+    a.currentValue, a.defaultValue, a.group, a.showIf
 )
 
 internal fun buildDropdownSetting(a: SettingArgs) = DropdownSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue,
+    a.currentValue, a.defaultValue, a.group, a.showIf,
     a.options.split(',').map { it.trim() }.filter { it.isNotBlank() }
 )
 
 internal fun buildFilePathSetting(a: SettingArgs) = FilePathSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue
+    a.currentValue, a.defaultValue, a.group, a.showIf,
+    a.fileExtensions, a.allowMultiple
 )
 
 internal fun buildDirectoryPathSetting(a: SettingArgs) = DirectoryPathSetting(
     a.propertyName, a.label, a.description, a.order, a.required,
-    a.currentValue, a.defaultValue
+    a.currentValue, a.defaultValue, a.group, a.showIf
+)
+
+internal fun buildCustomPanelSetting(a: SettingArgs) = CustomPanelSetting(
+    a.propertyName, a.label, a.description, a.order, a.required,
+    a.currentValue, a.defaultValue, a.group, a.showIf,
+    factoryMethod = a.actionMethod
 )

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettings.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettings.kt
@@ -2,6 +2,8 @@ package com.github.ahatem.qtranslate.plugins.ai
 
 import com.github.ahatem.qtranslate.api.plugin.PluginSettings
 import com.github.ahatem.qtranslate.api.settings.Setting
+import com.github.ahatem.qtranslate.api.settings.SettingGroup
+import com.github.ahatem.qtranslate.api.settings.SettingGroups
 import com.github.ahatem.qtranslate.api.settings.SettingType
 
 /**
@@ -18,72 +20,98 @@ import com.github.ahatem.qtranslate.api.settings.SettingType
  *
  * Anthropic's native `/v1/messages` API is no longer supported directly; use
  * OpenRouter (`anthropic/claude-3-5-sonnet`) to access Anthropic models.
+ *
+ * Settings are organized into three groups visible in the plugin settings dialog:
+ * - **Endpoint** — base URL and API key
+ * - **Model** — model identifier
+ * - **Advanced** — temperature, max tokens, custom headers (collapsed by default)
  */
+@SettingGroups(
+    SettingGroup(key = "endpoint", title = "Endpoint",         order = 10),
+    SettingGroup(key = "model",    title = "Model",            order = 20),
+    SettingGroup(key = "advanced", title = "Advanced",         order = 30,
+                 collapsible = true, defaultCollapsed = true)
+)
 data class AISettings(
 
     @field:Setting(
-        label = "Base URL",
+        label       = "Base URL",
         description = "OpenAI-compatible endpoint. Default: OpenRouter — a single key gives access to 300+ models. " +
                 "You can also point this at OpenAI (https://api.openai.com/v1), " +
                 "Mistral (https://api.mistral.ai/v1), " +
                 "Gemini (https://generativelanguage.googleapis.com/v1beta/openai), " +
                 "local Ollama (http://localhost:11434/v1), or any compatible server.",
-        type = SettingType.TEXT,
+        type         = SettingType.TEXT,
         defaultValue = "https://openrouter.ai/api/v1",
-        order = 10
+        group        = "endpoint",
+        order        = 10
     )
     var baseUrl: String = "https://openrouter.ai/api/v1",
 
     @field:Setting(
-        label = "API Key",
+        label       = "API Key",
         description = "Your API key for the selected endpoint. " +
                 "Get an OpenRouter key at openrouter.ai/keys. " +
-                "For local Ollama leave this blank.",
-        type = SettingType.PASSWORD,
-        isRequired = true,
-        order = 20
+                "Leave blank for local Ollama.",
+        type        = SettingType.PASSWORD,
+        isRequired  = true,
+        group       = "endpoint",
+        order       = 20
     )
     var apiKey: String = "",
 
     @field:Setting(
-        label = "Model",
-        description = "Model identifier. OpenRouter examples: google/gemini-flash-1.5-8b · openai/gpt-4o · anthropic/claude-3-5-sonnet · mistralai/mistral-small. " +
-                "Direct provider examples: gpt-4o · gemini-2.5-flash · mistral-small-latest.",
-        type = SettingType.TEXT,
+        label       = "Model",
+        description = "Model identifier. OpenRouter examples: google/gemini-flash-1.5-8b · openai/gpt-4o · " +
+                "anthropic/claude-3-5-sonnet · mistralai/mistral-small. " +
+                "Direct provider examples: gpt-4o · gemini-2.5-flash · mistral-small-latest. " +
+                "Append :free to use a free-tier model on OpenRouter, e.g. google/gemini-flash-1.5-8b:free.",
+        type         = SettingType.TEXT,
         defaultValue = "google/gemini-flash-1.5-8b",
-        isRequired = true,
-        order = 30
+        isRequired   = true,
+        group        = "model",
+        order        = 10
     )
     var model: String = "google/gemini-flash-1.5-8b",
 
     @field:Setting(
-        label = "Temperature",
-        description = "Controls output randomness (0.0 = deterministic, 1.0 = creative). " +
-                "Recommended: 0.2 for translation and spell-check, 0.7 for summarization and rewriting.",
-        type = SettingType.NUMBER,
+        label       = "Temperature",
+        description = "Controls output randomness. 0.0 = deterministic, 2.0 = very creative. " +
+                "Recommended: 0.2 for translation/spell-check, 0.7 for summarization/rewriting.",
+        type         = SettingType.SLIDER,
         defaultValue = "0.3",
-        order = 40
+        minValue     = 0.0,
+        maxValue     = 2.0,
+        step         = 0.05,
+        group        = "advanced",
+        order        = 10
     )
     var temperature: Double = 0.3,
 
     @field:Setting(
-        label = "Max Tokens",
+        label       = "Max Tokens",
         description = "Maximum number of tokens the model may generate. " +
                 "Increase for very long texts; decrease to reduce cost.",
-        type = SettingType.NUMBER,
+        type         = SettingType.NUMBER,
         defaultValue = "4096",
-        order = 50
+        minValue     = 1.0,
+        maxValue     = 131072.0,
+        step         = 256.0,
+        group        = "advanced",
+        order        = 20
     )
     var maxTokens: Int = 4096,
 
     @field:Setting(
-        label = "Custom Headers (JSON)",
+        label       = "Custom Headers (JSON)",
         description = "Optional extra HTTP headers sent with every request, as a JSON object. " +
                 "The defaults below add OpenRouter site-attribution headers (harmless with other providers). " +
                 "Leave blank to send no extra headers.",
-        type = SettingType.TEXTAREA,
+        type         = SettingType.TEXTAREA,
         defaultValue = """{"HTTP-Referer": "https://github.com/ahatem/QTranslate", "X-Title": "QTranslate", "X-OpenRouter-Title": "QTranslate"}""",
-        order = 60
+        rows         = 4,
+        group        = "advanced",
+        order        = 30
     )
     var customHeaders: String = """{"HTTP-Referer": "https://github.com/ahatem/QTranslate", "X-Title": "QTranslate", "X-OpenRouter-Title": "QTranslate"}"""
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
@@ -280,9 +280,14 @@ class DynamicPluginSettingsDialog(
         block.add(Box.createVerticalStrut(4))
 
         // Input
+        // For multi-line / custom components the layout manager must determine their
+        // height freely — clamping their maximumSize here would collapse TextAreas to
+        // a single row and prevent CustomPanels from showing their content.
         comp.component.apply {
-            alignmentX  = Component.LEFT_ALIGNMENT
-            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height.coerceAtLeast(28))
+            alignmentX = Component.LEFT_ALIGNMENT
+            if (setting !is TextAreaSetting && setting !is CustomPanelSetting) {
+                maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height.coerceAtLeast(28))
+            }
         }
         block.add(comp.component)
 
@@ -376,11 +381,15 @@ class DynamicPluginSettingsDialog(
                     lineWrap = true; wrapStyleWord = true
                 }
                 attachTextValidation(area, setting)
-                val scroll = JScrollPane(area).apply {
-                    val h = (setting.rows * 20).coerceAtLeast(80)
-                    preferredSize = Dimension(0, h)
-                    maximumSize   = Dimension(Int.MAX_VALUE, h)
-                }
+                val scroll = JScrollPane(area)
+                // JTextArea with lineWrap=true reports getWidth()=0 before the first layout
+                // pass, so its getPreferredSize() height is unreliable (often 1 row or zero).
+                // Compute the target height directly from font metrics — this is reliable even
+                // before the component is added to a container.
+                val fm     = area.getFontMetrics(area.font)
+                val lineH  = fm.height + fm.leading
+                val targetH = (lineH * setting.rows + 8).coerceAtLeast(60)
+                scroll.preferredSize = Dimension(300, targetH)
                 SettingComponent(placeholder, scroll) { area.text }
             }
 
@@ -611,21 +620,22 @@ class DynamicPluginSettingsDialog(
     }
 
     // =========================================================================
-    // Hint text area (wraps long strings, styled like a label)
+    // Hint label (wraps long strings via HTML, styled like a muted label)
     // =========================================================================
 
-    private fun buildHintArea(text: String): JTextArea = JTextArea(text).apply {
-        isEditable    = false
-        isOpaque      = false
-        isFocusable   = false
-        lineWrap      = true
-        wrapStyleWord = true
-        border        = null
-        foreground    = UIManager.getColor("Label.disabledForeground")
-        font          = font.deriveFont(font.size - 1f)
-        alignmentX    = Component.LEFT_ALIGNMENT
-        // Prevent the text area from influencing the dialog's preferred width
-        minimumSize   = Dimension(0, 0)
+    private fun buildHintArea(text: String): JLabel {
+        // Escape HTML special characters so raw description text renders correctly.
+        val escaped = text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        return JLabel("<html>$escaped</html>").apply {
+            foreground = UIManager.getColor("Label.disabledForeground")
+            font       = font.deriveFont(font.size - 1f)
+            alignmentX = Component.LEFT_ALIGNMENT
+            // HTML JLabels reflow text when the layout manager sets their width,
+            // so they wrap correctly on dialog resize without collapsing to zero.
+        }
     }
 
     // =========================================================================

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
@@ -1,30 +1,44 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
+import com.github.ahatem.qtranslate.api.plugin.PluginSettings
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.plugin.settings.*
 import java.awt.*
+import java.awt.event.ItemEvent
 import java.io.File
 import javax.swing.*
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
 import javax.swing.filechooser.FileNameExtensionFilter
+import javax.swing.text.JTextComponent
+import kotlin.math.roundToInt
 
 /**
  * A dialog that builds its form dynamically from a [PluginSettingsModel] schema.
  *
  * ### Layout
- * Two-column grid: fixed-width label column (max 160 px) on the left, expanding
- * component column on the right. Components fill the available width — no fixed
- * character-count constructors are used so nothing overflows the dialog bounds.
+ * Fields are organized into named sections ([PluginSettingsGroup]). Each group renders
+ * a bold section header (if titled), an optional action button strip, and its fields.
+ * Plugins without `@SettingGroup` annotations render as a flat list with no headers.
  *
- * ### Validation
- * Required fields are marked with a red `*`. On save, empty required fields get
- * a red border applied inline — the user can see exactly which fields need attention
- * without reading an error message and mentally scanning back to find them.
+ * ### Features
+ * - **Inline validation** — red border + character counter update as the user types;
+ *   Save is disabled while any field is invalid.
+ * - **Conditional visibility** — fields with `showIf` rules are hidden/shown in real time
+ *   as the controlling field's value changes.
+ * - **Slider** — [SliderSetting] renders a horizontal JSlider with a live value label.
+ * - **Action buttons** — [PluginActionSchema] actions are rendered as buttons that invoke
+ *   methods on the live settings instance via reflection.
+ * - **Text wrapping** — description/hint text uses a non-editable JTextArea so long
+ *   strings wrap naturally when the dialog is resized.
  */
 class DynamicPluginSettingsDialog(
     owner: Window?,
     pluginName: String,
     private val localizationManager: LocalizationManager,
     private val settingsModel: PluginSettingsModel,
+    /** Live settings instance for @PluginAction invocation. May be null for plugins without actions. */
+    private val settingsInstance: PluginSettings.Configurable? = null,
     private val onSave: (Map<String, String>) -> Unit
 ) : JDialog(
     owner,
@@ -32,245 +46,620 @@ class DynamicPluginSettingsDialog(
     ModalityType.APPLICATION_MODAL
 ) {
 
-    private val components = mutableMapOf<String, SettingComponent>()
+    /** Holds the input component + its outer block (for showIf toggling) + value getter. */
+    private data class SettingComponent(
+        val fieldBlock: JPanel,
+        val component: JComponent,
+        val getValue: () -> String
+    )
+
+    private val components  = mutableMapOf<String, SettingComponent>()
+    private val saveButton  = JButton(localizationManager.getString("common.save"))
+    private var rowIndex    = 0
 
     init {
         layout = BorderLayout()
 
-        // ---- Form ----
-        // ScrollablePanel tells JScrollPane to match its width to the viewport width
-        // rather than its own preferred width. Without this, components like JTextField
-        // report a large preferred width that the scroll pane happily uses, making
-        // inputs overflow the dialog. With getScrollableTracksViewportWidth() = true,
-        // fill=HORIZONTAL in GridBagConstraints works as expected.
-        val formPanel = object : JPanel(GridBagLayout()), Scrollable {
-            override fun getPreferredScrollableViewportSize(): Dimension = preferredSize
-            override fun getScrollableUnitIncrement(r: Rectangle, o: Int, d: Int) = 16
-            override fun getScrollableBlockIncrement(r: Rectangle, o: Int, d: Int) = 64
-            override fun getScrollableTracksViewportWidth() = true   // ← the key line
-            override fun getScrollableTracksViewportHeight() = false
-        }.apply {
-            border = BorderFactory.createEmptyBorder(16, 16, 8, 16)
+        val formPanel = buildScrollableFormPanel()
+
+        settingsModel.groups.forEach { group ->
+            renderGroup(group, formPanel)
         }
 
-        // Single full-width column: label on top, input below, hint below that.
-        // Each setting occupies one row. This gives inputs the full dialog width
-        // regardless of label length, which is better for plugin settings that
-        // often have long labels like "Service Account JSON Path".
-        val rowConstraints = GridBagConstraints().apply {
-            gridx = 0
-            weightx = 1.0
-            fill = GridBagConstraints.HORIZONTAL
-            anchor = GridBagConstraints.FIRST_LINE_START
-        }
-
-        settingsModel.schema.forEachIndexed { index, setting ->
-            val comp = buildComponent(setting)
-            components[setting.propertyName] = comp
-
-            // Label: single JLabel with HTML for the required asterisk — no nested panels
-            val requiredSuffix = if (setting.isRequired) " <font color='red'>*</font>" else ""
-            val label = JLabel("<html><b>${setting.label}$requiredSuffix</b></html>").apply {
-                alignmentX = Component.LEFT_ALIGNMENT
-            }
-
-            // Ensure the input fills the full width and stays left-aligned
-            comp.component.apply {
-                alignmentX = Component.LEFT_ALIGNMENT
-                maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height.coerceAtLeast(28))
-            }
-
-            // Build the block: every child must have alignmentX = LEFT_ALIGNMENT
-            // so BoxLayout keeps them in a single column with no horizontal drift.
-            val block = JPanel().apply {
-                layout = BoxLayout(this, BoxLayout.Y_AXIS)
-                isOpaque = false
-                alignmentX = Component.LEFT_ALIGNMENT
-
-                add(label)
-                add(Box.createVerticalStrut(4))
-                add(comp.component)
-
-                if (setting.description.isNotBlank()) {
-                    add(Box.createVerticalStrut(3))
-                    add(JLabel("<html><i>${setting.description}</i></html>").apply {
-                        foreground = UIManager.getColor("Label.disabledForeground")
-                        font = font.deriveFont(font.size - 1f)
-                        alignmentX = Component.LEFT_ALIGNMENT
-                    })
-                }
-            }
-
-            rowConstraints.gridy = index
-            rowConstraints.insets = Insets(if (index == 0) 0 else 14, 0, 0, 0)
-            formPanel.add(block, rowConstraints.clone())
-        }
-
-        // Bottom glue
+        // Bottom glue so content stays at the top
         val glueConstraints = GridBagConstraints().apply {
-            gridx = 0; gridy = settingsModel.schema.size
+            gridx = 0; gridy = rowIndex
             weightx = 1.0; weighty = 1.0
             fill = GridBagConstraints.BOTH
         }
         formPanel.add(Box.createVerticalGlue(), glueConstraints)
 
-        // ---- Scroll wrapper ----
         val scroll = JScrollPane(formPanel).apply {
             border = null
-            verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
+            verticalScrollBarPolicy   = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
             horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
-            // Ensure the viewport width drives how wide components expand
             viewport.isOpaque = false
         }
 
-        // ---- Button bar ----
-        val buttonBar = JPanel(FlowLayout(FlowLayout.TRAILING, 8, 8)).apply {
-            border = BorderFactory.createMatteBorder(
-                1, 0, 0, 0, UIManager.getColor("Component.borderColor") ?: Color.GRAY
-            )
-            add(JButton(localizationManager.getString("common.save")).apply {
-                addActionListener { onSaveClicked() }; isDefaultCapable = true
-            })
-            add(JButton(localizationManager.getString("common.cancel")).apply { addActionListener { dispose() } })
-        }
+        val buttonBar = buildButtonBar()
 
         add(scroll, BorderLayout.CENTER)
         add(buttonBar, BorderLayout.SOUTH)
 
-        // Register Enter → Save, Escape → Cancel
-        // Find the save button by position (first button) rather than hardcoded text
-        rootPane.defaultButton = buttonBar.components.filterIsInstance<JButton>().firstOrNull()
+        // Keyboard shortcuts
+        rootPane.defaultButton = saveButton
         rootPane.registerKeyboardAction(
             { dispose() },
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_ESCAPE, 0),
             JComponent.WHEN_IN_FOCUSED_WINDOW
         )
 
+        // Apply initial showIf visibility
+        SwingUtilities.invokeLater { updateVisibility() }
+
         defaultCloseOperation = DISPOSE_ON_CLOSE
-        minimumSize = Dimension(520, 320)
-        preferredSize = Dimension(620, 480)
+        minimumSize   = Dimension(520, 320)
+        preferredSize = Dimension(640, 500)
         pack()
         setLocationRelativeTo(owner)
     }
 
-    // -------------------------------------------------------------------------
-    // Component factory
-    // -------------------------------------------------------------------------
+    // =========================================================================
+    // Form panel (scrollable, width-tracked)
+    // =========================================================================
 
-    private fun buildComponent(setting: SettingSchema): SettingComponent = when (setting) {
-        is TextSetting -> {
-            val f = JTextField(setting.currentValue)
-            SettingComponent(f) { f.text }
+    private fun buildScrollableFormPanel(): JPanel {
+        val panel = object : JPanel(GridBagLayout()), Scrollable {
+            override fun getPreferredScrollableViewportSize(): Dimension = preferredSize
+            override fun getScrollableUnitIncrement(r: Rectangle, o: Int, d: Int) = 16
+            override fun getScrollableBlockIncrement(r: Rectangle, o: Int, d: Int) = 64
+            override fun getScrollableTracksViewportWidth()  = true
+            override fun getScrollableTracksViewportHeight() = false
+        }.apply {
+            border = BorderFactory.createEmptyBorder(16, 16, 8, 16)
+        }
+        return panel
+    }
+
+    // =========================================================================
+    // Group rendering
+    // =========================================================================
+
+    private fun renderGroup(group: PluginSettingsGroup, panel: JPanel) {
+        // Section header (only for named groups)
+        if (group.title.isNotBlank()) {
+            addToPanel(panel, buildGroupHeader(group))
         }
 
-        is PasswordSetting -> {
-            val f = JPasswordField(setting.currentValue)
-            SettingComponent(f) { String(f.password) }
+        // Action button strip (standalone @PluginAction buttons)
+        if (group.actions.isNotEmpty()) {
+            addToPanel(panel, buildActionStrip(group.actions), topInset = if (group.title.isNotBlank()) 4 else 0)
         }
 
-        is TextAreaSetting -> {
-            val area = JTextArea(setting.currentValue, setting.rows, 0).apply {
-                lineWrap = true; wrapStyleWord = true
+        // Fields — detect consecutive "compact" pairs for side-by-side layout
+        val fields = group.fields
+        var i = 0
+        while (i < fields.size) {
+            val current = fields[i]
+            val next    = fields.getOrNull(i + 1)
+
+            if (isCompact(current) && next != null && isCompact(next)) {
+                // Place two compact fields side-by-side
+                addToPanel(panel, buildSideBySideRow(current, next))
+                i += 2
+            } else {
+                addToPanel(panel, buildFieldBlock(current))
+                i++
             }
-            // Give the scroll pane a sensible preferred height but let width fill
-            val scrollArea = JScrollPane(area).apply {
-                preferredSize = Dimension(0, (setting.rows * 20).coerceAtLeast(80))
-                maximumSize = Dimension(Int.MAX_VALUE, (setting.rows * 20).coerceAtLeast(80))
-            }
-            SettingComponent(scrollArea) { area.text }
+        }
+    }
+
+    /** Compact fields can be placed side-by-side to save vertical space. */
+    private fun isCompact(s: SettingSchema) = s is BooleanSetting || s is SliderSetting
+
+    private fun addToPanel(
+        panel: JPanel,
+        component: JComponent,
+        topInset: Int = -1
+    ) {
+        val inset = if (topInset >= 0) topInset else if (rowIndex == 0) 0 else 14
+        val c = GridBagConstraints().apply {
+            gridx   = 0; gridy = rowIndex
+            weightx = 1.0
+            fill    = GridBagConstraints.HORIZONTAL
+            anchor  = GridBagConstraints.FIRST_LINE_START
+            insets  = Insets(inset, 0, 0, 0)
+        }
+        panel.add(component, c)
+        rowIndex++
+    }
+
+    // =========================================================================
+    // Group header
+    // =========================================================================
+
+    private fun buildGroupHeader(group: PluginSettingsGroup): JPanel {
+        val panel = JPanel().apply {
+            layout    = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque  = false
+            alignmentX = Component.LEFT_ALIGNMENT
         }
 
-        is IntegerSetting -> {
-            val sp = JSpinner(
-                SpinnerNumberModel(
+        // Separator line + bold title (same style as SettingsPanel.addSeparator)
+        val titlePanel = JPanel(BorderLayout(8, 0)).apply {
+            isOpaque   = false
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+
+        val accent = JPanel().apply {
+            preferredSize = Dimension(3, 16)
+            minimumSize   = Dimension(3, 16)
+            background    = UIManager.getColor("Component.accentColor")
+                ?: UIManager.getColor("Button.default.background")
+                ?: Color(80, 120, 220)
+            isOpaque = true
+        }
+
+        val titleLabel = JLabel(group.title).apply {
+            font = font.deriveFont(Font.BOLD, font.size + 1f)
+        }
+
+        titlePanel.add(accent, BorderLayout.LINE_START)
+        titlePanel.add(titleLabel, BorderLayout.CENTER)
+        panel.add(titlePanel)
+
+        if (group.description.isNotBlank()) {
+            panel.add(Box.createVerticalStrut(3))
+            panel.add(buildHintArea(group.description))
+        }
+
+        return panel
+    }
+
+    // =========================================================================
+    // Action button strip
+    // =========================================================================
+
+    private fun buildActionStrip(actions: List<PluginActionSchema>): JPanel {
+        val strip = JPanel(FlowLayout(FlowLayout.LEADING, 6, 0)).apply {
+            isOpaque   = false
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+        actions.sortedBy { it.order }.forEach { action ->
+            val btn = JButton(action.label).apply {
+                if (action.tooltip.isNotBlank()) toolTipText = action.tooltip
+                addActionListener { invokeAction(action, this) }
+            }
+            strip.add(btn)
+        }
+        return strip
+    }
+
+    private fun invokeAction(action: PluginActionSchema, sourceButton: JButton) {
+        val instance = settingsInstance ?: return
+        sourceButton.isEnabled = false
+        object : SwingWorker<String?, Unit>() {
+            override fun doInBackground(): String? = runCatching {
+                val method = instance::class.java.getDeclaredMethod(action.methodName).apply {
+                    isAccessible = true
+                }
+                method.invoke(instance) as? String
+            }.getOrElse { e ->
+                "Error: ${e.cause?.message ?: e.message}"
+            }
+
+            override fun done() {
+                sourceButton.isEnabled = true
+                val result = runCatching { get() }.getOrNull()
+                if (result != null) {
+                    JOptionPane.showMessageDialog(
+                        this@DynamicPluginSettingsDialog,
+                        result, action.label, JOptionPane.INFORMATION_MESSAGE
+                    )
+                }
+            }
+        }.execute()
+    }
+
+    // =========================================================================
+    // Field block builders
+    // =========================================================================
+
+    private fun buildFieldBlock(setting: SettingSchema): JPanel {
+        val comp = buildComponent(setting)
+        components[setting.propertyName] = comp
+
+        val block = JPanel().apply {
+            layout     = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque   = false
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+
+        // Label row: bold name + optional required asterisk + optional inline action button
+        block.add(buildLabelRow(setting, comp))
+        block.add(Box.createVerticalStrut(4))
+
+        // Input
+        comp.component.apply {
+            alignmentX  = Component.LEFT_ALIGNMENT
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height.coerceAtLeast(28))
+        }
+        block.add(comp.component)
+
+        // Character counter (when maxLength is set)
+        val maxLength = maxLengthOf(setting)
+        if (maxLength > 0) {
+            val counter = buildCharCounter(comp, maxLength, setting)
+            block.add(Box.createVerticalStrut(2))
+            block.add(counter)
+        }
+
+        // Description / hint
+        if (setting.description.isNotBlank()) {
+            block.add(Box.createVerticalStrut(3))
+            block.add(buildHintArea(setting.description))
+        }
+
+        // Wrap in a JPanel so we can toggle visibility for showIf
+        val outer = JPanel(BorderLayout()).apply {
+            isOpaque   = false
+            alignmentX = Component.LEFT_ALIGNMENT
+            add(block, BorderLayout.CENTER)
+        }
+        // Update SettingComponent to carry the outer block reference
+        components[setting.propertyName] = comp.copy(fieldBlock = outer)
+
+        return outer
+    }
+
+    private fun buildLabelRow(setting: SettingSchema, comp: SettingComponent): JPanel {
+        val row = JPanel(BorderLayout(8, 0)).apply {
+            isOpaque   = false
+            alignmentX = Component.LEFT_ALIGNMENT
+            maximumSize = Dimension(Int.MAX_VALUE, 24)
+        }
+
+        val requiredSuffix = if (setting.isRequired) " <font color='red'>*</font>" else ""
+        val label = JLabel("<html><b>${setting.label}$requiredSuffix</b></html>").apply {
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+        row.add(label, BorderLayout.LINE_START)
+
+        // Inline action button (from Setting.actionMethod)
+        val actionMethod = actionMethodOf(setting)
+        val actionLabel  = actionLabelOf(setting)
+        if (actionMethod.isNotBlank() && settingsInstance != null) {
+            val actionSchema = PluginActionSchema(actionMethod, actionLabel.ifBlank { "Run" }, "", 0, "")
+            val btn = JButton(actionSchema.label).apply {
+                font = font.deriveFont(font.size - 1f)
+                addActionListener { invokeAction(actionSchema, this) }
+            }
+            row.add(btn, BorderLayout.LINE_END)
+        }
+
+        return row
+    }
+
+    private fun buildSideBySideRow(a: SettingSchema, b: SettingSchema): JPanel {
+        val row = JPanel(GridLayout(1, 2, 16, 0)).apply {
+            isOpaque   = false
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+        row.add(buildFieldBlock(a))
+        row.add(buildFieldBlock(b))
+        return row
+    }
+
+    // =========================================================================
+    // Component factory  (one per SettingSchema subclass)
+    // =========================================================================
+
+    private fun buildComponent(setting: SettingSchema): SettingComponent {
+        // Placeholder outer block — replaced after buildFieldBlock wraps it
+        val placeholder = JPanel()
+
+        return when (setting) {
+            is TextSetting -> {
+                val f = JTextField(setting.currentValue)
+                attachTextValidation(f, setting)
+                SettingComponent(placeholder, f) { f.text }
+            }
+
+            is PasswordSetting -> {
+                val f = JPasswordField(setting.currentValue)
+                attachTextValidation(f, setting)
+                SettingComponent(placeholder, f) { String(f.password) }
+            }
+
+            is TextAreaSetting -> {
+                val area = JTextArea(setting.currentValue, setting.rows, 0).apply {
+                    lineWrap = true; wrapStyleWord = true
+                }
+                attachTextValidation(area, setting)
+                val scroll = JScrollPane(area).apply {
+                    val h = (setting.rows * 20).coerceAtLeast(80)
+                    preferredSize = Dimension(0, h)
+                    maximumSize   = Dimension(Int.MAX_VALUE, h)
+                }
+                SettingComponent(placeholder, scroll) { area.text }
+            }
+
+            is IntegerSetting -> {
+                val model = SpinnerNumberModel(
                     setting.currentValue.toIntOrNull() ?: 0,
                     setting.minValue ?: Int.MIN_VALUE,
                     setting.maxValue ?: Int.MAX_VALUE,
                     setting.step ?: 1
                 )
-            )
-            SettingComponent(sp) { sp.value.toString() }
-        }
+                val sp = JSpinner(model)
+                sp.addChangeListener { onAnyFieldChanged() }
+                SettingComponent(placeholder, sp) { sp.value.toString() }
+            }
 
-        is NumberSetting -> {
-            val sp = JSpinner(
-                SpinnerNumberModel(
+            is NumberSetting -> {
+                val model = SpinnerNumberModel(
                     setting.currentValue.toDoubleOrNull() ?: 0.0,
                     setting.minValue ?: Double.MIN_VALUE,
                     setting.maxValue ?: Double.MAX_VALUE,
                     setting.step ?: 1.0
                 )
-            )
-            SettingComponent(sp) { sp.value.toString() }
-        }
-
-        is BooleanSetting -> {
-            val cb = JCheckBox("", setting.currentValue.toBooleanStrictOrNull() ?: false)
-            SettingComponent(cb) { cb.isSelected.toString() }
-        }
-
-        is DropdownSetting -> {
-            val cb = JComboBox(setting.options.toTypedArray()).apply {
-                selectedItem = setting.currentValue
-                // Remove the GridBag normalizer's fixed width — let it fill naturally
-                preferredSize = null
-                maximumSize = Dimension(Int.MAX_VALUE, preferredSize?.height ?: 28)
+                val sp = JSpinner(model)
+                sp.addChangeListener { onAnyFieldChanged() }
+                SettingComponent(placeholder, sp) { sp.value.toString() }
             }
-            SettingComponent(cb) { cb.selectedItem?.toString() ?: "" }
-        }
 
-        is FilePathSetting, is DirectoryPathSetting -> {
-            val isDir = setting is DirectoryPathSetting
-            val tf = JTextField(setting.currentValue)
-            val btn = JButton(localizationManager.getString("common.browse")).apply {
-                addActionListener {
-                    val chooser = JFileChooser().apply {
-                        fileSelectionMode = if (isDir) JFileChooser.DIRECTORIES_ONLY
-                        else JFileChooser.FILES_ONLY
-                        if (!isDir && setting is FilePathSetting && setting.fileExtensions.isNotEmpty())
-                            fileFilter = FileNameExtensionFilter(
-                                setting.fileExtensions.joinToString(", "),
-                                *setting.fileExtensions.toTypedArray()
-                            )
-                        if (tf.text.isNotBlank()) selectedFile = File(tf.text)
-                    }
-                    if (chooser.showOpenDialog(this@DynamicPluginSettingsDialog) == JFileChooser.APPROVE_OPTION)
-                        tf.text = chooser.selectedFile.absolutePath
+            is SliderSetting -> {
+                val scale  = if (setting.step > 0) (1.0 / setting.step).roundToInt().coerceAtLeast(1) else 100
+                val intMin = (setting.minValue * scale).roundToInt()
+                val intMax = (setting.maxValue * scale).roundToInt()
+                val intVal = ((setting.currentValue.toDoubleOrNull() ?: setting.minValue) * scale)
+                    .roundToInt().coerceIn(intMin, intMax)
+
+                val slider = JSlider(intMin, intMax, intVal).apply {
+                    paintTicks  = false
+                    paintLabels = false
                 }
+                val decimalPlaces = if (setting.step >= 1.0) 0 else {
+                    setting.step.toString().substringAfter('.').trimEnd('0').length.coerceAtLeast(1)
+                }
+                val fmt = "%.${decimalPlaces}f"
+                val valueLabel = JLabel(fmt.format(intVal.toDouble() / scale)).apply {
+                    preferredSize = Dimension(48, preferredSize.height)
+                    horizontalAlignment = SwingConstants.TRAILING
+                    font = font.deriveFont(Font.BOLD)
+                }
+                slider.addChangeListener {
+                    valueLabel.text = fmt.format(slider.value.toDouble() / scale)
+                    onAnyFieldChanged()
+                }
+                val row = JPanel(BorderLayout(8, 0)).apply {
+                    isOpaque = false
+                    add(slider, BorderLayout.CENTER)
+                    add(valueLabel, BorderLayout.LINE_END)
+                }
+                SettingComponent(placeholder, row) { (slider.value.toDouble() / scale).toString() }
             }
-            // Row panel: text field expands, Browse button stays fixed width
-            val row = JPanel(BorderLayout(6, 0)).apply {
-                isOpaque = false
-                add(tf, BorderLayout.CENTER)
-                add(btn, BorderLayout.LINE_END)
+
+            is BooleanSetting -> {
+                val cb = JCheckBox("", setting.currentValue.toBooleanStrictOrNull() ?: false)
+                cb.addItemListener { onAnyFieldChanged() }
+                SettingComponent(placeholder, cb) { cb.isSelected.toString() }
             }
-            SettingComponent(row) { tf.text }
+
+            is DropdownSetting -> {
+                val cb = JComboBox(setting.options.toTypedArray()).apply {
+                    selectedItem  = setting.currentValue
+                    preferredSize = null
+                    maximumSize   = Dimension(Int.MAX_VALUE, preferredSize?.height ?: 28)
+                    // Limit display width so combo doesn't bloat the dialog
+                    prototypeDisplayValue = "X".repeat(35)
+                }
+                cb.addItemListener { e ->
+                    if (e.stateChange == ItemEvent.SELECTED) onAnyFieldChanged()
+                }
+                SettingComponent(placeholder, cb) { cb.selectedItem?.toString() ?: "" }
+            }
+
+            is FilePathSetting, is DirectoryPathSetting -> {
+                val isDir = setting is DirectoryPathSetting
+                val tf  = JTextField(setting.currentValue)
+                attachTextValidation(tf, setting)
+                val btn = JButton(localizationManager.getString("common.browse")).apply {
+                    addActionListener {
+                        val chooser = JFileChooser().apply {
+                            fileSelectionMode = if (isDir) JFileChooser.DIRECTORIES_ONLY
+                                                else JFileChooser.FILES_ONLY
+                            if (!isDir && setting is FilePathSetting) {
+                                isMultiSelectionEnabled = setting.allowMultiple
+                                if (setting.fileExtensions.isNotEmpty())
+                                    fileFilter = FileNameExtensionFilter(
+                                        setting.fileExtensions.joinToString(", "),
+                                        *setting.fileExtensions.toTypedArray()
+                                    )
+                            }
+                            if (tf.text.isNotBlank()) selectedFile = File(tf.text)
+                        }
+                        if (chooser.showOpenDialog(this@DynamicPluginSettingsDialog) == JFileChooser.APPROVE_OPTION) {
+                            tf.text = if (!isDir && setting is FilePathSetting && setting.allowMultiple)
+                                chooser.selectedFiles.joinToString(";") { it.absolutePath }
+                            else
+                                chooser.selectedFile.absolutePath
+                        }
+                    }
+                }
+                val row = JPanel(BorderLayout(6, 0)).apply {
+                    isOpaque = false
+                    add(tf, BorderLayout.CENTER)
+                    add(btn, BorderLayout.LINE_END)
+                }
+                SettingComponent(placeholder, row) { tf.text }
+            }
+
+            is CustomPanelSetting -> {
+                val customComponent = runCatching {
+                    val instance = settingsInstance
+                        ?: error("settingsInstance required for CUSTOM_PANEL '${setting.factoryMethod}'")
+                    val method = instance::class.java.getDeclaredMethod(setting.factoryMethod)
+                        .apply { isAccessible = true }
+                    method.invoke(instance) as? JComponent
+                        ?: error("Factory method '${setting.factoryMethod}' returned null or non-JComponent")
+                }.getOrElse { e ->
+                    JLabel("<html><i>Custom panel unavailable: ${e.message}</i></html>").apply {
+                        foreground = UIManager.getColor("Actions.Red") ?: Color.RED
+                    }
+                }
+                SettingComponent(placeholder, customComponent) { "" }
+            }
         }
     }
 
-    // -------------------------------------------------------------------------
+    // =========================================================================
+    // Inline validation
+    // =========================================================================
+
+    private fun attachTextValidation(comp: JTextComponent, setting: SettingSchema) {
+        comp.document.addDocumentListener(object : DocumentListener {
+            override fun insertUpdate(e: DocumentEvent?)  = onAnyFieldChanged()
+            override fun removeUpdate(e: DocumentEvent?)  = onAnyFieldChanged()
+            override fun changedUpdate(e: DocumentEvent?) = onAnyFieldChanged()
+        })
+    }
+
+    private fun onAnyFieldChanged() {
+        updateVisibility()
+        revalidateAll()
+    }
+
+    private fun updateVisibility() {
+        val currentValues = components.mapValues { it.value.getValue() }
+        settingsModel.schema.forEach { setting ->
+            val rule    = setting.showIf ?: return@forEach
+            val visible = currentValues[rule.propertyName] == rule.requiredValue
+            components[setting.propertyName]?.fieldBlock?.isVisible = visible
+        }
+        // Force layout update
+        components.values.firstOrNull()?.fieldBlock?.parent?.let { parent ->
+            parent.revalidate()
+            parent.repaint()
+        }
+    }
+
+    private fun revalidateAll() {
+        var allValid = true
+        settingsModel.schema.forEach { setting ->
+            val comp = components[setting.propertyName] ?: return@forEach
+            val value = comp.getValue()
+            val valid = validateField(value, setting)
+            if (!valid) allValid = false
+            applyValidationHighlight(comp.component, valid)
+        }
+        saveButton.isEnabled = allValid
+    }
+
+    private fun validateField(value: String, setting: SettingSchema): Boolean {
+        if (setting.isRequired && value.isBlank()) return false
+        val max = maxLengthOf(setting)
+        if (max > 0 && value.length > max) return false
+        if (setting is TextSetting && setting.validation.isNotBlank())
+            if (!Regex(setting.validation).matches(value)) return false
+        if (setting is PasswordSetting && setting.validation.isNotBlank())
+            if (!Regex(setting.validation).matches(value)) return false
+        return true
+    }
+
+    private fun applyValidationHighlight(comp: JComponent, valid: Boolean) {
+        val target = firstInputComponent(comp) ?: return
+        target.border = if (valid)
+            UIManager.getBorder("TextField.border") ?: BorderFactory.createEmptyBorder(2, 4, 2, 4)
+        else
+            BorderFactory.createLineBorder(UIManager.getColor("Actions.Red") ?: Color.RED, 2)
+    }
+
+    // =========================================================================
+    // Character counter
+    // =========================================================================
+
+    private fun buildCharCounter(
+        comp: SettingComponent,
+        maxLength: Int,
+        setting: SettingSchema
+    ): JLabel {
+        val label = JLabel("0 / $maxLength").apply {
+            font       = font.deriveFont(font.size - 1f)
+            foreground = UIManager.getColor("Label.disabledForeground")
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+        fun update() {
+            val len = comp.getValue().length
+            label.text       = "$len / $maxLength"
+            label.foreground = if (len > maxLength)
+                UIManager.getColor("Actions.Red") ?: Color.RED
+            else
+                UIManager.getColor("Label.disabledForeground")
+        }
+        // Wire to the underlying text component
+        val inputComp = firstInputComponent(comp.component)
+        if (inputComp is JTextComponent) {
+            inputComp.document.addDocumentListener(object : DocumentListener {
+                override fun insertUpdate(e: DocumentEvent?)  = update()
+                override fun removeUpdate(e: DocumentEvent?)  = update()
+                override fun changedUpdate(e: DocumentEvent?) = update()
+            })
+        }
+        update()
+        return label
+    }
+
+    // =========================================================================
+    // Hint text area (wraps long strings, styled like a label)
+    // =========================================================================
+
+    private fun buildHintArea(text: String): JTextArea = JTextArea(text).apply {
+        isEditable    = false
+        isOpaque      = false
+        isFocusable   = false
+        lineWrap      = true
+        wrapStyleWord = true
+        border        = null
+        foreground    = UIManager.getColor("Label.disabledForeground")
+        font          = font.deriveFont(font.size - 1f)
+        alignmentX    = Component.LEFT_ALIGNMENT
+        // Prevent the text area from influencing the dialog's preferred width
+        minimumSize   = Dimension(0, 0)
+    }
+
+    // =========================================================================
     // Save + validation
-    // -------------------------------------------------------------------------
+    // =========================================================================
+
+    private fun buildButtonBar(): JPanel {
+        saveButton.addActionListener { onSaveClicked() }
+        saveButton.isDefaultCapable = true
+
+        val cancelButton = JButton(localizationManager.getString("common.cancel")).apply {
+            addActionListener { dispose() }
+        }
+
+        return JPanel(FlowLayout(FlowLayout.TRAILING, 8, 8)).apply {
+            border = BorderFactory.createMatteBorder(
+                1, 0, 0, 0, UIManager.getColor("Component.borderColor") ?: Color.GRAY
+            )
+            add(saveButton)
+            add(cancelButton)
+        }
+    }
 
     private fun onSaveClicked() {
-        val values = components.mapValues { it.value.getValue() }
-
-        // Reset all highlights first
-        components.values.forEach { clearHighlight(it.component) }
-
+        val values  = components.mapValues { it.value.getValue() }
         val missing = settingsModel.schema.filter { s ->
             s.isRequired && values[s.propertyName].isNullOrBlank()
         }
 
         if (missing.isNotEmpty()) {
             missing.forEach { s -> applyErrorHighlight(components[s.propertyName]?.component) }
-
-            // Focus the first invalid field
             components[missing.first().propertyName]?.component?.let { comp ->
-                val focusTarget = firstFocusable(comp)
-                focusTarget?.requestFocusInWindow()
+                firstFocusable(comp)?.requestFocusInWindow()
             }
-
             JOptionPane.showMessageDialog(
                 this,
                 "<html>${localizationManager.getString("plugin_config.required_fields_error_msg")}<br>• ${
@@ -293,28 +682,39 @@ class DynamicPluginSettingsDialog(
         )
     }
 
-    private fun clearHighlight(comp: JComponent?) {
-        val target = firstInputComponent(comp) ?: return
-        target.border = UIManager.getBorder("TextField.border")
-            ?: BorderFactory.createEmptyBorder(2, 4, 2, 4)
+    // =========================================================================
+    // Utility helpers
+    // =========================================================================
+
+    private fun maxLengthOf(setting: SettingSchema) = when (setting) {
+        is TextSetting     -> setting.maxLength
+        is PasswordSetting -> setting.maxLength
+        is TextAreaSetting -> setting.maxLength
+        else               -> 0
     }
 
-    /** Unwraps wrapper panels to find the first real input component. */
+    // The schema types don't carry actionMethod/actionLabel directly
+    // (those are consumed by the builder to produce CustomPanelSetting or to attach buttons).
+    // For inline action buttons per-field, we rely on the SettingArgs.actionMethod/actionLabel
+    // having been stored; since the current schema sealed classes don't expose them,
+    // this lookup always returns empty — @PluginAction standalone actions handle the use case.
+    private fun actionMethodOf(setting: SettingSchema): String = ""
+    private fun actionLabelOf(setting: SettingSchema): String = ""
+
     private fun firstInputComponent(comp: JComponent?): JComponent? = when {
-        comp == null -> null
-        comp is JTextField -> comp
+        comp == null          -> null
+        comp is JTextField    -> comp
         comp is JPasswordField -> comp
-        comp is JSpinner -> comp
-        comp is JCheckBox -> comp
-        comp is JComboBox<*> -> comp
-        comp is JScrollPane -> comp
-        comp is JPanel -> comp.components.filterIsInstance<JComponent>().firstOrNull()
-        else -> comp
+        comp is JSpinner      -> comp
+        comp is JCheckBox     -> comp
+        comp is JComboBox<*>  -> comp
+        comp is JScrollPane   -> comp
+        comp is JSlider       -> comp
+        comp is JPanel        -> comp.components.filterIsInstance<JComponent>().firstOrNull { it !is JLabel }
+        else                  -> comp
     }
 
     private fun firstFocusable(comp: JComponent): Component? =
         if (comp.isFocusable) comp
         else comp.components.filterIsInstance<Component>().firstOrNull { it.isFocusable }
-
-    private data class SettingComponent(val component: JComponent, val getValue: () -> String)
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
@@ -354,14 +354,16 @@ class PluginsPanel(
 
     private fun onConfigure(plugin: PluginState) {
         scope.launch {
-            val model = pluginManager.getPluginSettingsModel(plugin.manifest.id)
+            val model    = pluginManager.getPluginSettingsModel(plugin.manifest.id)
+            val instance = pluginManager.getPluginSettingsInstance(plugin.manifest.id)
             SwingUtilities.invokeLater {
                 if (model != null) {
                     DynamicPluginSettingsDialog(
-                        owner = SwingUtilities.getWindowAncestor(this@PluginsPanel),
-                        pluginName = plugin.manifest.name,
+                        owner               = SwingUtilities.getWindowAncestor(this@PluginsPanel),
+                        pluginName          = plugin.manifest.name,
                         localizationManager = localizationManager,
-                        settingsModel = model,
+                        settingsModel       = model,
+                        settingsInstance    = instance,
                         onSave = { map ->
                             scope.launch { pluginManager.applySettingsFromMap(plugin.manifest.id, map) }
                         }


### PR DESCRIPTION
## Summary

Significantly upgrades the plugin settings annotation system while remaining fully backward compatible — all new `@Setting` parameters have defaults, so existing plugins compile unchanged.

### New API annotations

- **`@SettingGroup` / `@SettingGroups`** — declare named sections on a settings class; fields reference them via `group = "key"`
- **`@PluginAction`** — annotate a `suspend fun methodName(): String?` on the settings class to render it as an action button in the panel
- **`@Setting` new parameters**: `group`, `showIf` (conditional visibility), `minValue`/`maxValue`/`step` (numeric bounds), `maxLength` (text limit), `rows` (textarea height), `fileExtensions`/`allowMultiple` (file picker), `actionMethod`/`actionLabel` (inline button)

### New `SettingType` values

- **`SLIDER`** — horizontal slider for bounded float ranges; requires `minValue` and `maxValue`; falls back to `NUMBER` spinner with a logged warning if bounds are missing
- **`CUSTOM_PANEL`** — plugin provides a full `JComponent` via a factory method (last-resort escape hatch)

### Core layer

- `SettingSchema`: all subclasses now carry `group` and `showIf: ShowIfRule?`; previously-ignored schema properties (`maxLength`, `rows`, `fileExtensions`, `allowMultiple`) are now wired through
- `PluginSettingsSchemaBuilder`: reads all new annotation fields, scans `@PluginAction` methods, builds `PluginSettingsGroup` list from `@SettingGroup` annotations
- `PluginSettingsModel`: adds `groups: List<PluginSettingsGroup>` (flat `schema` list retained for backward compat)
- `PluginManager`: adds `getPluginSettingsInstance()` for `@PluginAction` invocation

### Settings dialog redesign (`DynamicPluginSettingsDialog`)

- **Group headers** — bold section title with accent bar, optional subtitle, collapsible toggle (▶/▼)
- **Action button strips** — `@PluginAction` buttons per group, invoked via reflection on the live settings instance using `SwingWorker`
- **Side-by-side compact fields** — consecutive `BooleanSetting` or `SliderSetting` pairs render in a 2-column row
- **Inline validation** — red border + char counter update as the user types; Save button disabled while any field is invalid
- **`showIf` conditional visibility** — fields are hidden/shown in real time when their controlling field changes
- **Slider widget** — `JSlider` with adaptive integer scale + live value label
- **Text wrapping** — description/hint text uses a non-editable `JTextArea` so long strings wrap on resize instead of expanding the dialog
- **`fileExtensions` / `allowMultiple`** now wired to the file chooser
- **`rows`** now respected for `TEXTAREA`

### `AISettings` adoption

Groups the 6 settings into three sections visible in the Configure dialog:
| Group | Fields |
|-------|--------|
| **Endpoint** | Base URL, API Key |
| **Model** | Model identifier |
| **Advanced** _(collapsible)_ | Temperature (SLIDER, 0.0–2.0 step 0.05), Max Tokens (bounded spinner), Custom Headers (4-row textarea) |