### PR TITLE
refactor(ui): make DictionaryPanel and StatusBar theme-aware

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainEvent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainEvent.kt
@@ -28,4 +28,10 @@ sealed interface MainEvent : UiEvent {
         val type: NotificationType = NotificationType.INFO,
         val isTemporary: Boolean = true
     ) : MainEvent
+
+    /**
+     * Instructs the UI to copy [text] to the system clipboard.
+     * Emitted after [MainIntent.OcrAndCopyText] successfully extracts text.
+     */
+    data class CopyToClipboard(val text: String) : MainEvent
 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
@@ -50,6 +50,12 @@ sealed interface MainIntent : UiIntent {
     data class OcrAndTranslateImage(val image: ImageData) : MainIntent
 
     /**
+     * User requested OCR on an image to extract text and copy it to the clipboard —
+     * without triggering a translation. Emits [MainEvent.CopyToClipboard] on success.
+     */
+    data class OcrAndCopyText(val image: ImageData) : MainIntent
+
+    /**
      * User requested text-to-speech for a specific text panel.
      * @property textSource Which panel to read aloud.
      * @property text Optional text override. If `null`, uses the text from [textSource].

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -246,6 +246,10 @@ class MainStore(
                 handleOcrAndTranslate(intent)
             }
 
+            is MainIntent.OcrAndCopyText -> scope.launch {
+                handleOcrAndCopyText(intent)
+            }
+
             is MainIntent.ShowQuickTranslate -> scope.launch {
                 handleShowQuickTranslate(intent)
             }
@@ -297,6 +301,22 @@ class MainStore(
         // Write extracted text into input then translate — same path as manual typing.
         _state.update { it.copy(inputText = extractedText) }
         translateText()
+    }
+
+    /**
+     * OCR-only path: extracts text from [intent.image] and emits [MainEvent.CopyToClipboard]
+     * so the UI layer can write it to the system clipboard.
+     * Does NOT translate — the user chose "Copy Text", not "Translate".
+     */
+    private suspend fun handleOcrAndCopyText(intent: MainIntent.OcrAndCopyText) {
+        val extractedText = ocrAndTranslateUseCase(
+            image = intent.image,
+            currentState = _state.value,
+            onStatusUpdate = ::updateStatusBar
+        )
+        if (extractedText.isBlank()) return
+        _eventChannel.send(MainEvent.CopyToClipboard(extractedText))
+        updateStatusBar(StatusCode.OcrTextCopied, NotificationType.INFO, true)
     }
 
     private suspend fun handleShowQuickTranslate(intent: MainIntent.ShowQuickTranslate) {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -287,7 +287,14 @@ data class Configuration(
     val isQuickDictionaryPinned: Boolean = false,
     val isQuickDictionaryAutoPositionEnabled: Boolean = true,
     val quickDictionaryIdleTimeoutSeconds: Int = 8,
-    val quickDictionaryTransparencyPercentage: Int = 5
+    val quickDictionaryTransparencyPercentage: Int = 5,
+
+    // ---- Donation nudge ----
+    /**
+     * Set to `true` the first time the one-time donation nudge is shown.
+     * Prevents the nudge from ever appearing again after it has been displayed once.
+     */
+    val donationNudgeShown: Boolean = false
 ) {
     fun getActivePreset(): ServicePreset? =
         servicePresets.find { it.id == activeServicePresetId }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/StatusCode.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/StatusCode.kt
@@ -41,6 +41,7 @@ sealed class StatusCode {
     object OcrTimeout : StatusCode()
     object NoTextInImage : StatusCode()
     object OcrComplete : StatusCode()
+    object OcrTextCopied : StatusCode()
     data class OcrFailed(val summary: String) : StatusCode()
 
     // ---- Summarize ----

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -375,6 +375,8 @@ required_fields_error_msg = "Please fill in the required fields:"
 [about_dialog]
 title = "About QTranslate"
 description = "The original QTranslate was abandoned. This is a full rewrite — same idea, plugin-driven so the app never goes stale."
+support_button = "Support this project ♥"
+donation_nudge = "You've translated a lot with QTranslate! If you find it useful, consider supporting the project (About → Support ♥)"
 
 [history_dialog]
 title = "Translation History"
@@ -474,6 +476,7 @@ recognizing_text = "Recognizing text from image..."
 ocr_timeout = "OCR timed out. Please try again with a smaller image."
 no_text_in_image = "No text was found in the captured image."
 ocr_complete = "Text recognized successfully!"
+ocr_text_copied = "Text recognized and copied to clipboard."
 ocr_failed = "Text recognition failed: %s"
 # Summarize
 no_summarizer_active = "No summarizer service is active. Install and configure a summarizer plugin."

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialog.kt
@@ -1,99 +1,174 @@
 package com.github.ahatem.qtranslate.ui.swing.about
 
 import com.formdev.flatlaf.FlatClientProperties
-import com.github.ahatem.qtranslate.ui.swing.shared.util.GridBag
+import com.formdev.flatlaf.FlatClientProperties.BUTTON_TYPE
+import java.awt.Color
+import java.awt.Component
 import java.awt.Cursor
 import java.awt.Desktop
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
 import java.awt.Frame
-import java.awt.GridBagConstraints
+import java.awt.Graphics
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import java.net.URI
 import javax.swing.*
 
 class InfoDialog(owner: Frame) : JDialog(owner, true) {
 
-    private val iconLabel = JLabel()
-    private val titleLabel = JLabel()
-    private val versionLabel = JLabel()
-    private val descriptionLabel = JLabel()
+    // ── Widgets ───────────────────────────────────────────────────────────────
+    private val iconLabel     = JLabel()
+    private val titleLabel    = JLabel()
+    private val versionLabel  = JLabel()
+    private val descLabel     = JLabel()    // HTML-wrapped, width-constrained
+    private val linkLabel     = JLabel()
+    private val supportButton = JButton()
+    private val closeButton   = JButton()
 
-    private val linkLabel = JLabel()
-    private val closeButton = JButton()
+    companion object {
+        /** Inner text column width in pixels. Drives text wrapping and dialog width. */
+        private const val CONTENT_W = 300
+        /** Edge padding on each side. */
+        private const val PAD = 28
+    }
 
     init {
         defaultCloseOperation = HIDE_ON_CLOSE
         isResizable = false
 
-        val rootPanel = JPanel()
-        contentPane = rootPanel
-        val grid = GridBag(rootPanel)
+        // ── Root: fixed-width vertical column ────────────────────────────────
+        val root = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            border = BorderFactory.createEmptyBorder(PAD, PAD, PAD - 4, PAD)
+            // Fix width so the dialog never grows wider than CONTENT_W + padding.
+            maximumSize = Dimension(CONTENT_W + PAD * 2, Int.MAX_VALUE)
+        }
+        contentPane = root
 
-        val edgePadding = 24 // Generous padding from window edges
-        val sectionGap = 20  // Larger gap between Header <-> Body <-> Footer
-        val titleGap = 4     // Small gap between title and version
-        val textGap = 12     // Standard gap between paragraphs/links
+        // ── Helper — center any component in the column ────────────────────
+        fun centered(comp: Component) = JPanel(FlowLayout(FlowLayout.CENTER, 0, 0)).apply {
+            isOpaque = false
+            alignmentX = Component.CENTER_ALIGNMENT
+            add(comp)
+        }
 
-        iconLabel.horizontalAlignment = SwingConstants.CENTER
-        titleLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "h1")
+        // ── Icon ──────────────────────────────────────────────────────────────
+        iconLabel.alignmentX  = Component.CENTER_ALIGNMENT
+        titleLabel.alignmentX = Component.CENTER_ALIGNMENT
+        versionLabel.alignmentX = Component.CENTER_ALIGNMENT
+        descLabel.alignmentX = Component.CENTER_ALIGNMENT
+        linkLabel.alignmentX = Component.CENTER_ALIGNMENT
+
+        titleLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "h2")
         versionLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "medium")
         versionLabel.foreground = UIManager.getColor("Label.disabledForeground")
         linkLabel.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 
-        grid.defaultAnchor(GridBagConstraints.CENTER)
-            .defaultFill(GridBagConstraints.HORIZONTAL)
+        // Style the support button as a filled accent (FlatLaf "default" type).
+        supportButton.putClientProperty(BUTTON_TYPE, "default")
+        supportButton.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 
-            // --- Header Section ---
-            .insets(top = edgePadding, left = edgePadding, bottom = 0, right = edgePadding)
-            .add(iconLabel)
+        root.add(centered(iconLabel))
+        root.add(Box.createVerticalStrut(16))
 
-            .nextRow().insets(top = sectionGap, left = edgePadding, bottom = 0, right = edgePadding)
-            .add(titleLabel)
+        root.add(titleLabel)
+        root.add(Box.createVerticalStrut(4))
 
-            .nextRow().insets(top = titleGap, left = edgePadding, bottom = 0, right = edgePadding)
-            .add(versionLabel)
+        root.add(centered(versionLabel))
+        root.add(Box.createVerticalStrut(16))
 
-            // --- Body Section ---
-            .nextRow().insets(top = sectionGap, left = edgePadding, bottom = 0, right = edgePadding)
-            .add(descriptionLabel)
+        // Thin separator under header
+        root.add(makeSeparator())
+        root.add(Box.createVerticalStrut(16))
 
-            .nextRow().insets(top = textGap, left = edgePadding, bottom = 0, right = edgePadding)
-            .add(linkLabel)
+        root.add(descLabel)
+        root.add(Box.createVerticalStrut(10))
 
-            // --- Footer Section ---
-            .nextRow().insets(top = sectionGap, left = edgePadding, bottom = edgePadding, right = edgePadding)
-            .fill(GridBagConstraints.NONE) // Do not stretch the button
-            .add(closeButton)
+        root.add(centered(linkLabel))
+
+        // ── Footer ────────────────────────────────────────────────────────────
+        root.add(Box.createVerticalStrut(20))
+        root.add(makeSeparator())
+        root.add(Box.createVerticalStrut(16))
+
+        // Buttons side-by-side, centred
+        val btnRow = JPanel(FlowLayout(FlowLayout.CENTER, 8, 0)).apply {
+            isOpaque = false
+            alignmentX = Component.CENTER_ALIGNMENT
+        }
+        btnRow.add(supportButton)
+        btnRow.add(closeButton)
+        root.add(btnRow)
 
         closeButton.addActionListener { isVisible = false }
         rootPane.defaultButton = closeButton
     }
 
-    fun showDialog(state: InfoDialogState) {
-        title = state.title
-        titleLabel.text = state.appName
-        versionLabel.text = state.versionText
-        iconLabel.icon = state.icon
-        descriptionLabel.text = "<html><div style='text-align: center;'>${state.descriptionHtml.replace("\n", "<br>")}</div></html>"
+    // ── Show ──────────────────────────────────────────────────────────────────
 
+    fun showDialog(state: InfoDialogState) {
+        title          = state.title
+        titleLabel.text  = state.appName
+        versionLabel.text = state.versionText
+        iconLabel.icon   = state.icon
+
+        // Description — wrap at CONTENT_W, centred via HTML.
+        val safe = state.descriptionHtml
+            .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        descLabel.text =
+            "<html><body style='width:${CONTENT_W}px; text-align:center;'>$safe</body></html>"
+
+        // Website link
         if (state.websiteUrl.isNotBlank()) {
             linkLabel.text = "<html><a href=''>${state.websiteUrl}</a></html>"
             linkLabel.mouseListeners.forEach { linkLabel.removeMouseListener(it) }
             linkLabel.addMouseListener(object : MouseAdapter() {
-                override fun mouseClicked(e: MouseEvent) {
-                    try {
-                        Desktop.getDesktop().browse(java.net.URI(state.websiteUrl))
-                    } catch (_: Exception) {
-                    }
-                }
+                override fun mouseClicked(e: MouseEvent) = openUrl(state.websiteUrl)
             })
             linkLabel.isVisible = true
         } else {
             linkLabel.isVisible = false
         }
+
+        // Support button
+        if (state.supportUrl.isNotBlank() && state.supportButtonText.isNotBlank()) {
+            supportButton.text = state.supportButtonText
+            supportButton.actionListeners.forEach { supportButton.removeActionListener(it) }
+            supportButton.addActionListener { openUrl(state.supportUrl) }
+            supportButton.isVisible = true
+        } else {
+            supportButton.isVisible = false
+        }
+
         closeButton.text = state.closeButtonText
 
         pack()
         setLocationRelativeTo(owner)
         isVisible = true
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun makeSeparator(): Component = object : JComponent() {
+        init {
+            maximumSize   = Dimension(Int.MAX_VALUE, 1)
+            preferredSize = Dimension(CONTENT_W, 1)
+            alignmentX    = Component.CENTER_ALIGNMENT
+        }
+        override fun paintComponent(g: Graphics) {
+            val c = UIManager.getColor("Separator.foreground") ?: Color(80, 80, 80)
+            g.color = Color(c.red, c.green, c.blue, 80)
+            g.drawLine(0, 0, width, 0)
+        }
+    }
+
+    private fun openUrl(url: String) {
+        runCatching {
+            if (Desktop.isDesktopSupported() &&
+                Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
+            ) Desktop.getDesktop().browse(URI(url))
+        }
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialogState.kt
@@ -10,5 +10,9 @@ data class InfoDialogState(
     val websiteUrl: String,
     val icon: Icon,
     val closeButtonText: String,
-    val isVisible: Boolean = false
+    val isVisible: Boolean = false,
+    /** URL opened when the user clicks the support button. Empty string = hide the button. */
+    val supportUrl: String = "",
+    /** Label for the "Support this project" button. */
+    val supportButtonText: String = ""
 )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanel.kt
@@ -4,8 +4,9 @@ import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceInfo
 import com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
-import com.github.ahatem.qtranslate.ui.swing.shared.util.applyForegroundColorFilter
 import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.Color
 import java.awt.Dimension
 import javax.swing.*
 
@@ -16,17 +17,15 @@ class DictionaryPanel(
     private val onClose: () -> Unit,
 ) : JPanel(BorderLayout()) {
 
+    private var isInitialized = false
+
     private val searchField = JTextField()
     private val lookupButton = JButton()
 
-    private val hintLabel = JLabel("", SwingConstants.CENTER).apply {
-        foreground = UIManager.getColor("Label.disabledForeground")
-    }
-    private val loadingLabel = JLabel("", SwingConstants.CENTER).apply {
-        foreground = UIManager.getColor("Label.disabledForeground")
-    }
+    private val hintLabel = JLabel("", SwingConstants.CENTER)
+    private val loadingLabel = JLabel("", SwingConstants.CENTER)
     private val resultView = DictionaryResultView()
-    private val cardPanel = JPanel(java.awt.CardLayout())
+    private val cardPanel = JPanel(CardLayout())
 
     private val serviceCombo = JComboBox<ServiceInfo>().apply {
         putClientProperty("JComboBox.isTableCellEditor", true)
@@ -46,13 +45,11 @@ class DictionaryPanel(
 
     private var updatingFromState = false
 
-    // Icons for the auto-source cycling button
-    private val activeLinkIcon: FlatSVGIcon = (iconManager.getIcon("icons/lucide/link-2.svg", 13, 13) as FlatSVGIcon)
-        .applyForegroundColorFilter()
-    private val offUnlinkIcon: FlatSVGIcon = (iconManager.getIcon("icons/lucide/unlink.svg", 13, 13) as FlatSVGIcon)
-        .apply { colorFilter = FlatSVGIcon.ColorFilter { UIManager.getColor("Label.disabledForeground") } }
+    private val activeLinkIconBase: FlatSVGIcon =
+        iconManager.getIcon("icons/lucide/link-2.svg", 13, 13) as FlatSVGIcon
+    private val offUnlinkIconBase: FlatSVGIcon =
+        iconManager.getIcon("icons/lucide/unlink.svg", 13, 13) as FlatSVGIcon
 
-    // Cycling button: Off → Translated → Source → Off
     private val autoSourceButton = JButton().apply {
         putClientProperty("JButton.buttonType", "toolBarButton")
         isFocusable = false
@@ -111,15 +108,7 @@ class DictionaryPanel(
             add(cardPanel, BorderLayout.CENTER)
         }
 
-        border = BorderFactory.createCompoundBorder(
-            BorderFactory.createMatteBorder(
-                0, 1, 0, 0,
-                UIManager.getColor("Component.borderColor")
-                    ?: UIManager.getColor("Separator.foreground")
-            ),
-            BorderFactory.createEmptyBorder(12, 12, 12, 12)
-        )
-
+        // Build border — defer to refreshBorder() to avoid duplication
         add(topPanel, BorderLayout.NORTH)
         add(contentArea, BorderLayout.CENTER)
 
@@ -136,15 +125,70 @@ class DictionaryPanel(
         }
 
         autoSourceButton.addActionListener {
-            // Cycle: OFF → TRANSLATED → SOURCE → OFF
             val next = when (currentAutoSource) {
-                DictionaryAutoSource.OFF        -> DictionaryAutoSource.TRANSLATED
+                DictionaryAutoSource.OFF -> DictionaryAutoSource.TRANSLATED
                 DictionaryAutoSource.TRANSLATED -> DictionaryAutoSource.SOURCE
-                DictionaryAutoSource.SOURCE     -> DictionaryAutoSource.OFF
+                DictionaryAutoSource.SOURCE -> DictionaryAutoSource.OFF
             }
-            // Read from clientProperty so we always call the latest callback.
             (getClientProperty("onAutoSourceChanged") as? (DictionaryAutoSource) -> Unit)?.invoke(next)
         }
+
+        // Apply initial styling
+        isInitialized = true
+        refreshAllColors()
+    }
+
+    override fun updateUI() {
+        super.updateUI()
+
+        if (!isInitialized) return
+
+        refreshAllColors()
+
+    }
+
+    private fun refreshAllColors() {
+        refreshBorder()
+        refreshLabelColors()
+        refreshIcons()
+    }
+
+    private fun refreshBorder() {
+        val borderColor = UIManager.getColor("Component.borderColor")
+            ?: UIManager.getColor("Panel.background")?.darker()
+            ?: Color.GRAY
+
+        border = BorderFactory.createCompoundBorder(
+            BorderFactory.createMatteBorder(0, 1, 0, 0, borderColor),
+            BorderFactory.createEmptyBorder(12, 12, 12, 12)
+        )
+    }
+
+    private fun refreshLabelColors() {
+        val disabledColor = UIManager.getColor("Label.disabledForeground")
+            ?: UIManager.getColor("Label.foreground")?.let {
+                Color(it.red, it.green, it.blue, 128)
+            }
+            ?: Color.GRAY
+
+        hintLabel.foreground = disabledColor
+        loadingLabel.foreground = disabledColor
+    }
+
+    private fun refreshIcons() {
+        val accentColor = UIManager.getColor("Component.accentColor")
+            ?: UIManager.getColor("Actions.Blue")
+            ?: Color(0x2675BF)
+
+        val disabledColor = UIManager.getColor("Label.disabledForeground")
+            ?: UIManager.getColor("Label.foreground")?.let {
+                Color(it.red, it.green, it.blue, 128)
+            }
+            ?: Color.GRAY
+
+        // Recreate icons with current theme colors
+        activeLinkIconBase.colorFilter = FlatSVGIcon.ColorFilter { accentColor }
+        offUnlinkIconBase.colorFilter = FlatSVGIcon.ColorFilter { disabledColor }
     }
 
     fun render(state: DictionaryPanelState) {
@@ -155,25 +199,28 @@ class DictionaryPanel(
             toolTipText = state.closeLabel
         }
 
-        // Sync auto-source button — store callback in clientProperty so the
-        // ActionListener always calls the fresh lambda from the latest render.
+        // Sync auto-source button
         putClientProperty("onAutoSourceChanged", state.onAutoSourceChanged)
         if (currentAutoSource != state.autoSource) {
             currentAutoSource = state.autoSource
         }
         val (autoLabel, autoTip) = when (state.autoSource) {
-            DictionaryAutoSource.OFF        -> state.autoSourceOffLabel        to state.autoSourceOffLabel
+            DictionaryAutoSource.OFF -> state.autoSourceOffLabel to state.autoSourceOffLabel
             DictionaryAutoSource.TRANSLATED -> state.autoSourceTranslatedLabel to state.autoSourceTranslatedLabel
-            DictionaryAutoSource.SOURCE     -> state.autoSourceSourceLabel     to state.autoSourceSourceLabel
+            DictionaryAutoSource.SOURCE -> state.autoSourceSourceLabel to state.autoSourceSourceLabel
         }
         autoSourceButton.text = autoLabel
         autoSourceButton.toolTipText = autoTip
+
         val isActive = state.autoSource != DictionaryAutoSource.OFF
-        autoSourceButton.icon = if (isActive) activeLinkIcon else offUnlinkIcon
-        autoSourceButton.foreground = if (isActive)
-            UIManager.getColor("Component.accentColor") ?: UIManager.getColor("Button.foreground")
-        else
-            UIManager.getColor("Label.disabledForeground")
+        val accentColor = UIManager.getColor("Component.accentColor")
+            ?: UIManager.getColor("Actions.Blue")
+            ?: Color(0x2675BF)
+        val disabledColor = UIManager.getColor("Label.disabledForeground")
+            ?: Color.GRAY
+
+        autoSourceButton.icon = if (isActive) activeLinkIconBase else offUnlinkIconBase
+        autoSourceButton.foreground = if (isActive) accentColor else disabledColor
 
         lookupButton.text = state.lookupButtonLabel
         loadingLabel.text = state.loadingMessage
@@ -182,10 +229,11 @@ class DictionaryPanel(
             state.hasFailed -> state.errorMessage
             state.lookedUpWord.isNotBlank() && !state.isLoading && state.entries.isEmpty() ->
                 state.notFoundMessage
+
             else -> state.hintMessage
         }
 
-        // Chip management — only act once a lookup has completed (not loading).
+        // Chip management
         if (chips.hasChips && !state.isLoading && state.lookedUpWord.isNotBlank()) {
             if (state.entries.isEmpty() && !state.hasFailed) {
                 chips.removeChipForWord(state.lookedUpWord)
@@ -194,7 +242,7 @@ class DictionaryPanel(
             }
         }
 
-        // Service picker.
+        // Service picker
         updatingFromState = true
         try {
             val dicts = state.availableDictionaries
@@ -220,7 +268,7 @@ class DictionaryPanel(
             state.entries.isNotEmpty() -> "results"
             else -> "hint"
         }
-        (cardPanel.layout as java.awt.CardLayout).show(cardPanel, card)
+        (cardPanel.layout as CardLayout).show(cardPanel, card)
 
         if (state.entries.isNotEmpty()) {
             resultView.render(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -374,8 +374,37 @@ class MainAppFrame(
                             releaseUrl = event.releaseUrl
                         ))
                     }
+                    is MainEvent.CopyToClipboard -> {
+                        runCatching {
+                            Toolkit.getDefaultToolkit().systemClipboard
+                                .setContents(StringSelection(event.text), null)
+                        }
+                    }
                 }
             }
+        }
+
+        // Donation nudge — track successful translations in-memory; show once at 500.
+        // Uses scan() to detect isLoading true→false transitions that produced output.
+        appScope.launch(handler) {
+            var translationCount = 0
+            mainStore.state
+                .scan(Pair<MainState?, MainState?>(null, null)) { (_, prev), curr -> prev to curr }
+                .filter { (prev, curr) ->
+                    prev != null && curr != null &&
+                    prev.isLoading && !curr.isLoading && curr.translatedText.isNotBlank()
+                }
+                .collect {
+                    translationCount++
+                    if (translationCount >= 500 &&
+                        !settingsStore.state.value.workingConfiguration.donationNudgeShown
+                    ) {
+                        settingsStore.dispatch(
+                            SettingsIntent.ToggleSetting { it.copy(donationNudgeShown = true) }
+                        )
+                        withContext(Dispatchers.Swing) { showDonationNudge() }
+                    }
+                }
         }
 
         // Background/system notifications — UpdateAvailable → dialog; everything else → popover
@@ -1129,10 +1158,26 @@ class MainAppFrame(
             descriptionHtml = localizer.getString("about_dialog.description"),
             websiteUrl = "https://github.com/ahatem/qtranslate",
             icon = iconManager.getIcon("icons/app/128.png", 32, 32),
-            closeButtonText = localizer.getString("common.close")
+            closeButtonText = localizer.getString("common.close"),
+            supportUrl = "https://buymeacoffee.com/ahmedhatem",
+            supportButtonText = localizer.getString("about_dialog.support_button")
         )
 
         runOnUi { aboutDialog.showDialog(state) }
+    }
+
+    /** Shows a one-time donation nudge in the notification popover. */
+    private fun showDonationNudge() {
+        val message = localizer.getString("about_dialog.donation_nudge")
+        statusBarController.addToPopover(
+            com.github.ahatem.qtranslate.core.shared.notification.AppNotification(
+                type = com.github.ahatem.qtranslate.api.plugin.NotificationType.INFO,
+                code = com.github.ahatem.qtranslate.core.shared.notification.NotificationCode.Custom(
+                    title = "",
+                    body = message
+                )
+            )
+        )
     }
 
     private fun showUpdateDialog(code: NotificationCode.UpdateAvailable) {
@@ -1470,6 +1515,7 @@ class MainAppFrame(
             StatusCode.OcrTimeout                   -> localizer.getString("status_bar.ocr_timeout")
             StatusCode.NoTextInImage                -> localizer.getString("status_bar.no_text_in_image")
             StatusCode.OcrComplete                  -> localizer.getString("status_bar.ocr_complete")
+            StatusCode.OcrTextCopied               -> localizer.getString("status_bar.ocr_text_copied")
             is StatusCode.OcrFailed                 -> localizer.getString("status_bar.ocr_failed", code.summary)
             StatusCode.NoSummarizerActive           -> localizer.getString("status_bar.no_summarizer_active")
             StatusCode.Summarizing                  -> localizer.getString("status_bar.summarizing")

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/StatusBar.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/StatusBar.kt
@@ -28,13 +28,13 @@ class StatusBar(
     /** Thin indeterminate bar that hugs the bottom edge while a translation is in progress. */
     private val progressBar = object : JProgressBar() {
         override fun getPreferredSize() = Dimension(super.getPreferredSize().width, 3)
-        override fun getMinimumSize()   = Dimension(0, 3)
-        override fun getMaximumSize()   = Dimension(Int.MAX_VALUE, 3)
+        override fun getMinimumSize() = Dimension(0, 3)
+        override fun getMaximumSize() = Dimension(Int.MAX_VALUE, 3)
     }.apply {
-        isIndeterminate  = true
-        isVisible        = false
-        isBorderPainted  = false
-        isOpaque         = false
+        isIndeterminate = true
+        isVisible = false
+        isBorderPainted = false
+        isOpaque = false
     }
 
     private val notificationButton = createButtonWithIcon(iconManager, "icons/lucide/notification.svg", 14).apply {
@@ -44,8 +44,6 @@ class StatusBar(
     }
 
     init {
-        border = MatteBorder(1, 0, 0, 0, UIManager.getColor("Component.borderColor"))
-
         val contentPanel = JPanel(BorderLayout(4, 0)).apply {
             border = BorderFactory.createEmptyBorder(4, 8, 4, 8)
             isOpaque = false
@@ -54,15 +52,36 @@ class StatusBar(
         }
 
         add(contentPanel, BorderLayout.CENTER)
-        add(progressBar,  BorderLayout.SOUTH)
+        add(progressBar, BorderLayout.SOUTH)
+
+        UIManager.addPropertyChangeListener { evt ->
+            if (evt.propertyName == "lookAndFeel") {
+                updateBorder()
+            }
+        }
     }
 
     override fun render(state: StatusBarState) {
-        border = MatteBorder(1, 0, 0, 0, UIManager.getColor("Component.borderColor"))
+        updateBorder()
         chip.update(state.message, state.type)
         progressBar.isVisible = state.isLoading
         notificationButton.toolTipText = state.notificationTooltip
-        notificationButton.isEnabled   = state.isNotificationButtonEnabled
+        notificationButton.isEnabled = state.isNotificationButtonEnabled
+    }
+
+    override fun updateUI() {
+        super.updateUI()
+        updateBorder()
+    }
+
+    private fun updateBorder() {
+        val borderColor = UIManager.getColor("Component.borderColor")
+            ?: UIManager.getColor("Panel.background")?.darker()
+            ?: Color.GRAY
+
+        border = MatteBorder(1, 0, 0, 0, borderColor)
+        revalidate()
+        repaint()
     }
 
     fun text(): String = chip.currentText
@@ -77,37 +96,58 @@ class StatusBar(
      * with the full message text so long strings are readable on hover.
      */
     private class StatusChip(private val onClicked: (message: String) -> Unit) : JComponent() {
+
         var currentText: String = ""
             private set
+
         private var currentType: NotificationType = NotificationType.INFO
+
+        private val chipBackgroundAlpha = 40  // 15% opacity for chip backgrounds
+        private val cornerArcFraction = 1.0   // Fully round (pill shape)
 
         init {
             isOpaque = false
+            font = UIManager.getFont("Label.font") ?: font
+
             addMouseListener(object : MouseAdapter() {
                 override fun mouseClicked(e: MouseEvent) {
                     if (isClickable()) onClicked(currentText)
                 }
+
                 override fun mouseEntered(e: MouseEvent) {
                     cursor = if (isClickable()) Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                             else Cursor.getDefaultCursor()
+                    else Cursor.getDefaultCursor()
                 }
+
                 override fun mouseExited(e: MouseEvent) {
                     cursor = Cursor.getDefaultCursor()
                 }
             })
         }
 
-        private fun isClickable() =
-            currentText.isNotBlank() &&
-            (currentType == NotificationType.ERROR || currentType == NotificationType.WARNING)
-
-        fun update(text: String, type: NotificationType) {
-            currentText = text
-            currentType = type
-            // Full text as tooltip so even truncated messages are fully readable on hover.
-            toolTipText = if (text.isNotBlank() && type != NotificationType.INFO) text else null
+        override fun updateUI() {
+            super.updateUI()
+            font = UIManager.getFont("Label.font") ?: font
             revalidate()
             repaint()
+        }
+
+        private fun isClickable() =
+            currentText.isNotBlank() &&
+                    (currentType == NotificationType.ERROR || currentType == NotificationType.WARNING)
+
+        fun update(text: String, type: NotificationType) {
+            val changed = currentText != text || currentType != type
+            currentText = text
+            currentType = type
+
+            // Full text as tooltip so even truncated messages are fully readable on hover.
+            toolTipText = if (text.isNotBlank() && type != NotificationType.INFO) text else null
+
+            if (changed) {
+                revalidate()
+                repaint()
+            }
         }
 
         override fun paintComponent(g: Graphics) {
@@ -115,48 +155,122 @@ class StatusBar(
             if (currentText.isBlank()) return
 
             val g2 = g.create() as Graphics2D
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,      RenderingHints.VALUE_ANTIALIAS_ON)
-            g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB)
 
-            val f  = UIManager.getFont("Label.font") ?: font
-            g2.font = f
-            val fm = g2.fontMetrics
+                g2.font = font
+                val fm = g2.fontMetrics
 
-            val chipH = fm.height + 6
-            val chipW = fm.stringWidth(currentText) + 16
-            val chipY = (height - chipH) / 2
+                val chipH = fm.height + 6
+                val chipW = fm.stringWidth(currentText) + 16
+                val arcH = (chipH * cornerArcFraction).toFloat()
+                val chipY = (height - chipH) / 2
 
-            val isLtr = componentOrientation.isLeftToRight
-            val chipX = if (isLtr) 0 else width - chipW
+                val isLtr = componentOrientation.isLeftToRight
+                val chipX = if (isLtr) 0 else width - chipW
 
-            val color = typeColor()
+                val color = resolveColor()
 
-            if (currentType != NotificationType.INFO) {
-                g2.color = Color(color.red, color.green, color.blue, 28)
-                g2.fill(RoundRectangle2D.Float(
-                    chipX.toFloat(), chipY.toFloat(),
-                    chipW.toFloat(), chipH.toFloat(),
-                    chipH.toFloat(), chipH.toFloat()
-                ))
+                // Draw background pill (only for non-INFO types)
+                if (currentType != NotificationType.INFO) {
+                    // Use theme-aware alpha: darker themes get slightly more opaque backgrounds
+                    val alpha = if (isDarkTheme()) chipBackgroundAlpha + 10 else chipBackgroundAlpha
+                    g2.color = Color(color.red, color.green, color.blue, alpha.coerceIn(0, 255))
+                    g2.fill(
+                        RoundRectangle2D.Float(
+                            chipX.toFloat(), chipY.toFloat(),
+                            chipW.toFloat(), chipH.toFloat(),
+                            arcH, arcH
+                        )
+                    )
+
+                    // Draw subtle border for better contrast on some themes
+                    g2.color = Color(color.red, color.green, color.blue, alpha + 40)
+                    g2.stroke = BasicStroke(1f)
+                    g2.draw(
+                        RoundRectangle2D.Float(
+                            chipX.toFloat(), chipY.toFloat(),
+                            chipW.toFloat(), chipH.toFloat(),
+                            arcH, arcH
+                        )
+                    )
+                }
+
+                // Draw text
+                g2.color = color
+                val textY = chipY + fm.ascent + 3
+                g2.drawString(currentText, chipX + 8, textY)
+            } finally {
+                g2.dispose()
             }
-
-            g2.color = color
-            g2.drawString(currentText, chipX + 8, chipY + fm.ascent + 3)
-            g2.dispose()
         }
 
         override fun getPreferredSize(): Dimension {
-            val f  = UIManager.getFont("Label.font") ?: font
+            val f = font
             val fm = getFontMetrics(f)
-            val w  = if (currentText.isNotEmpty()) fm.stringWidth(currentText) + 16 else 0
+            val w = if (currentText.isNotEmpty()) fm.stringWidth(currentText) + 16 else 0
             return Dimension(maxOf(w, 0), fm.height + 8)
         }
 
-        private fun typeColor(): Color = when (currentType) {
-            NotificationType.SUCCESS -> UIManager.getColor("Actions.Green")  ?: Color(0x59A869)
-            NotificationType.WARNING -> UIManager.getColor("Actions.Yellow") ?: Color(0xE2A53A)
-            NotificationType.ERROR   -> UIManager.getColor("Actions.Red")    ?: Color(0xE05555)
-            NotificationType.INFO    -> UIManager.getColor("Label.foreground") ?: Color.GRAY
+        private fun resolveColor(): Color {
+            return when (currentType) {
+                NotificationType.SUCCESS -> getThemeColor(
+                    "Actions.Green",
+                    "FlatLaf.accentColor",
+                    defaultColor = Color(0x59A869)
+                )
+
+                NotificationType.WARNING -> getThemeColor(
+                    "Actions.Yellow",
+                    "Component.warning.focusedBorderColor",
+                    defaultColor = Color(0xE2A53A)
+                )
+
+                NotificationType.ERROR -> getThemeColor(
+                    "Actions.Red",
+                    "Component.error.focusedBorderColor",
+                    defaultColor = Color(0xE05555)
+                )
+
+                NotificationType.INFO -> UIManager.getColor("Label.foreground")
+                    ?: Color.GRAY
+            }
         }
+
+        /**
+         * Tries a list of UIManager keys in order, falling back to [defaultColor]
+         * if none are found. This handles theme variations gracefully.
+         */
+        private fun getThemeColor(vararg keys: String, defaultColor: Color): Color {
+            for (key in keys) {
+                val color = UIManager.getColor(key)
+                if (color != null) {
+                    // Adjust brightness if needed for the current theme
+                    return if (isDarkTheme() && isTooDark(color)) {
+                        color.brighter()
+                    } else if (!isDarkTheme() && isTooBright(color)) {
+                        color.darker()
+                    } else {
+                        color
+                    }
+                }
+            }
+            return defaultColor
+        }
+
+        private fun isDarkTheme(): Boolean {
+            return UIManager.getLookAndFeel().isNativeLookAndFeel && // fallback check
+                    (UIManager.getColor("Panel.background")?.let { bg ->
+                        val luminance = 0.299 * bg.red + 0.587 * bg.green + 0.114 * bg.blue
+                        luminance < 128
+                    } ?: false)
+        }
+
+        private fun isTooDark(color: Color): Boolean =
+            0.299 * color.red + 0.587 * color.green + 0.114 * color.blue < 40
+
+        private fun isTooBright(color: Color): Boolean =
+            0.299 * color.red + 0.587 * color.green + 0.114 * color.blue > 220
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/snippingtool/ScreenCaptureController.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/snippingtool/ScreenCaptureController.kt
@@ -25,6 +25,25 @@ class ScreenCaptureController(
         this.currentState = newState
     }
 
+    /**
+     * Resets to [CaptureMode.IDLE] so the user can draw a new selection
+     * without dismissing the overlay. Called when the user clicks "Re-crop".
+     */
+    fun resetToIdle() {
+        dragStartPoint = null
+        dragStartSelection = null
+        activeMouseAction = MouseAction.NONE
+        onStateChanged(
+            currentState.copy(
+                mode = CaptureMode.IDLE,
+                selection = null,
+                mouseAction = MouseAction.CROSSHAIR,
+                showButtons = false,
+                buttonsPosition = null
+            )
+        )
+    }
+
     override fun mousePressed(e: MouseEvent) {
         dragStartPoint = e.point
         val currentSelection = currentState.selection

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/snippingtool/ScreenCapturePanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/snippingtool/ScreenCapturePanel.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.snippingtool
 
+import com.formdev.flatlaf.FlatClientProperties
 import com.github.ahatem.qtranslate.ui.swing.shared.util.getVirtualScreenBounds
 import java.awt.*
 import java.awt.geom.RoundRectangle2D
@@ -8,9 +9,23 @@ import javax.swing.*
 import kotlin.math.roundToInt
 
 class ScreenCapturePanel(
-    private val onCapture: (BufferedImage) -> Unit,
-    private val onCancel: () -> Unit
+    private val onTranslate: (BufferedImage) -> Unit,
+    private val onCopyText: (BufferedImage) -> Unit,
+    private val onCopyImage: (BufferedImage) -> Unit,
+    private val onSaveImage: (BufferedImage) -> Unit,
+    private val onRecrop: () -> Unit,
+    private val onCancel: () -> Unit,
+    private val buttonLabels: ButtonLabels = ButtonLabels()
 ) : JLayeredPane() {
+
+    data class ButtonLabels(
+        val translate: String  = "Translate",
+        val copyText: String   = "Copy Text",
+        val copyImage: String  = "Copy Image",
+        val saveImage: String  = "Save Image",
+        val recrop: String     = "Re-crop",
+        val cancel: String     = "Cancel"
+    )
 
     private var currentState: ScreenCaptureState? = null
     private val buttonsPanel: JPanel
@@ -52,6 +67,10 @@ class ScreenCapturePanel(
         return state.screenshot.getSubimage(selection.x, selection.y, selection.width, selection.height)
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // Painting
+    // ─────────────────────────────────────────────────────────────────────────
+
     override fun paintComponent(g: Graphics) {
         super.paintComponent(g)
         val g2d = g as Graphics2D
@@ -68,106 +87,191 @@ class ScreenCapturePanel(
         g2d.color = Color(baseColor.red, baseColor.green, baseColor.blue, overlayAlpha)
 
         state.selection?.takeIf { it.width > 0 && it.height > 0 }?.let { sel ->
-            // Draw overlay around selection
-            g2d.fillRect(0, 0, width, sel.y) // top
-            g2d.fillRect(0, sel.y + sel.height, width, height - (sel.y + sel.height)) // bottom
-            g2d.fillRect(0, sel.y, sel.x, sel.height) // left
-            g2d.fillRect(sel.x + sel.width, sel.y, width - (sel.x + sel.width), sel.height) // right
+            // Dim everything outside the selection
+            g2d.fillRect(0, 0, width, sel.y)
+            g2d.fillRect(0, sel.y + sel.height, width, height - (sel.y + sel.height))
+            g2d.fillRect(0, sel.y, sel.x, sel.height)
+            g2d.fillRect(sel.x + sel.width, sel.y, width - (sel.x + sel.width), sel.height)
 
-            g2d.composite = AlphaComposite.SrcOver // reset alpha
+            g2d.composite = AlphaComposite.SrcOver
 
-            // Selection border
+            // Dashed selection border
             val borderColor = UIManager.getColor("Component.focusedBorderColor") ?: Color(0, 120, 215)
-            val dash = floatArrayOf(4f, 4f)
             g2d.color = borderColor
-            g2d.stroke = BasicStroke(2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1f, dash, 0f)
+            g2d.stroke = BasicStroke(2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1f, floatArrayOf(4f, 4f), 0f)
             g2d.drawRect(sel.x, sel.y, sel.width, sel.height)
 
-            // Semi-transparent fill inside selection
+            // 15% tinted fill inside selection
             val fillColor = UIManager.getColor("TextField.selectionBackground")?.let {
-                Color(it.red, it.green, it.blue, (255 * 0.15).roundToInt()) // 15%
-            } ?: Color(0, 120, 215, (255 * 0.15).roundToInt()) // 15%
+                Color(it.red, it.green, it.blue, (255 * 0.15).roundToInt())
+            } ?: Color(0, 120, 215, (255 * 0.15).roundToInt())
             g2d.color = fillColor
             g2d.fillRect(sel.x + 1, sel.y + 1, sel.width - 1, sel.height - 1)
 
-            // Corner handles
-            val handleSize = 8
-            val half = handleSize / 2
-            val accentColor = UIManager.getColor("Component.accentColor") ?: Color(0, 120, 215)
-            val borderHandleColor = UIManager.getColor("Component.borderColor") ?: Color.BLACK
-            val shadowColor = Color(0, 0, 0, 100)
+            // Corner resize handles
+            paintCornerHandles(g2d, sel)
 
-            val corners = listOf(
-                Point(sel.x, sel.y),
-                Point(sel.x + sel.width, sel.y),
-                Point(sel.x, sel.y + sel.height),
-                Point(sel.x + sel.width, sel.y + sel.height)
-            )
-
-            corners.forEach { c ->
-                // Shadow
-                g2d.color = shadowColor
-                g2d.fillRect(c.x - half + 1, c.y - half + 1, handleSize, handleSize)
-
-                // Fill handle
-                g2d.color = accentColor
-                g2d.fillRect(c.x - half, c.y - half, handleSize, handleSize)
-
-                // Handle border
-                g2d.color = borderHandleColor
-                g2d.stroke = BasicStroke(1f)
-                g2d.drawRect(c.x - half, c.y - half, handleSize, handleSize)
-            }
+            // Dimensions badge
+            paintDimensionsLabel(g2d, sel)
 
         } ?: run {
-            // No selection so draw full overlay
             g2d.fillRect(0, 0, width, height)
         }
     }
 
+    private fun paintCornerHandles(g2d: Graphics2D, sel: Rectangle) {
+        val handleSize = 8
+        val half = handleSize / 2
+        val accentColor = UIManager.getColor("Component.accentColor") ?: Color(0, 120, 215)
+        val borderHandleColor = UIManager.getColor("Component.borderColor") ?: Color.BLACK
+        val shadowColor = Color(0, 0, 0, 100)
+
+        listOf(
+            Point(sel.x, sel.y),
+            Point(sel.x + sel.width, sel.y),
+            Point(sel.x, sel.y + sel.height),
+            Point(sel.x + sel.width, sel.y + sel.height)
+        ).forEach { c ->
+            g2d.color = shadowColor
+            g2d.fillRect(c.x - half + 1, c.y - half + 1, handleSize, handleSize)
+            g2d.color = accentColor
+            g2d.fillRect(c.x - half, c.y - half, handleSize, handleSize)
+            g2d.color = borderHandleColor
+            g2d.stroke = BasicStroke(1f)
+            g2d.drawRect(c.x - half, c.y - half, handleSize, handleSize)
+        }
+    }
+
+    private fun paintDimensionsLabel(g2d: Graphics2D, sel: Rectangle) {
+        val label = "${sel.width} × ${sel.height} px"
+        val labelFont = g2d.font.deriveFont(Font.BOLD, 11f)
+        g2d.font = labelFont
+        val fm = g2d.fontMetrics
+        val textW = fm.stringWidth(label)
+        val textH = fm.ascent
+        val pad = 4
+
+        val bgW = textW + pad * 2
+        val bgH = textH + pad * 2
+
+        // Only draw if there's enough room inside the selection
+        if (bgW + 8 > sel.width || bgH + 8 > sel.height) return
+
+        val bgX = (sel.x + sel.width - bgW - 6).coerceAtLeast(sel.x + 2)
+        val bgY = (sel.y + sel.height - bgH - 6).coerceAtLeast(sel.y + 2)
+
+        g2d.color = Color(0, 0, 0, 160)
+        g2d.fill(RoundRectangle2D.Float(bgX.toFloat(), bgY.toFloat(), bgW.toFloat(), bgH.toFloat(), 6f, 6f))
+        g2d.color = Color.WHITE
+        g2d.drawString(label, bgX + pad, bgY + pad + textH - fm.descent)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Button panel
+    // ─────────────────────────────────────────────────────────────────────────
+
     private fun createButtonsPanel(): JPanel {
-        return object : JPanel(FlowLayout(FlowLayout.CENTER, 10, 5)) {
+        val translateBtn = JButton(buttonLabels.translate).apply {
+            // "default" = filled accent button — primary action
+            putClientProperty(FlatClientProperties.BUTTON_TYPE, "default")
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            toolTipText = "OCR and translate the captured region"
+            addActionListener { getSelectedImage()?.let(onTranslate) }
+            alignmentY = Component.CENTER_ALIGNMENT
+        }
+        val copyTextBtn  = flatBtn(buttonLabels.copyText,  "Recognize text and copy to clipboard")  { getSelectedImage()?.let(onCopyText)  }
+        val copyImageBtn = flatBtn(buttonLabels.copyImage, "Copy image to clipboard")                 { getSelectedImage()?.let(onCopyImage) }
+        val saveImageBtn = flatBtn(buttonLabels.saveImage, "Save captured image as PNG")              { getSelectedImage()?.let(onSaveImage) }
+        val recropBtn    = flatBtn(buttonLabels.recrop,    "Clear selection and draw a new one")      { onRecrop()    }
+        val cancelBtn    = flatBtn(buttonLabels.cancel,    "Close the capture tool")                  { onCancel()    }
+
+        return object : JPanel() {
             override fun paintComponent(g: Graphics) {
                 val g2d = g as Graphics2D
                 g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
                 g2d.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE)
 
-                val bgColor = UIManager.getColor("Panel.background") ?: Color(40, 40, 40)
-                g2d.color = Color(bgColor.red, bgColor.green, bgColor.blue, 200)
-                g2d.fillRoundRect(0, 0, width, height, 12, 12)
+                val bg = UIManager.getColor("Panel.background") ?: Color(40, 40, 40)
+                g2d.color = Color(bg.red, bg.green, bg.blue, 215)
+                g2d.fillRoundRect(0, 0, width, height, 14, 14)
 
-                val borderColor = UIManager.getColor("Component.borderColor") ?: Color(70, 70, 70)
-                g2d.color = Color(borderColor.red, borderColor.green, borderColor.blue, 180)
+                val border = UIManager.getColor("Component.borderColor") ?: Color(80, 80, 80)
+                g2d.color = Color(border.red, border.green, border.blue, 160)
                 g2d.stroke = BasicStroke(1.5f)
-                val rect = RoundRectangle2D.Float(
-                    0.75f, 0.75f, width - 1.5f, height - 1.5f, 12f, 12f
-                )
-                g2d.draw(rect)
+                g2d.draw(RoundRectangle2D.Float(0.75f, 0.75f, width - 1.5f, height - 1.5f, 14f, 14f))
 
                 super.paintComponent(g)
             }
-
         }.apply {
             isOpaque = false
-            border = BorderFactory.createEmptyBorder(5, 10, 5, 10)
+            layout = BoxLayout(this, BoxLayout.X_AXIS)
+            border = BorderFactory.createEmptyBorder(7, 12, 7, 12)
 
-            add(JButton("Translate").apply {
-                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                addActionListener { getSelectedImage()?.let(onCapture) }
-            })
-            add(JButton("Cancel").apply {
-                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                addActionListener { onCancel() }
-            })
+            // ── Group 1: primary action ──────────────────────────────────────
+            add(Box.createHorizontalStrut(2))
+            add(translateBtn)
+
+            // ── Separator ───────────────────────────────────────────────────
+            add(Box.createHorizontalStrut(10))
+            add(makeSeparator())
+            add(Box.createHorizontalStrut(6))
+
+            // ── Group 2: copy / save ─────────────────────────────────────────
+            add(copyTextBtn)
+            add(Box.createHorizontalStrut(2))
+            add(copyImageBtn)
+            add(Box.createHorizontalStrut(2))
+            add(saveImageBtn)
+
+            // ── Separator ───────────────────────────────────────────────────
+            add(Box.createHorizontalStrut(6))
+            add(makeSeparator())
+            add(Box.createHorizontalStrut(6))
+
+            // ── Group 3: utility ─────────────────────────────────────────────
+            add(recropBtn)
+            add(Box.createHorizontalStrut(2))
+            add(cancelBtn)
+            add(Box.createHorizontalStrut(2))
 
             size = preferredSize
         }
     }
 
+    /** Flat borderless toolbar-style button. */
+    private fun flatBtn(text: String, tooltip: String, action: () -> Unit): JButton =
+        JButton(text).apply {
+            putClientProperty(FlatClientProperties.BUTTON_TYPE, "toolBarButton")
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            toolTipText = tooltip
+            alignmentY = Component.CENTER_ALIGNMENT
+            addActionListener { action() }
+        }
+
+    /** Thin vertical divider painted inline with the button row. */
+    private fun makeSeparator(): Component = object : JComponent() {
+        init {
+            val h = 22
+            preferredSize = Dimension(1, h)
+            maximumSize  = Dimension(1, h)
+            minimumSize  = Dimension(1, h)
+            alignmentY   = Component.CENTER_ALIGNMENT
+        }
+        override fun paintComponent(g: Graphics) {
+            val c = UIManager.getColor("Component.borderColor") ?: Color(100, 100, 100)
+            g.color = Color(c.red, c.green, c.blue, 100)
+            g.drawLine(0, 2, 0, height - 2)
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Position helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
     fun calculateButtonsPosition(selection: Rectangle): Point {
         val panelSize = buttonsPanel.preferredSize
         val screenBounds = getVirtualScreenBounds()
-        val padding = 10
+        val padding = 12
 
         var x = selection.x + (selection.width - panelSize.width) / 2
         var y = selection.y + selection.height + padding

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/snippingtool/SnippingToolDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/snippingtool/SnippingToolDialog.kt
@@ -5,16 +5,18 @@ import com.github.ahatem.qtranslate.core.main.mvi.MainIntent
 import com.github.ahatem.qtranslate.core.main.mvi.MainStore
 import com.github.ahatem.qtranslate.ui.swing.shared.util.getVirtualScreenBounds
 import com.github.ahatem.qtranslate.ui.swing.shared.util.toImageData
-import java.awt.BorderLayout
-import java.awt.Frame
-import java.awt.Robot
+import java.awt.*
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
-import javax.swing.JComponent
-import javax.swing.JDialog
-import javax.swing.JFrame
-import javax.swing.KeyStroke
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import javax.swing.*
+import javax.swing.filechooser.FileNameExtensionFilter
 
 class SnippingToolDialog(
     owner: Frame,
@@ -42,9 +44,24 @@ class SnippingToolDialog(
         }
 
         panel = ScreenCapturePanel(
-            onCapture = { capturedImage ->
+            onTranslate = { capturedImage ->
                 val imageData = capturedImage.toImageData("png")
                 dispatchOcrAndTranslate(imageData)
+            },
+            onCopyText = { capturedImage ->
+                val imageData = capturedImage.toImageData("png")
+                dispatchOcrAndCopyText(imageData)
+            },
+            onCopyImage = { capturedImage ->
+                copyImageToClipboard(capturedImage)
+                dispose()
+            },
+            onSaveImage = { capturedImage ->
+                saveImageToFile(capturedImage)
+                dispose()
+            },
+            onRecrop = {
+                controller.resetToIdle()
             },
             onCancel = {
                 dispose()
@@ -69,6 +86,41 @@ class SnippingToolDialog(
             it.toFront()
         }
         dispose()
+    }
+
+    private fun dispatchOcrAndCopyText(image: ImageData) {
+        mainStore.dispatch(MainIntent.OcrAndCopyText(image))
+        dispose()
+    }
+
+    private fun copyImageToClipboard(image: BufferedImage) {
+        val transferable = object : Transferable {
+            override fun getTransferDataFlavors() = arrayOf(DataFlavor.imageFlavor)
+            override fun isDataFlavorSupported(flavor: DataFlavor) = flavor == DataFlavor.imageFlavor
+            @Throws(UnsupportedFlavorException::class)
+            override fun getTransferData(flavor: DataFlavor): Any {
+                if (!isDataFlavorSupported(flavor)) throw UnsupportedFlavorException(flavor)
+                return image
+            }
+        }
+        runCatching {
+            Toolkit.getDefaultToolkit().systemClipboard.setContents(transferable, null)
+        }
+    }
+
+    private fun saveImageToFile(image: BufferedImage) {
+        val chooser = JFileChooser().apply {
+            dialogTitle = "Save Captured Image"
+            fileFilter = FileNameExtensionFilter("PNG Image (*.png)", "png")
+            selectedFile = File("screenshot.png")
+        }
+        if (chooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
+            var file = chooser.selectedFile
+            if (!file.name.endsWith(".png", ignoreCase = true)) {
+                file = File("${file.absolutePath}.png")
+            }
+            runCatching { ImageIO.write(image, "PNG", file) }
+        }
     }
 
     private fun setupListeners() {


### PR DESCRIPTION
## What does this PR do?

Improves Look and Feel (L&F) handling for dictionary and status bar UI components to ensure colors, borders, icons, and custom-rendered components refresh correctly when the application theme changes.

This refactor centralizes theme-dependent styling into dedicated refresh methods and updates components safely through `updateUI()` lifecycle hooks.

Changes include:
- Theme-aware icon, label, and border refreshing in DictionaryPanel
- Safe UI refresh handling during Swing initialization
- Dynamic StatusBar border and chip updates on L&F changes
- Improved StatusChip color resolution and contrast handling
- Better rendering quality for chip text and borders

## Related issues

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)