### PR TITLE
refactor(core): clarify app data override handling

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDataDirectory.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDataDirectory.kt
@@ -38,9 +38,10 @@ object AppDataDirectory {
      * Returns the resolved app data directory, creating it if it does not exist.
      */
     fun resolve(): File {
-        // Debug override — set -DappData="C:\path\to\data" in your run config.
-        // Never set in production; falls through to the normal resolution below.
-        System.getProperty("appData")?.let { return File(it).also { f -> f.mkdirs() } }
+        System.getProperty("appData")?.let {
+            val file = File(it)
+            return file.also { f -> f.mkdirs() }
+        }
 
         val jarDir = jarLocation()
         if (jarDir != null && jarDir.canWrite()) {


### PR DESCRIPTION
## What does this PR do?

Cleans up the app data directory resolution logic by making the `appData` system property override handling more explicit and readable.

The behavior remains unchanged: when `-DappData=/path/to/data` is provided, the app uses that directory and ensures it exists before falling back to the JAR directory or OS-specific app data location.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [ ] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)