### PR TITLE
fix: backward translation status stuck, history bugs (A-1/A-2), plugin icon theme

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/history/HistorySnapshot.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/history/HistorySnapshot.kt
@@ -9,5 +9,11 @@ data class HistorySnapshot(
     val sourceLanguage: String,
     val targetLanguage: String,
     val translatorId: String,
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    /** The language actually detected when source was AUTO; null if source was explicit. */
+    val detectedSourceLanguage: String? = null,
+    /** Extra output text (backward translation, summary, or rewrite) at the time of translation. */
+    val extraOutputText: String = "",
+    /** Serialized [com.github.ahatem.qtranslate.core.settings.data.ExtraOutputType] name. */
+    val extraOutputType: String = "None"
 )

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
@@ -172,7 +172,8 @@ class TranslateTextUseCase(
                         onStatusUpdate(StatusCode.TranslationComplete, NotificationType.SUCCESS, true)
 
                         val (newHistory, newHistoryIndex) = buildHistory(
-                            currentState, textToTranslate, response.translatedText, translator.id
+                            currentState, textToTranslate, response.translatedText, translator.id,
+                            detectedSourceLanguage = detectedLanguage?.tag
                         )
 
                         val extraOutput = handleExtraOutput(
@@ -183,19 +184,23 @@ class TranslateTextUseCase(
                             onStatusUpdate    = onStatusUpdate
                         )
 
+                        val finalHistory = patchExtraOutput(
+                            newHistory, extraOutput, settingsState.value.extraOutputType.name
+                        )
+
                         updateState {
                             copy(
                                 isLoading              = false,
                                 translatedText         = response.translatedText,
                                 detectedSourceLanguage = detectedLanguage,
-                                history                = newHistory,
+                                history                = finalHistory,
                                 historyIndex           = newHistoryIndex,
                                 extraOutputText        = extraOutput
                             )
                         }
 
                         if (settingsState.value.isHistoryEnabled) {
-                            historyRepository.saveHistory(newHistory)
+                            historyRepository.saveHistory(finalHistory)
                         }
                     },
                     failure = { error ->
@@ -257,7 +262,8 @@ class TranslateTextUseCase(
                 onStatusUpdate(StatusCode.TranslationComplete, NotificationType.SUCCESS, true)
 
                 val (newHistory, newHistoryIndex) = buildHistory(
-                    currentState, textToTranslate, retryResponse.translatedText, translator.id
+                    currentState, textToTranslate, retryResponse.translatedText, translator.id,
+                    detectedSourceLanguage = detectedLanguage.tag
                 )
 
                 val extraOutput = handleExtraOutput(
@@ -268,20 +274,24 @@ class TranslateTextUseCase(
                     onStatusUpdate    = onStatusUpdate
                 )
 
+                val finalHistory = patchExtraOutput(
+                    newHistory, extraOutput, settingsState.value.extraOutputType.name
+                )
+
                 updateState {
                     copy(
                         isLoading              = false,
                         translatedText         = retryResponse.translatedText,
                         detectedSourceLanguage = detectedLanguage,
                         targetLanguage         = ruleTarget,
-                        history                = newHistory,
+                        history                = finalHistory,
                         historyIndex           = newHistoryIndex,
                         extraOutputText        = extraOutput
                     )
                 }
 
                 if (settingsState.value.isHistoryEnabled) {
-                    historyRepository.saveHistory(newHistory)
+                    historyRepository.saveHistory(finalHistory)
                 }
             },
             failure = { error ->
@@ -312,18 +322,20 @@ class TranslateTextUseCase(
         currentState: MainState,
         inputText: String,
         translatedText: String,
-        translatorId: String
+        translatorId: String,
+        detectedSourceLanguage: String? = null
     ): Pair<List<HistorySnapshot>, Int> {
         if (!settingsState.value.isHistoryEnabled) {
             return currentState.history to currentState.historyIndex
         }
 
         val snapshot = HistorySnapshot(
-            inputText      = inputText,
-            translatedText = translatedText,
-            sourceLanguage = currentState.sourceLanguage.tag,
-            targetLanguage = currentState.targetLanguage.tag,
-            translatorId   = translatorId
+            inputText              = inputText,
+            translatedText         = translatedText,
+            sourceLanguage         = currentState.sourceLanguage.tag,
+            targetLanguage         = currentState.targetLanguage.tag,
+            translatorId           = translatorId,
+            detectedSourceLanguage = detectedSourceLanguage
         )
 
         // Truncate any "future" entries that were undone before this new translation,
@@ -333,6 +345,20 @@ class TranslateTextUseCase(
 
         logger.debug("History: ${updated.size}/${AppConstants.MAX_HISTORY_ENTRIES} entries")
         return updated to updated.size
+    }
+
+    /** Patches the last snapshot in [history] with the resolved extra output. */
+    private fun patchExtraOutput(
+        history: List<HistorySnapshot>,
+        extraOutputText: String,
+        extraOutputType: String
+    ): List<HistorySnapshot> {
+        if (history.isEmpty() || (extraOutputText.isEmpty() && extraOutputType == "None")) return history
+        val patched = history.last().copy(
+            extraOutputText = extraOutputText,
+            extraOutputType = extraOutputType
+        )
+        return history.dropLast(1) + patched
     }
 
     // -------------------------------------------------------------------------
@@ -395,15 +421,18 @@ class TranslateTextUseCase(
 
         return if (result == null) {
             logger.error("Backward translation timed out")
+            onStatusUpdate(StatusCode.TranslationComplete, NotificationType.SUCCESS, true)
             "Backward translation timed out."
         } else {
             result.fold(
                 success = { response ->
                     logger.debug("Backward translation successful")
+                    onStatusUpdate(StatusCode.TranslationComplete, NotificationType.SUCCESS, true)
                     response.translatedText
                 },
                 failure = { error ->
                     logger.error("Backward translation failed: ${error.message}", error.cause)
+                    onStatusUpdate(StatusCode.TranslationComplete, NotificationType.SUCCESS, true)
                     "Backward translation failed: ${error.message}"
                 }
             )

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -410,8 +410,8 @@ class MainStore(
                 targetLanguage         = LanguageCode(snapshot.targetLanguage),
                 historyIndex           = newIndex,
                 isLoading              = false,
-                extraOutputText        = "",
-                detectedSourceLanguage = null,
+                extraOutputText        = snapshot.extraOutputText,
+                detectedSourceLanguage = snapshot.detectedSourceLanguage?.let { tag -> LanguageCode(tag) },
                 spellCheckCorrections  = emptyList()
             )
         }
@@ -450,8 +450,8 @@ class MainStore(
                     targetLanguage         = LanguageCode(snapshot.targetLanguage),
                     historyIndex           = newIndex,
                     isLoading              = false,
-                    extraOutputText        = "",
-                    detectedSourceLanguage = null,
+                    extraOutputText        = snapshot.extraOutputText,
+                    detectedSourceLanguage = snapshot.detectedSourceLanguage?.let { tag -> LanguageCode(tag) },
                     spellCheckCorrections  = emptyList()
                 )
             }
@@ -469,8 +469,8 @@ class MainStore(
                 targetLanguage         = LanguageCode(snapshot.targetLanguage),
                 historyIndex           = if (idx >= 0) idx + 1 else it.historyIndex,
                 isLoading              = false,
-                extraOutputText        = "",
-                detectedSourceLanguage = null,
+                extraOutputText        = snapshot.extraOutputText,
+                detectedSourceLanguage = snapshot.detectedSourceLanguage?.let { tag -> LanguageCode(tag) },
                 spellCheckCorrections  = emptyList()
             )
         }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
@@ -218,7 +218,9 @@ class PluginsPanel(
         val headerIcon: Icon = if (pluginIconPath != null && serviceId != null)
             iconManager.getIcon(serviceId, pluginIconPath, 24, 24)
         else
-            iconManager.getIcon("icons/lucide/package.svg", 24, 24)
+            FlatSVGIcon("icons/lucide/package.svg", 24, 24, javaClass.classLoader).apply {
+                colorFilter = FlatSVGIcon.ColorFilter { UIManager.getColor("Label.foreground") }
+            }
 
         val nameLabel = JLabel(plugin.manifest.name).apply {
             font = font.deriveFont(Font.BOLD, font.size + 2f)
@@ -560,7 +562,9 @@ class PluginsPanel(
                 plugin.services.firstOrNull()?.id?.let { svc ->
                     iconManager.getIcon(svc, path, 15, 15)
                 }
-            } ?: iconManager.getIcon("icons/lucide/package.svg", 15, 15)
+            } ?: FlatSVGIcon("icons/lucide/package.svg", 15, 15, javaClass.classLoader).apply {
+                colorFilter = FlatSVGIcon.ColorFilter { UIManager.getColor("Label.foreground") }
+            }
 
             val nameLabel = JLabel(plugin.manifest.name, icon, SwingConstants.LEADING).apply {
                 font        = font.deriveFont(Font.BOLD)


### PR DESCRIPTION
## What does this PR do?

**Backward translation status stuck (new fix)**
`PerformingBackwardTranslation` was emitted with `isTemporary=false` but never cleared. `performBackwardTranslation` now emits `TranslationComplete` on all exit paths (success, failure, timeout) so the status bar always returns to idle. An earlier attempt to fix this by moving `TranslationComplete` after `handleExtraOutput()` was reverted — it incorrectly replaced summarize/rewrite error statuses.

**A-1 — History loses detected language on AUTO source**
`HistorySnapshot` stored `sourceLanguage = "auto"` instead of the actual detected language. Added `detectedSourceLanguage: String?` to the snapshot, populated from the translation response, and restored on undo/redo/history restore.

**A-2 — Undo/redo loses extra output**
`extraOutputText` was not stored in `HistorySnapshot`, so navigating history always cleared summaries and rewrites. Added `extraOutputText: String` and `extraOutputType: String` to the snapshot, patched after extra output resolves, and restored on undo/redo/history restore.

**Plugin icon dark on disabled plugins**
The fallback package icon rendered in black regardless of theme. Both the plugin list cell renderer and detail panel now create the icon directly with a `Label.foreground` color filter so it adapts to dark and light themes.

## Related issues

Closes A-1, A-2 from pre-release checklist.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

N/A — status bar and icon behavior changes, no layout changes.