### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
@@ -15,7 +15,7 @@ object AppConstants {
      * Used by [com.github.ahatem.qtranslate.core.main.domain.usecase.CheckForUpdatesUseCase]
      * to compare against the latest release.
      */
-    const val APP_VERSION = "1.1.0"
+    const val APP_VERSION = "1.2.0"
 
     // ============================================================
     // Timing


### PR DESCRIPTION
## What does this PR do?

Bumps `AppConstants.APP_VERSION` from `1.1.0` to `1.2.0` ahead of the v1.2.0 release tag.

## Related issues

N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

N/A