### PR TITLE
chore: mark v1.2.0 in CHANGELOG and update comparison links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [1.2.0] — 2026-05-10
+
 ### Added
 - **Quick Dictionary** — global `Ctrl+D` hotkey, floating panel with auto-lookup on selected text
 - **Translation history** dialog — view, restore, and clear past translations
@@ -96,6 +100,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/ahatem/QTranslate/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ahatem/QTranslate/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ahatem/QTranslate/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ahatem/QTranslate/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ahatem/QTranslate/releases/tag/v1.0.0


### PR DESCRIPTION
## What does this PR do?

Post-release CHANGELOG housekeeping:

- Renames `[Unreleased]` section to `[1.2.0] — 2026-05-10`
- Adds a fresh empty `[Unreleased]` section at the top for future work
- Updates comparison links at the bottom (`[Unreleased]` now compares against `v1.2.0`)

## Related issues

N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

N/A