### PR TITLE
fix: remember target language across sessions

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -55,7 +55,9 @@ class MainStore(
     private val _state = MutableStateFlow(
         MainState(
             isDictionaryPanelVisible = settingsState.value.showDictionaryPanel,
-            isQuickDictionaryPinned  = settingsState.value.isQuickDictionaryPinned
+            isQuickDictionaryPinned  = settingsState.value.isQuickDictionaryPinned,
+            targetLanguage           = LanguageCode(settingsState.value.preferredTargetLanguage),
+            sourceLanguage           = LanguageCode(settingsState.value.preferredSourceLanguage)
         )
     )
     override val state: StateFlow<MainState> = _state.asStateFlow()
@@ -86,13 +88,30 @@ class MainStore(
     private fun observeAvailableServices() {
         scope.launch {
             selectActiveServiceUseCase.observe().collect { selection ->
-                _state.update {
-                    it.copy(
-                        availableServices = selection.availableServices,
-                        availableLanguages = selection.availableLanguages.sortedWith(
-                            compareBy<LanguageCode> { lc -> lc.tag != "auto" }
-                                .thenBy { lc -> lc.getDisplayName() }
-                        )
+                _state.update { current ->
+                    val sortedLanguages = selection.availableLanguages.sortedWith(
+                        compareBy<LanguageCode> { lc -> lc.tag != "auto" }
+                            .thenBy { lc -> lc.getDisplayName() }
+                    )
+
+                    // If the previously selected target language is not available in the new
+                    // list (e.g. because pinnedLanguages hides it, or the translator doesn't
+                    // support it), fall back to the saved preference then to the first available
+                    // non-auto language so the user is never silently translated to the wrong language.
+                    val targetLang = when {
+                        current.targetLanguage in sortedLanguages -> current.targetLanguage
+                        else -> {
+                            val preferred = LanguageCode(settingsState.value.preferredTargetLanguage)
+                            sortedLanguages.firstOrNull { it == preferred }
+                                ?: sortedLanguages.firstOrNull { it.tag != "auto" }
+                                ?: current.targetLanguage
+                        }
+                    }
+
+                    current.copy(
+                        availableServices  = selection.availableServices,
+                        availableLanguages = sortedLanguages,
+                        targetLanguage     = targetLang
                     )
                 }
             }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -243,6 +243,20 @@ data class Configuration(
     val isRemoveLineBreaksEnabled: Boolean = false,
     val translationRules: List<TranslationRule> = emptyList(),
 
+    // ---- Language Preferences ----
+    /**
+     * The language tag ("en", "fr", "ar", …) last selected as the target language.
+     * Restored on startup so the app remembers the user's preferred language across sessions.
+     * Defaults to "en" (English) so new users see a sensible translation immediately.
+     */
+    val preferredTargetLanguage: String = "en",
+
+    /**
+     * The language tag last selected as the source language, or "auto" for auto-detect.
+     * Restored on startup.
+     */
+    val preferredSourceLanguage: String = "auto",
+
     // ---- Language Filtering ----
     /**
      * When non-empty, only these language codes appear in the target language picker.

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -157,6 +157,9 @@ window_layout = "Window & Layout"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_group = "Startup"
 startup_updates_group = "Startup & Updates"
 launch_on_startup = "Launch on system startup"

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -160,6 +160,9 @@ window_layout = "النافذة والتخطيط"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "بدء التشغيل والتحديثات"
 startup_group = "بدء التشغيل"
 launch_on_startup = "التشغيل عند بدء تشغيل النظام"

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -160,6 +160,9 @@ window_layout = "উইন্ডো এবং লেআউট"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "স্টার্টআপ ও আপডেট"
 startup_group = "স্টার্টআপ"
 launch_on_startup = "সিস্টেম স্টার্টআপে চালু করুন"

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -160,6 +160,9 @@ window_layout = "Fenster & Layout"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Start & Updates"
 startup_group = "Systemstart"
 launch_on_startup = "Mit dem System starten"

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -160,6 +160,9 @@ window_layout = "Window & Layout"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Startup & Updates"
 startup_group = "Startup"
 launch_on_startup = "Launch on system startup"

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -160,6 +160,9 @@ window_layout = "Ventana y Diseño"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Inicio y actualizaciones"
 startup_group = "Inicio"
 launch_on_startup = "Ejecutar al iniciar el sistema"

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -160,6 +160,9 @@ window_layout = "Fenêtre & Mise en page"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Démarrage et mises à jour"
 startup_group = "Démarrage"
 launch_on_startup = "Lancer au démarrage du système"

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -160,6 +160,9 @@ window_layout = "Ablak és elrendezés"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Indítás és frissítések"
 startup_group = "Indítás"
 launch_on_startup = "Indítás a rendszer indulásakor"

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -160,6 +160,9 @@ window_layout = "Finestra e layout"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Avvio e aggiornamenti"
 startup_group = "Avvio"
 launch_on_startup = "Esegui all'avvio del sistema"

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -160,6 +160,9 @@ window_layout = "ウィンドウとレイアウト"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "起動と更新"
 startup_group = "起動"
 launch_on_startup = "システム起動時に実行"

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -160,6 +160,9 @@ window_layout = "Janela e Layout"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Inicialização e Atualizações"
 startup_group = "Inicialização"
 launch_on_startup = "Iniciar com o sistema"

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -160,6 +160,9 @@ window_layout = "Окно и интерфейс"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Запуск и обновления"
 startup_group = "Запуск"
 launch_on_startup = "Запускать при старте системы"

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -160,6 +160,9 @@ window_layout = "Pencere ve Düzen"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "Başlangıç ve Güncellemeler"
 startup_group = "Başlangıç"
 launch_on_startup = "Sistem başlangıcında çalıştır"

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -160,6 +160,9 @@ window_layout = "窗口与布局"
 # ===================================================================
 
 [settings_general]
+default_language_group = "Default Language"
+default_target_language = "Default Target Language:"
+default_target_language_hint = "The target language selected when the app starts. Your choice is remembered automatically after you change it in the main window."
 startup_updates_group = "启动与更新"
 startup_group = "启动"
 launch_on_startup = "开机自启动"

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -132,7 +132,8 @@ class MainAppFrame(
         pluginManager = pluginManager,
         iconManager = iconManager,
         themeManager = themeManager,
-        localizationManager = localizer
+        localizationManager = localizer,
+        availableLanguages = { mainStore.state.value.availableLanguages }
     )
 
     private val mainContentView: MainContentView = MainContentView(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -78,9 +78,15 @@ class MainContentView(
         iconManager = iconManager,
         localizer = localizer,
         onClear = { dispatch(MainIntent.UpdateInputText("")) },
-        onSourceLanguageSelected = { lang -> dispatch(MainIntent.SelectSourceLanguage(lang)) },
+        onSourceLanguageSelected = { lang ->
+            dispatch(MainIntent.SelectSourceLanguage(lang))
+            dispatchSettings(SettingsIntent.ToggleSetting { it.copy(preferredSourceLanguage = lang.tag) })
+        },
         onSwap = { dispatch(MainIntent.SwapLanguages) },
-        onTargetLanguageSelected = { lang -> dispatch(MainIntent.SelectTargetLanguage(lang)) },
+        onTargetLanguageSelected = { lang ->
+            dispatch(MainIntent.SelectTargetLanguage(lang))
+            dispatchSettings(SettingsIntent.ToggleSetting { it.copy(preferredTargetLanguage = lang.tag) })
+        },
         onTranslate = { dispatch(MainIntent.Translate()) },
         onCancel = { dispatch(MainIntent.CancelTranslation) }
     )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
@@ -33,7 +33,13 @@ class SettingsDialog(
     private val pluginManager: PluginManager,
     private val iconManager: IconManager,
     private val themeManager: ThemeManager,
-    private val localizationManager: LocalizationManager
+    private val localizationManager: LocalizationManager,
+    /**
+     * Snapshot of languages currently supported by the active translator.
+     * Evaluated lazily so [GeneralPanel] always gets the latest list when
+     * it renders — not whatever was available when the dialog was constructed.
+     */
+    private val availableLanguages: () -> List<com.github.ahatem.qtranslate.api.language.LanguageCode> = { emptyList() }
 ) : JDialog(owner, "Settings", true) {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -267,7 +273,7 @@ class SettingsDialog(
 
     private fun createPanel(name: String): JPanel = when (name) {
         localizationManager.getString("settings_dialog_sidebar.general") ->
-            GeneralPanel(settingsStore, localizationManager)
+            GeneralPanel(settingsStore, localizationManager, availableLanguages)
 
         localizationManager.getString("settings_dialog_sidebar.appearance") ->
             AppearancePanel(settingsStore, themeManager, localizationManager, scope)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/GeneralPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/GeneralPanel.kt
@@ -1,20 +1,52 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
+import com.github.ahatem.qtranslate.api.language.LanguageCode
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsState
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsStore
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.LanguageComboBox
 import javax.swing.JCheckBox
 
-class GeneralPanel(private val store: SettingsStore, private val localizationManager: LocalizationManager) : SettingsPanel() {
+class GeneralPanel(
+    private val store: SettingsStore,
+    private val localizationManager: LocalizationManager,
+    /**
+     * Returns the current list of languages supported by the active translator.
+     * Evaluated at render time so it is always up-to-date.
+     * AUTO is excluded — a default *target* language must be a concrete language.
+     */
+    private val availableLanguages: () -> List<LanguageCode>
+) : SettingsPanel() {
 
     private lateinit var launchCheckbox:  JCheckBox
     private lateinit var updatesCheckbox: JCheckBox
     private lateinit var historyCheckbox: JCheckBox
     private lateinit var clearCheckbox:   JCheckBox
 
+    /**
+     * Picker for the default target language restored on every app startup.
+     * Uses the same [LanguageComboBox] as the main window so search-by-typing,
+     * RTL rendering, and display names are all consistent.
+     */
+    private val defaultLanguageCombo = LanguageComboBox(
+        onLanguageSelected = { lang ->
+            if (!isUpdatingFromState)
+                applyDraft(store) { it.copy(preferredTargetLanguage = lang.tag) }
+        },
+        localizer = localizationManager
+    )
+
     init { buildUI() }
 
     private fun buildUI() {
+        // ── Default Language
+        addSeparator(localizationManager.getString("settings_general.default_language_group"))
+        addRow(
+            localizationManager.getString("settings_general.default_target_language"),
+            defaultLanguageCombo
+        )
+        addHint(localizationManager.getString("settings_general.default_target_language_hint"))
+
         // ── Startup & Updates (merged — two closely related checkboxes, not two separate sections)
         addSeparator(localizationManager.getString("settings_general.startup_updates_group"))
 
@@ -52,7 +84,19 @@ class GeneralPanel(private val store: SettingsStore, private val localizationMan
 
     override fun render(state: SettingsState) {
         val c = state.workingConfiguration
+
+        // Exclude AUTO — a default target language must be a concrete language.
+        val langs = availableLanguages().filter { it.tag != "auto" }
+        val preferred = LanguageCode(c.preferredTargetLanguage)
+
         withoutTrigger {
+            defaultLanguageCombo.render(
+                availableLanguages    = langs,
+                selectedLanguage      = preferred,
+                autoDetectedLanguage  = null,
+                isEnabled             = langs.isNotEmpty()
+            )
+
             launchCheckbox.isSelected  = c.launchOnSystemStartup
             updatesCheckbox.isSelected = c.autoCheckForUpdates
             historyCheckbox.isSelected = c.isHistoryEnabled

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/LanguageComboBox.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/LanguageComboBox.kt
@@ -82,7 +82,13 @@ class LanguageComboBox(
                 currentLanguages = availableLanguages
             }
 
-            this.selectedItem = selectedLanguage
+            // Only update the selection when the language is actually present in the current model.
+            // If the model is still empty (plugins not yet loaded) or the language was filtered out
+            // by pinnedLanguages, leave the current selection untouched so we don't silently
+            // display the wrong language or trigger a spurious onLanguageSelected callback.
+            if (selectedLanguage != null && selectedLanguage in availableLanguages) {
+                this.selectedItem = selectedLanguage
+            }
             this.isEnabled = isEnabled
             isRendering = false
         }


### PR DESCRIPTION
## What does this PR do?

On every launch the app translated to Arabic regardless of what the user had previously selected. The user had to open the dropdown, pick a different language, then re-pick their preferred one just to \"activate\" it.

Root causes fixed:
- `MainState` hard-coded `targetLanguage = LanguageCode.ARABIC` — never read from saved settings
- `Configuration` had no `preferredTargetLanguage` / `preferredSourceLanguage` fields
- `MainStore` initial state never loaded the language pair from config
- `LanguageComboBox.render()` called `setSelectedItem` unconditionally, including when the language wasn't in the model yet (plugins still loading) — causing spurious callbacks
- When `pinnedLanguages` filtered out the active target, the combo showed a different language but translations still went to the wrong one

Changes:
- Add `preferredTargetLanguage` (`"en"`) and `preferredSourceLanguage` (`"auto"`) to `Configuration`; old configs pick up the defaults via kotlinx.serialization without a migration step
- Restore both into `MainState` when `MainStore` is constructed
- `observeAvailableServices()` now corrects `targetLanguage` when it isn't in the newly loaded list (also handles the `pinnedLanguages` filtering edge case)
- Every explicit language selection now dispatches `SettingsIntent.ToggleSetting` to persist the choice immediately
- `LanguageComboBox.render()` now guards `setSelectedItem` — only fires when the language is actually in the current model
- New **Default Target Language** picker added to **Settings → General** so users can configure the startup default without touching the main window

## Related issues

Closes #92

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

**Settings → General — new Default Language section:**

The new picker appears at the top of the General settings panel. It is populated with languages from the active translator and defaults to English for new installs.