### PR TITLE
fix: keyboard nav, configurable focus shortcuts & Compact layout tab switching

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
@@ -17,7 +17,7 @@ import com.github.ahatem.qtranslate.api.core.Logger
 object ConfigMigrator {
 
     /** Must match the default value of [Configuration.configVersion]. */
-    private const val CURRENT_VERSION = 1
+    private const val CURRENT_VERSION = 2
 
     /**
      * Applies all pending migrations to [config] in order and returns the result.
@@ -43,12 +43,18 @@ object ConfigMigrator {
 
     private fun applyMigration(config: Configuration, logger: Logger): Configuration =
         when (config.configVersion) {
-            // v1 is the initial schema — nothing to migrate yet.
-            // Future example:
-            //   1 -> {
-            //       logger.info("ConfigMigrator: migrating v1 → v2")
-            //       config.copy(configVersion = 2, newField = computedDefault)
-            //   }
+            1 -> {
+                // v1 → v2: inject default bindings for any HotkeyActions that were added after the
+                // user's config was first saved (FOCUS_INPUT, FOCUS_OUTPUT, FOCUS_EXTRA_OUTPUT).
+                // This is safe to run repeatedly — it only adds bindings that are missing.
+                logger.info("ConfigMigrator: migrating v1 → v2 — patching missing hotkey defaults")
+                val existingActions = config.hotkeys.map { it.action }.toSet()
+                val missingDefaults = HotkeyBinding.DEFAULTS.filter { it.action !in existingActions }
+                config.copy(
+                    configVersion = 2,
+                    hotkeys = config.hotkeys + missingDefaults
+                )
+            }
             else -> {
                 logger.warn("ConfigMigrator: unknown configVersion ${config.configVersion} — returning unchanged")
                 config

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -81,7 +81,10 @@ enum class HotkeyAction {
     REPLACE_WITH_TRANSLATION,  // Rob #2 / Davide — translate and replace selected text
     CYCLE_TARGET_LANGUAGE,     // Yan #3 — cycle through available target languages
     SHOW_DICTIONARY,           // open floating dictionary popup
-    TRANSLATE                  // trigger translation (default: Ctrl+Enter, LOCAL)
+    TRANSLATE,                 // trigger translation (default: Ctrl+Enter, LOCAL)
+    FOCUS_INPUT,               // move keyboard focus to the input text pane (default: Alt+1, LOCAL)
+    FOCUS_OUTPUT,              // move keyboard focus to the output text pane (default: Alt+2, LOCAL)
+    FOCUS_EXTRA_OUTPUT         // move keyboard focus to the extra-output pane (default: Alt+3, LOCAL)
 }
 
 /**
@@ -154,6 +157,9 @@ data class HotkeyBinding(
             HotkeyBinding(HotkeyAction.CYCLE_TARGET_LANGUAGE,    keyCode = java.awt.event.KeyEvent.VK_L,               modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK,  scope = HotkeyScope.LOCAL),
             HotkeyBinding(HotkeyAction.SHOW_DICTIONARY,          keyCode = java.awt.event.KeyEvent.VK_D,               modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK,  scope = HotkeyScope.GLOBAL),
             HotkeyBinding(HotkeyAction.TRANSLATE,                keyCode = java.awt.event.KeyEvent.VK_ENTER,            modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK,  scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.FOCUS_INPUT,              keyCode = java.awt.event.KeyEvent.VK_1,                modifiers = java.awt.event.InputEvent.ALT_DOWN_MASK,   scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.FOCUS_OUTPUT,             keyCode = java.awt.event.KeyEvent.VK_2,                modifiers = java.awt.event.InputEvent.ALT_DOWN_MASK,   scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.FOCUS_EXTRA_OUTPUT,       keyCode = java.awt.event.KeyEvent.VK_3,                modifiers = java.awt.event.InputEvent.ALT_DOWN_MASK,   scope = HotkeyScope.LOCAL),
         )
     }
 }

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -264,6 +264,9 @@ action_replace = "Replace Selection with Translation (experimental)"
 action_cycle_language = "Cycle Target Language"
 action_show_dictionary = "Show Dictionary"
 action_translate = "Translate"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Click to toggle between Global and Local"
 
 # Default Actions Descriptions
@@ -544,3 +547,8 @@ dictionary_ready = "Definition found."
 dictionary_not_found = "No definitions found for \"%s\"."
 dictionary_timeout = "Dictionary lookup timed out."
 dictionary_failed = "Dictionary lookup failed: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -267,6 +267,9 @@ action_replace = "استبدال المحدد بالترجمة (تجريبي)"
 action_cycle_language = "تبديل لغة الهدف"
 action_show_dictionary = "فتح القاموس"
 action_translate = "ترجمة"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "انقر للتبديل بين العالمي والمحلي"
 
 # Default Actions Descriptions
@@ -538,3 +541,8 @@ dictionary_ready = "تم العثور على التعريف."
 dictionary_not_found = "لم يُعثر على تعريف لـ \"%s\"."
 dictionary_timeout = "انتهت مهلة البحث في القاموس."
 dictionary_failed = "فشل البحث في القاموس: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -267,6 +267,9 @@ action_replace = "অনুবাদ দিয়ে নির্বাচন �
 action_cycle_language = "টার্গেট ভাষা পরিবর্তন (সাইকেল)"
 action_show_dictionary = "অভিধান দেখান"
 action_translate = "অনুবাদ করুন"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "গ্লোবাল এবং লোকাল এর মধ্যে পরিবর্তন করতে ক্লিক করুন"
 
 # Default Actions Descriptions
@@ -538,3 +541,8 @@ dictionary_ready = "সংজ্ঞা পাওয়া গেছে।"
 dictionary_not_found = "\"%s\" এর জন্য কোনো সংজ্ঞা পাওয়া যায়নি।"
 dictionary_timeout = "অভিধান অনুসন্ধানের সময় শেষ হয়ে গেছে।"
 dictionary_failed = "অভিধান অনুসন্ধান ব্যর্থ হয়েছে: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -267,6 +267,9 @@ action_replace = "Auswahl durch Übersetzung ersetzen (exp.)"
 action_cycle_language = "Zielsprache wechseln"
 action_show_dictionary = "Wörterbuch anzeigen"
 action_translate = "Übersetzen"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Klicken, um zwischen Global und Lokal zu wechseln"
 
 # Default Actions Descriptions
@@ -538,3 +541,8 @@ dictionary_ready = "Definition gefunden."
 dictionary_not_found = "Keine Definition für \"%s\" gefunden."
 dictionary_timeout = "Wörterbuchabfrage abgelaufen."
 dictionary_failed = "Wörterbuchabfrage fehlgeschlagen: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -267,6 +267,9 @@ action_replace = "Replace Selection with Translation (experimental)"
 action_cycle_language = "Cycle Target Language"
 action_show_dictionary = "Show Dictionary"
 action_translate = "Translate"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Click to toggle between Global and Local"
 
 # Default Actions Descriptions
@@ -537,3 +540,8 @@ dictionary_ready = "Definition found."
 dictionary_not_found = "No definitions found for \"%s\"."
 dictionary_timeout = "Dictionary lookup timed out."
 dictionary_failed = "Dictionary lookup failed: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -267,6 +267,9 @@ action_replace = "Reemplazar Selección con Traducción (experimental)"
 action_cycle_language = "Ciclar Idioma de Destino"
 action_show_dictionary = "Mostrar diccionario"
 action_translate = "Traducir"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Haga clic para cambiar entre Global y Local"
 
 # Default Actions Descriptions
@@ -538,3 +541,8 @@ dictionary_ready = "Definición encontrada."
 dictionary_not_found = "No se encontraron definiciones para \"%s\"."
 dictionary_timeout = "La búsqueda en el diccionario ha superado el tiempo límite."
 dictionary_failed = "La búsqueda en el diccionario falló: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -267,6 +267,9 @@ action_replace = "Remplacer la sélection par la traduction (expérimental)"
 action_cycle_language = "Changer la langue cible"
 action_show_dictionary = "Afficher le dictionnaire"
 action_translate = "Traduire"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Cliquez pour basculer entre Global et Local"
 
 # Default Actions Descriptions
@@ -536,3 +539,8 @@ dictionary_ready = "Définition trouvée."
 dictionary_not_found = "Aucune définition trouvée pour \"%s\"."
 dictionary_timeout = "La recherche dans le dictionnaire a expiré."
 dictionary_failed = "La recherche dans le dictionnaire a échoué : %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -267,6 +267,9 @@ action_replace = "A kiválasztás lecserélése fordításra (kísérleti)"
 action_cycle_language = "Célnyelv váltása"
 action_show_dictionary = "Szótár megjelenítése"
 action_translate = "Fordítás"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Kattintson a Globális és a Helyi közötti váltáshoz"
 
 # Default Actions Descriptions
@@ -536,3 +539,8 @@ dictionary_ready = "Meghatározás megtalálva."
 dictionary_not_found = "Nem találtunk meghatározást a következőre: \"%s\"."
 dictionary_timeout = "A szótárkeresés túllépte az időkorlátot."
 dictionary_failed = "A szótárkeresés sikertelen: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -267,6 +267,9 @@ action_replace = "Sostituisci selezione con traduzione (sperimentale)"
 action_cycle_language = "Cambia lingua destinazione"
 action_show_dictionary = "Mostra dizionario"
 action_translate = "Traduci"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Fai clic per cambiare da globale a locale"
 
 # Default Actions Descriptions
@@ -536,3 +539,8 @@ dictionary_ready = "Definizione trovata."
 dictionary_not_found = "Nessuna definizione trovata per \"%s\"."
 dictionary_timeout = "Ricerca nel dizionario scaduta."
 dictionary_failed = "Ricerca nel dizionario fallita: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -267,6 +267,9 @@ action_replace = "選択範囲を翻訳で置換 (試験的)"
 action_cycle_language = "ターゲット言語を切り替え"
 action_show_dictionary = "辞書を表示"
 action_translate = "翻訳"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "クリックしてグローバルとローカルを切り替え"
 
 # Default Actions Descriptions
@@ -536,3 +539,8 @@ dictionary_ready = "定義が見つかりました。"
 dictionary_not_found = "\"%s\" の定義が見つかりませんでした。"
 dictionary_timeout = "辞書検索がタイムアウトしました。"
 dictionary_failed = "辞書検索に失敗しました: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -267,6 +267,9 @@ action_replace = "Substituir Seleção pela Tradução (experimental)"
 action_cycle_language = "Alternar Idioma de Destino"
 action_show_dictionary = "Mostrar dicionário"
 action_translate = "Traduzir"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Clique para alternar entre Global e Local"
 
 # Default Actions Descriptions
@@ -537,3 +540,8 @@ dictionary_ready = "Definição encontrada."
 dictionary_not_found = "Nenhuma definição encontrada para \"%s\"."
 dictionary_timeout = "A pesquisa no dicionário expirou."
 dictionary_failed = "A pesquisa no dicionário falhou: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -267,6 +267,9 @@ action_replace = "Заменить выделение переводом (экс
 action_cycle_language = "Переключить целевой язык"
 action_show_dictionary = "Показать словарь"
 action_translate = "Перевести"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Нажмите для переключения между Глобально и Локально"
 
 # Default Actions Descriptions
@@ -537,3 +540,8 @@ dictionary_ready = "Определение найдено."
 dictionary_not_found = "Определений для \"%s\" не найдено."
 dictionary_timeout = "Время поиска в словаре истекло."
 dictionary_failed = "Поиск в словаре не удался: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -267,6 +267,9 @@ action_replace = "Seçileni Çeviri ile Değiştir (deneysel)"
 action_cycle_language = "Hedef Dili Değiştir"
 action_show_dictionary = "Sözlüğü Göster"
 action_translate = "Çevir"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "Küresel ve Yerel arasında geçiş yapmak için tıklayın"
 
 # Default Actions Descriptions
@@ -537,3 +540,8 @@ dictionary_ready = "Tanım bulundu."
 dictionary_not_found = "\""%s"\" için tanım bulunamadı."
 dictionary_timeout = "Sözlük araması zaman aşımına uğradı."
 dictionary_failed = "Sözlük araması başarısız oldu: %s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -267,6 +267,9 @@ action_replace = "用翻译替换选中文本 (实验性)"
 action_cycle_language = "循环切换目标语言"
 action_show_dictionary = "显示词典"
 action_translate = "翻译"
+action_focus_input = "Focus Input Pane"
+action_focus_output = "Focus Output Pane"
+action_focus_extra_output = "Focus Extra Output Pane"
 scope_toggle_hint = "点击在全局和本地范围之间切换"
 
 # Default Actions Descriptions
@@ -537,3 +540,8 @@ dictionary_ready = "找到释义。"
 dictionary_not_found = "未找到\"%s\"的释义。"
 dictionary_timeout = "词典查询超时。"
 dictionary_failed = "词典查询失败：%s"
+
+[layout_compact]
+tab_input_tooltip = "Source text (%s)"
+tab_output_tooltip = "Translation (%s)"
+tab_extra_tooltip = "Extra output (%s)"

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -227,6 +227,11 @@ class MainAppFrame(
             pack()
             if (config.mainWindowPosition == null) setLocationRelativeTo(null)
 
+            // Enforce Input → Output → Extra (→ Input) Tab cycle across all layouts.
+            // In Compact layout the policy also switches tabs so hidden panes become
+            // visible before Swing calls requestFocusInWindow() on them.
+            focusTraversalPolicy = TextPaneCycleFocusPolicy(mainContentView)
+
             setupWindowListeners()
             setupMenuBar()
             setupTrayMenu()
@@ -1581,6 +1586,54 @@ class MainAppFrame(
         }
 
     }
+}
+
+/**
+ * Custom focus-traversal policy for the main application window.
+ *
+ * When Tab/Shift+Tab is pressed inside any of the three text panes (input, output, extra),
+ * focus moves directly to the next/previous pane in the cycle — skipping toolbar buttons,
+ * scrollbars, and other intermediate components.  For Compact (tabbed) layout the policy
+ * also selects the target tab so the pane is visible before Swing calls requestFocusInWindow().
+ *
+ * When Tab is pressed from any component that is NOT one of the managed text panes the
+ * standard [LayoutFocusTraversalPolicy] takes over, preserving normal keyboard navigation
+ * for dialogs, settings panels, and anything else displayed in the same window.
+ */
+private class TextPaneCycleFocusPolicy(
+    private val contentView: MainContentView,
+    private val fallback: FocusTraversalPolicy = LayoutFocusTraversalPolicy()
+) : FocusTraversalPolicy() {
+
+    /** All visible text panes in traversal order. Re-evaluated on every Tab press. */
+    private fun panes(): List<JComponent> = contentView.orderedTextPanes()
+
+    override fun getComponentAfter(aContainer: Container, aComponent: Component): Component {
+        val all = panes()
+        val idx = all.indexOfFirst { it === aComponent }
+        if (idx < 0) return fallback.getComponentAfter(aContainer, aComponent)
+        val nextIdx = (idx + 1) % all.size
+        contentView.ensureCompactTabVisible(nextIdx)
+        return all[nextIdx]
+    }
+
+    override fun getComponentBefore(aContainer: Container, aComponent: Component): Component {
+        val all = panes()
+        val idx = all.indexOfFirst { it === aComponent }
+        if (idx < 0) return fallback.getComponentBefore(aContainer, aComponent)
+        val prevIdx = (idx - 1 + all.size) % all.size
+        contentView.ensureCompactTabVisible(prevIdx)
+        return all[prevIdx]
+    }
+
+    override fun getFirstComponent(aContainer: Container): Component =
+        panes().firstOrNull() ?: fallback.getFirstComponent(aContainer)
+
+    override fun getLastComponent(aContainer: Container): Component =
+        panes().lastOrNull() ?: fallback.getLastComponent(aContainer)
+
+    override fun getDefaultComponent(aContainer: Container): Component =
+        panes().firstOrNull() ?: fallback.getDefaultComponent(aContainer)
 }
 
 /** Snapshot used to deduplicate auto-lookup triggers. */

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -651,7 +651,15 @@ class MainAppFrame(
             inputMap.put(keyStroke, actionKey)
             rootPane.actionMap.put(actionKey, object : AbstractAction() {
                 override fun actionPerformed(e: ActionEvent) {
-                    globalKeyListener.dispatchAction(binding.action)
+                    // FOCUS_* are LOCAL-only and require layout-aware handling (Compact layout must
+                    // switch tabs before focusing). Route them directly to MainContentView rather
+                    // than through globalKeyListener.dispatchAction(), which would do nothing.
+                    when (binding.action) {
+                        HotkeyAction.FOCUS_INPUT        -> mainContentView.switchToAndFocusInput()
+                        HotkeyAction.FOCUS_OUTPUT       -> mainContentView.switchToAndFocusOutput()
+                        HotkeyAction.FOCUS_EXTRA_OUTPUT -> mainContentView.switchToAndFocusExtraOutput()
+                        else -> globalKeyListener.dispatchAction(binding.action)
+                    }
                 }
             })
         }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -206,19 +206,17 @@ class MainContentView(
     init {
         add(splitPane, BorderLayout.CENTER)
 
-        // Direct panel focus shortcuts — work from anywhere in the window.
-        // Alt+1 → input, Alt+2 → output, Alt+3 → extra-output.
-        val im = getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        // Focus shortcuts — keystrokes are user-configurable (default Alt+1/2/3).
+        // The actual keystroke bindings are applied dynamically via updateFocusKeyStrokes()
+        // so they always reflect the current settings without restarting.
         val am = actionMap
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_1, InputEvent.ALT_DOWN_MASK), "focus-panel-input")
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_2, InputEvent.ALT_DOWN_MASK), "focus-panel-output")
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_3, InputEvent.ALT_DOWN_MASK), "focus-panel-extra")
         am.put("focus-panel-input",  object : AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent) { inputTextPanel.requestFocusOnText() } })
         am.put("focus-panel-output", object : AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent) { outputTextPanel.requestFocusOnText() } })
         am.put("focus-panel-extra",  object : AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent) { extraOutputPanel.requestFocusOnText() } })
 
         // Escape cancels an in-flight translation — only fires when isTranslating is true
         // so it doesn't interfere with dialogs or normal Escape usage in other contexts.
+        val im = getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
         im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "cancel-translation")
         am.put("cancel-translation", object : AbstractAction() {
             override fun actionPerformed(e: java.awt.event.ActionEvent) {
@@ -242,6 +240,7 @@ class MainContentView(
         }
 
         updateTranslateKeyStroke(config)
+        updateFocusKeyStrokes(config)
         renderDictionaryPanel(mainState, config)
         renderComponents(mainState, config)
         lastState = mainState to settingsState
@@ -261,6 +260,48 @@ class MainContentView(
         inputTextPanel.setTranslateKeyStroke(old, newStroke)
         outputTextPanel.setTranslateKeyStroke(old, newStroke)
         extraOutputPanel.setTranslateKeyStroke(old, newStroke)
+    }
+
+    /**
+     * Updates the Compact layout's JTabbedPane shortcuts + tab tooltips (1-D/E) to reflect
+     * the user's configured bindings. No-op for Classic/Side-by-Side layouts.
+     *
+     * Note: Classic/Side-by-Side focus shortcuts are handled by MainAppFrame.registerLocalHotkeys()
+     * which registers them on the rootPane's WHEN_ANCESTOR_OF_FOCUSED_COMPONENT InputMap and
+     * routes them to [switchToAndFocusInput], [switchToAndFocusOutput], [switchToAndFocusExtraOutput].
+     */
+    private fun updateFocusKeyStrokes(config: Configuration) {
+        fun resolveStroke(action: HotkeyAction): KeyStroke? =
+            config.hotkeys.find { it.action == action }?.takeIf { it.isEnabled }?.toKeyStroke()
+
+        val newInput  = resolveStroke(HotkeyAction.FOCUS_INPUT)
+        val newOutput = resolveStroke(HotkeyAction.FOCUS_OUTPUT)
+        val newExtra  = resolveStroke(HotkeyAction.FOCUS_EXTRA_OUTPUT)
+
+        // Compact layout (1-D/E): bind on the JTabbedPane so switching tabs + focusing the text
+        // pane works even when the hidden tabs don't respond to WHEN_IN_FOCUSED_WINDOW.
+        // Tab tooltips display the shortcut so the binding is discoverable.
+        layoutManager.updateCompactShortcuts(
+            strokes  = Triple(newInput, newOutput, newExtra),
+            tooltips = Triple(
+                localizer.getString("layout_compact.tab_input_tooltip",  keystrokeLabel(newInput)),
+                localizer.getString("layout_compact.tab_output_tooltip", keystrokeLabel(newOutput)),
+                localizer.getString("layout_compact.tab_extra_tooltip",  keystrokeLabel(newExtra))
+            ),
+            actions  = Triple(
+                { inputTextPanel.requestFocusOnText() },
+                { outputTextPanel.requestFocusOnText() },
+                { extraOutputPanel.requestFocusOnText() }
+            )
+        )
+    }
+
+    /** Returns a human-readable label for [ks], e.g. "Alt+1", or "" when null. */
+    private fun keystrokeLabel(ks: KeyStroke?): String {
+        ks ?: return ""
+        val mods = java.awt.event.InputEvent.getModifiersExText(ks.modifiers)
+        val key  = java.awt.event.KeyEvent.getKeyText(ks.keyCode)
+        return if (mods.isEmpty()) key else "$mods+$key"
     }
 
     private fun renderDictionaryPanel(mainState: MainState, config: Configuration) {
@@ -573,6 +614,33 @@ class MainContentView(
 
     fun requestFocusOnInput() {
         inputTextPanel.requestFocusInWindow()
+    }
+
+    /**
+     * Switches to the Input tab (if in Compact layout) then moves focus into the input text pane.
+     * Used by MainAppFrame.registerLocalHotkeys() for the FOCUS_INPUT LOCAL hotkey.
+     */
+    fun switchToAndFocusInput() {
+        layoutManager.selectCompactTab(0)
+        inputTextPanel.requestFocusOnText()
+    }
+
+    /**
+     * Switches to the Output tab (if in Compact layout) then moves focus into the output text pane.
+     * Used by MainAppFrame.registerLocalHotkeys() for the FOCUS_OUTPUT LOCAL hotkey.
+     */
+    fun switchToAndFocusOutput() {
+        layoutManager.selectCompactTab(1)
+        outputTextPanel.requestFocusOnText()
+    }
+
+    /**
+     * Switches to the Extra Output tab (if in Compact layout) then moves focus into the extra pane.
+     * Used by MainAppFrame.registerLocalHotkeys() for the FOCUS_EXTRA_OUTPUT LOCAL hotkey.
+     */
+    fun switchToAndFocusExtraOutput() {
+        layoutManager.selectCompactTab(2)
+        extraOutputPanel.requestFocusOnText()
     }
 
     fun setDictionarySearchWord(word: String) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -643,6 +643,23 @@ class MainContentView(
         extraOutputPanel.requestFocusOnText()
     }
 
+    /**
+     * Returns the text-pane components in focus-traversal order: Input → Output → Extra.
+     * Extra is included only when its panel is currently visible (i.e. an extra output type is active).
+     * Used by the frame-level [TextPaneCycleFocusPolicy] to build the Tab/Shift+Tab cycle.
+     */
+    fun orderedTextPanes(): List<JComponent> = buildList {
+        add(inputTextPanel.textPaneComponent)
+        add(outputTextPanel.textPaneComponent)
+        if (extraOutputPanel.isVisible) add(extraOutputPanel.textPaneComponent)
+    }
+
+    /**
+     * Selects the Compact layout tab at [index] so the pane it contains becomes visible before
+     * the framework calls [Component.requestFocusInWindow] on it.  No-op for Classic / Side-by-Side.
+     */
+    fun ensureCompactTabVisible(index: Int) = layoutManager.selectCompactTab(index)
+
     fun setDictionarySearchWord(word: String) {
         dictionaryPanel.setSearchWord(word)
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
@@ -175,6 +175,11 @@ class MainGlobalKeyListener(
                 scope.launch { handleSelectedText(onShowDictionary) }
             HotkeyAction.TRANSLATE ->
                 onTranslate()
+            // Focus actions are LOCAL-scope only — handled by MainContentView's InputMap.
+            // Nothing to do here; the branch is required for exhaustive when.
+            HotkeyAction.FOCUS_INPUT,
+            HotkeyAction.FOCUS_OUTPUT,
+            HotkeyAction.FOCUS_EXTRA_OUTPUT -> Unit
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/input/InputTextPanel.kt
@@ -81,6 +81,9 @@ class InputTextPanel(
     fun setTranslateKeyStroke(old: javax.swing.KeyStroke?, new: javax.swing.KeyStroke?) =
         textPane.setTranslateKeyStroke(old, new)
 
+    /** The underlying text component — exposed for the frame-level focus traversal policy. */
+    val textPaneComponent: JComponent get() = textPane
+
     private fun customizeContextMenu(menu: JPopupMenu, clickPosition: Point) {
         spellingMenu?.let { menu.remove(it) }
         spellingMenuSeparator?.let { menu.remove(it) }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/LayoutManager.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/LayoutManager.kt
@@ -3,7 +3,10 @@ package com.github.ahatem.qtranslate.ui.swing.main.layout
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.ExtraOutputType
 import java.awt.BorderLayout
+import java.awt.event.ActionEvent
+import javax.swing.AbstractAction
 import javax.swing.JPanel
+import javax.swing.KeyStroke
 import javax.swing.SwingUtilities
 
 class LayoutManager(
@@ -12,6 +15,7 @@ class LayoutManager(
 ) {
     private var currentLayout: ArrangedLayout? = null
     private var currentLayoutId: String? = null
+    private var compactStrokes: Triple<KeyStroke?, KeyStroke?, KeyStroke?> = Triple(null, null, null)
 
     companion object {
         private val strategies = listOf(ClassicLayout, SideBySideLayout, CompactLayout)
@@ -52,6 +56,65 @@ class LayoutManager(
             components.translatorSelector,
             components.statusBar
         ).forEach { it.parent?.remove(it) }
+    }
+
+    /**
+     * Binds (or rebinds) the focus-panel shortcuts on the Compact layout's [JTabbedPane].
+     * Also updates the tab tooltip text to show the configured shortcut key (1-E).
+     *
+     * No-op when the current layout is not Compact. Must be called on the EDT.
+     *
+     * @param strokes  Keystroke for [input, output, extra] — null means disabled/unbound.
+     * @param tooltips Tooltip suffix strings e.g. "(Alt+1)" shown on each tab header.
+     * @param actions  Lambdas that switch to the tab AND request focus in the pane.
+     */
+    fun updateCompactShortcuts(
+        strokes: Triple<KeyStroke?, KeyStroke?, KeyStroke?>,
+        tooltips: Triple<String, String, String>,
+        actions: Triple<() -> Unit, () -> Unit, () -> Unit>
+    ) {
+        val tabs = (currentLayout?.componentRefs as? LayoutComponentRefs.WithTabs)?.tabbedPane
+            ?: return
+
+        // Remove previously registered compact focus strokes before rebinding.
+        val im = tabs.getInputMap(javax.swing.JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+        listOf(compactStrokes.first, compactStrokes.second, compactStrokes.third).forEach { old ->
+            old?.let { im.remove(it) }
+        }
+
+        val actionList = listOf(actions.first, actions.second, actions.third)
+        val strokeList = listOf(strokes.first, strokes.second, strokes.third)
+        strokeList.forEachIndexed { i, stroke ->
+            val key = "compact-focus-$i"
+            val fn  = actionList[i]
+            tabs.actionMap.put(key, object : AbstractAction() {
+                override fun actionPerformed(e: ActionEvent) {
+                    // Switch to the correct tab first, then request focus in the text pane.
+                    if (i < tabs.tabCount) tabs.selectedIndex = i
+                    fn()
+                }
+            })
+            stroke?.let { im.put(it, key) }
+        }
+        compactStrokes = strokes
+
+        // Tab tooltips (1-E): show the action name + shortcut hint so it's discoverable.
+        val tooltipList = listOf(tooltips.first, tooltips.second, tooltips.third)
+        tooltipList.forEachIndexed { i, tip ->
+            if (i < tabs.tabCount) tabs.setToolTipTextAt(i, tip)
+        }
+    }
+
+    /**
+     * Selects the tab at [index] in the Compact layout's JTabbedPane.
+     * No-op when the current layout is Classic or Side-by-Side (no JTabbedPane).
+     * Called by MainContentView.switchToAndFocusInput/Output/ExtraOutput() so the rootPane's
+     * LOCAL hotkey binding can switch to the correct tab before requesting focus.
+     */
+    fun selectCompactTab(index: Int) {
+        val tabs = (currentLayout?.componentRefs as? LayoutComponentRefs.WithTabs)?.tabbedPane
+            ?: return
+        if (index < tabs.tabCount) tabs.selectedIndex = index
     }
 
     fun updateVisibility(config: Configuration) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/Layouts.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/Layouts.kt
@@ -267,9 +267,10 @@ object CompactLayout : LayoutStrategy {
         val bottomBar = LayoutBuilders.createBottomBar(components.translatorSelector, components.statusBar)
 
         val tabs = JTabbedPane().apply {
-            addTab("Input", components.inputPanel)
+            addTab("Input",  components.inputPanel)
             addTab("Output", components.outputPanel)
-            setupKeyboardShortcuts(this)
+            // Shortcuts and tooltips are applied dynamically via LayoutManager.updateCompactShortcuts()
+            // so they always reflect the user's configured bindings.
         }
 
         val contentPanel = JPanel(BorderLayout(0, UISpacing.V_GAP)).apply {
@@ -293,23 +294,5 @@ object CompactLayout : LayoutStrategy {
         return ArrangedLayout(root, refs)
     }
 
-    private fun setupKeyboardShortcuts(tabs: JTabbedPane) {
-        tabs.actionMap.put("tab1", createTabSwitchAction(tabs, 0))
-        tabs.actionMap.put("tab2", createTabSwitchAction(tabs, 1))
-        tabs.inputMap.put(
-            KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_1, java.awt.event.InputEvent.ALT_DOWN_MASK),
-            "tab1"
-        )
-        tabs.inputMap.put(
-            KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_2, java.awt.event.InputEvent.ALT_DOWN_MASK),
-            "tab2"
-        )
-    }
-
-    private fun createTabSwitchAction(tabs: JTabbedPane, index: Int) = object : AbstractAction() {
-        override fun actionPerformed(e: java.awt.event.ActionEvent) {
-            if (index < tabs.tabCount && tabs.isEnabledAt(index)) tabs.selectedIndex = index
-        }
-    }
 }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/ExtraOutputPanel.kt
@@ -84,6 +84,9 @@ class ExtraOutputPanel(
     fun setTranslateKeyStroke(old: javax.swing.KeyStroke?, new: javax.swing.KeyStroke?) =
         textPane.setTranslateKeyStroke(old, new)
 
+    /** The underlying text component — exposed for the frame-level focus traversal policy. */
+    val textPaneComponent: JComponent get() = textPane
+
     private var currentState: ExtraOutputState? = null
 
     init {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -12,6 +12,7 @@ import java.awt.Point
 import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
 import javax.swing.AbstractAction
+import javax.swing.JComponent
 import javax.swing.JMenuItem
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
@@ -44,6 +45,9 @@ class OutputTextPanel(
     fun requestFocusOnText() = textPane.requestFocusInWindow()
     fun setTranslateKeyStroke(old: javax.swing.KeyStroke?, new: javax.swing.KeyStroke?) =
         textPane.setTranslateKeyStroke(old, new)
+
+    /** The underlying text component — exposed for the frame-level focus traversal policy. */
+    val textPaneComponent: JComponent get() = textPane
 
     init {
         add(readOnlyPanel, BorderLayout.CENTER)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
@@ -33,7 +33,10 @@ class KeyboardPanel(
         HotkeyAction.REPLACE_WITH_TRANSLATION,
         HotkeyAction.CYCLE_TARGET_LANGUAGE,
         HotkeyAction.SHOW_DICTIONARY,
-        HotkeyAction.TRANSLATE
+        HotkeyAction.TRANSLATE,
+        HotkeyAction.FOCUS_INPUT,
+        HotkeyAction.FOCUS_OUTPUT,
+        HotkeyAction.FOCUS_EXTRA_OUTPUT
     )
 
     // SHOW_MAIN_WINDOW can now have a custom keystroke — only its scope is locked to GLOBAL.
@@ -252,6 +255,9 @@ class KeyboardPanel(
         HotkeyAction.CYCLE_TARGET_LANGUAGE    -> localizationManager.getString("settings_hotkeys.action_cycle_language")
         HotkeyAction.SHOW_DICTIONARY          -> localizationManager.getString("settings_hotkeys.action_show_dictionary")
         HotkeyAction.TRANSLATE                -> localizationManager.getString("settings_hotkeys.action_translate")
+        HotkeyAction.FOCUS_INPUT              -> localizationManager.getString("settings_hotkeys.action_focus_input")
+        HotkeyAction.FOCUS_OUTPUT             -> localizationManager.getString("settings_hotkeys.action_focus_output")
+        HotkeyAction.FOCUS_EXTRA_OUTPUT       -> localizationManager.getString("settings_hotkeys.action_focus_extra_output")
     }
 
     private fun scopeLabel(scope: HotkeyScope): String = when (scope) {
@@ -448,6 +454,9 @@ object HotkeyRecorderDialog {
             HotkeyAction.CYCLE_TARGET_LANGUAGE    -> localizer.getString("settings_hotkeys.action_cycle_language")
             HotkeyAction.SHOW_DICTIONARY          -> localizer.getString("settings_hotkeys.action_show_dictionary")
             HotkeyAction.TRANSLATE                -> localizer.getString("settings_hotkeys.action_translate")
+            HotkeyAction.FOCUS_INPUT              -> localizer.getString("settings_hotkeys.action_focus_input")
+            HotkeyAction.FOCUS_OUTPUT             -> localizer.getString("settings_hotkeys.action_focus_output")
+            HotkeyAction.FOCUS_EXTRA_OUTPUT       -> localizer.getString("settings_hotkeys.action_focus_extra_output")
         }
 
         val promptLabel = JLabel(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -512,6 +512,29 @@ class AdvancedTextPane(
             if (undoManager.canRedo()) undoManager.redo()
         }
 
+        // Tab focus traversal — JTextPane normally inserts a literal tab; override that so
+        // keyboard-only users can navigate out of the pane.
+        //   Tab         → move focus to the next component in the traversal cycle
+        //   Shift+Tab   → move focus to the previous component
+        //   Ctrl+Tab    → insert a literal tab character (escape hatch for power users)
+        val tabForwardAction = object : AbstractAction("tab-forward") {
+            override fun actionPerformed(e: ActionEvent) = transferFocus()
+        }
+        val tabBackwardAction = object : AbstractAction("tab-backward") {
+            override fun actionPerformed(e: ActionEvent) = transferFocusBackward()
+        }
+        val tabInsertAction = object : AbstractAction("tab-insert") {
+            override fun actionPerformed(e: ActionEvent) {
+                if (isEditable) replaceSelection("\t")
+            }
+        }
+        actionMap.put("tab-forward",  tabForwardAction)
+        actionMap.put("tab-backward", tabBackwardAction)
+        actionMap.put("tab-insert",   tabInsertAction)
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0),                                       "tab-forward")
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.SHIFT_DOWN_MASK),              "tab-backward")
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK),               "tab-insert")
+
         // Translate action — keystroke is set dynamically via setTranslateKeyStroke() so the
         // user-configured binding is always used; selected text is preferred over full pane text.
         val translateAction = object : AbstractAction("Translate") {
@@ -736,6 +759,10 @@ class AdvancedTextPane(
         // Forcing it true ensures keyboard shortcuts (Ctrl+C, Ctrl+A, …) continue to work
         // in read-only output panes.
         isFocusable = true
+        // In read-only mode the system default caretColor can match the pane background in dark
+        // themes, making the caret invisible. Always use the foreground color so it is visible
+        // regardless of theme.
+        caretColor = UIManager.getColor("Label.foreground") ?: Color.WHITE
     }
 
     override fun updateUI() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -338,7 +338,20 @@ class AdvancedTextPane(
         highlighter  = WavyUnderlineHighlighter()
         editorKit    = WrappingEditorKit()
         caret        = AdvancedCaret()
+        // Enable Swing's built-in focus traversal so plain Tab / Shift+Tab are consumed by
+        // the KeyboardFocusManager and routed through TextPaneCycleFocusPolicy.
+        // By default the JDK also includes Ctrl+Tab / Shift+Ctrl+Tab in the traversal sets,
+        // which prevents those keystrokes from reaching the InputMap binding that inserts a
+        // literal tab character.  Override both sets to contain only the unmodified Tab strokes.
         focusTraversalKeysEnabled = true
+        setFocusTraversalKeys(
+            java.awt.KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS,
+            setOf(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0))
+        )
+        setFocusTraversalKeys(
+            java.awt.KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS,
+            setOf(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.SHIFT_DOWN_MASK))
+        )
         margin = Insets(6, 6, 6, 6)
 
         document.addUndoableEditListener(undoManager)


### PR DESCRIPTION
## What does this PR do?

Bundles three keyboard/focus improvements for the main window:

**Tab focus traversal** — Tab inside any text pane now moves focus directly to the next pane (Input → Output → Extra → Input), skipping toolbar buttons and language-bar controls. Shift+Tab goes backward. In Compact (tabbed) layout the destination tab is automatically selected before focus transfers, so the hidden pane becomes visible first.

A `TextPaneCycleFocusPolicy` is set on the frame. It only takes over when a managed text pane is focused; all other components fall through to Swing's standard `LayoutFocusTraversalPolicy`, so nothing else is affected.

Ctrl+Tab inserts a literal tab character. The JDK includes Ctrl+Tab in the default forward-traversal key set, which caused the `KeyboardFocusManager` to consume it before the `InputMap` binding fired. Removing Ctrl+Tab from that set lets it reach the component binding cleanly.

**Alt+1 / Alt+2 / Alt+3 focus shortcuts** — new configurable hotkeys (FOCUS_INPUT, FOCUS_OUTPUT, FOCUS_EXTRA_OUTPUT) that move keyboard focus to the named pane and, in Compact layout, also switch to the correct tab. Defaults are Alt+1/2/3; the user can remap them in Settings → Keyboard & Hotkeys. The bindings are added to existing configs via ConfigMigrator v1→v2.

**Compact layout tab UX** — tab tooltips now show the configured shortcut (e.g. "Source text (Alt+1)"), making the bindings discoverable. The extra-output tab appears/disappears correctly when the type is toggled.

**Invisible caret in read-only panes** — `AdvancedTextPane.setEditable(false)` now explicitly sets `caretColor` to the foreground color, preventing the caret from blending into the background in dark themes.

## Related issues

Closes #91

## Type of change

- [x] Bug fix
- [x] New feature
- [x] UI/UX improvement

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`