### PR TITLE
fix: non-deterministic service ordering across JVM restarts

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/registry/PluginRegistry.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/registry/PluginRegistry.kt
@@ -102,6 +102,7 @@ internal class PluginRegistry {
         containers.values
             .filter { it.status == PluginStatus.ENABLED }
             .flatMap { it.services }
+            .sortedBy { it.id }
             .associateBy { it.id }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`PluginRegistry.activeServices()` was iterating over a `HashMap`, whose iteration order is non-deterministic across JVM restarts. This caused the translator service selector to show services in a different order on every launch.

Added `.sortedBy { it.id }` before `.associateBy { it.id }` so the order is always stable and deterministic.

## Type of change

- [x] Bug fix

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally
- [x] MVI architecture respected — no logic in UI components
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)