### PR TITLE
fix(google): add Farsi language support

### DIFF
--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/common/GoogleLanguageMapper.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/common/GoogleLanguageMapper.kt
@@ -21,7 +21,7 @@ object GoogleLanguageMapper : LanguageMapper {
         LanguageCode.BELARUSIAN, LanguageCode.BENGALI, LanguageCode.BOSNIAN,
         LanguageCode.BULGARIAN, LanguageCode.BURMESE, LanguageCode.CATALAN,
         LanguageCode.CZECH, LanguageCode.DANISH, LanguageCode.DUTCH,
-        LanguageCode.ESTONIAN, LanguageCode.FINNISH, LanguageCode.GREEK,
+        LanguageCode.ESTONIAN, LanguageCode.FARSI, LanguageCode.FINNISH, LanguageCode.GREEK,
         LanguageCode.HEBREW, LanguageCode.HUNGARIAN, LanguageCode.ICELANDIC,
         LanguageCode.INDONESIAN, LanguageCode.IRISH, LanguageCode.KHMER,
         LanguageCode.LAO, LanguageCode.LATVIAN, LanguageCode.LITHUANIAN,


### PR DESCRIPTION
## What does this PR do?

Adds Farsi to the Google translation plugin language mapping so requests use the provider's supported `fa` language code.

Validated with `./gradlew build test`.

## Related issues

Closes #104

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected - no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
## Screenshots (if UI changes)

Not applicable. This is a provider language-mapping fix.
