### PR TITLE
feat(quick-translate): dismiss popup on outside click

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -340,6 +340,14 @@ class QuickTranslateDialog(
         if (awtMouseListener != null) return
         awtMouseListener = AWTEventListener { ev ->
             val me = ev as? MouseEvent ?: return@AWTEventListener
+            if (me.id == MouseEvent.MOUSE_PRESSED) {
+                if (!isPinned && isVisible) {
+                    val clickPoint = Point(me.locationOnScreen)
+                    SwingUtilities.convertPointFromScreen(clickPoint, contentPane)
+                    if (!contentPane.contains(clickPoint)) onDismiss()
+                }
+                return@AWTEventListener
+            }
             if (me.id != MouseEvent.MOUSE_MOVED && me.id != MouseEvent.MOUSE_ENTERED && me.id != MouseEvent.MOUSE_EXITED) return@AWTEventListener
             SwingUtilities.invokeLater {
                 val p = MouseInfo.getPointerInfo()?.location ?: return@invokeLater


### PR DESCRIPTION
## What does this PR do?

Dismisses the Quick Translate popup when the user clicks outside it while preserving normal interaction inside the popup. The global mouse listener is removed when the popup closes to avoid retaining UI resources.

Validated with `./gradlew build test`.

## Related issues

Closes #111

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected - no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
## Screenshots (if UI changes)

Not applicable. The popup appearance is unchanged; this PR changes dismissal behavior.
