### PR TITLE
feat(settings): allow disabling service types

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/SelectActiveServiceUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/SelectActiveServiceUseCase.kt
@@ -7,6 +7,7 @@ import com.github.ahatem.qtranslate.api.translator.Translator
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceInfo
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceSelectionState
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
+import com.github.ahatem.qtranslate.core.settings.data.isServiceDisabled
 import com.github.ahatem.qtranslate.core.shared.arch.ServiceType
 import com.github.ahatem.qtranslate.core.shared.logging.LoggerFactory
 import com.github.ahatem.qtranslate.core.shared.util.mapServiceToType
@@ -59,12 +60,16 @@ class SelectActiveServiceUseCase(
     fun observe(): Flow<ServiceSelectionState> =
         combine(activeServices, settingsState, dynamicLanguageCache) { services, config, langCache ->
             val availableServices = services.values
-                .filterNot { it.id in config.disabledServices }
+                .filterNot { service ->
+                    val type = mapServiceToType(service) ?: return@filterNot false
+                    config.isServiceDisabled(service.id, type)
+                }
                 .mapNotNull { toServiceInfo(it) }
 
             val activePreset = config.getActivePreset() ?: config.servicePresets.firstOrNull()
             val selectedTranslatorId = activePreset?.selectedServices?.get(ServiceType.TRANSLATOR)
-            val translator = services[selectedTranslatorId] as? Translator
+            val translator = (services[selectedTranslatorId] as? Translator)
+                ?.takeUnless { config.isServiceDisabled(it.id, ServiceType.TRANSLATOR) }
 
             val languages = if (translator != null) {
                 resolveLanguages(translator, langCache)
@@ -86,6 +91,7 @@ class SelectActiveServiceUseCase(
     suspend fun getLanguagesFor(serviceId: String?): List<LanguageCode> {
         if (serviceId == null) return emptyList()
         val translator = activeServices.value[serviceId] as? Translator ?: return emptyList()
+        if (settingsState.value.isServiceDisabled(translator.id, ServiceType.TRANSLATOR)) return emptyList()
         return resolveLanguagesSuspending(translator)
     }
 

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ActiveServiceManager.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ActiveServiceManager.kt
@@ -45,10 +45,16 @@ class ActiveServiceManager(
         val config = configuration.value
         val services = activeServices.value
 
+        if (!config.isServiceTypeEnabled(type)) return null
+
         val preferredId = config.getActivePreset()?.selectedServices?.get(type)
 
-        val resolved = preferredId?.let { services[it] }
-            ?: services.values.firstOrNull { mapServiceToType(it) == type }
+        val resolved = preferredId
+            ?.let { services[it] }
+            ?.takeUnless { config.isServiceDisabled(it.id, type) }
+            ?: services.values.firstOrNull {
+                mapServiceToType(it) == type && !config.isServiceDisabled(it.id, type)
+            }
 
         return resolved as? T
     }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigurationExtensions.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigurationExtensions.kt
@@ -2,6 +2,23 @@ package com.github.ahatem.qtranslate.core.settings.data
 
 import com.github.ahatem.qtranslate.core.shared.arch.ServiceType
 
+private const val DISABLED_SERVICE_TYPE_PREFIX = "type:"
+
+fun ServiceType.disabledServiceKey(): String = "$DISABLED_SERVICE_TYPE_PREFIX$name"
+
+fun Configuration.isServiceTypeEnabled(serviceType: ServiceType): Boolean =
+    serviceType.disabledServiceKey() !in disabledServices
+
+fun Configuration.withServiceTypeEnabled(serviceType: ServiceType, enabled: Boolean): Configuration {
+    val key = serviceType.disabledServiceKey()
+    return copy(
+        disabledServices = if (enabled) disabledServices - key else disabledServices + key
+    )
+}
+
+fun Configuration.isServiceDisabled(serviceId: String, serviceType: ServiceType): Boolean =
+    serviceId in disabledServices || !isServiceTypeEnabled(serviceType)
+
 /**
  * Extension functions for working with [Configuration] immutably.
  *

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/ServicesPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/ServicesPanel.kt
@@ -5,6 +5,8 @@ import com.github.ahatem.qtranslate.api.plugin.Service
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.plugin.PluginManager
 import com.github.ahatem.qtranslate.core.settings.data.ServicePreset
+import com.github.ahatem.qtranslate.core.settings.data.isServiceTypeEnabled
+import com.github.ahatem.qtranslate.core.settings.data.withServiceTypeEnabled
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsIntent
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsState
 import com.github.ahatem.qtranslate.core.settings.mvi.SettingsStore
@@ -26,6 +28,7 @@ class ServicesPanel(
     private lateinit var renameBtn: JButton
     private lateinit var deleteBtn: JButton
     private val serviceComboBoxes = mutableMapOf<ServiceType, JComboBox<ServiceOption>>()
+    private val serviceEnabledChecks = mutableMapOf<ServiceType, JCheckBox>()
 
     init {
         buildUI()
@@ -90,6 +93,15 @@ class ServicesPanel(
     private fun buildServiceCard(type: ServiceType, combo: JComboBox<ServiceOption>): JPanel {
         val icon = serviceIcon(type)
         val label = serviceLabel(type)
+        val enabledCheck = JCheckBox(localizationManager.getString("settings_plugins.status_enabled"), true).apply {
+            isOpaque = false
+            addActionListener {
+                if (!isUpdatingFromState) {
+                    applyDraft(store) { it.withServiceTypeEnabled(type, isSelected) }
+                }
+            }
+        }
+        serviceEnabledChecks[type] = enabledCheck
 
         val header = JPanel(FlowLayout(FlowLayout.LEADING, 5, 0)).apply {
             isOpaque = false
@@ -98,6 +110,7 @@ class ServicesPanel(
                 foreground = UIManager.getColor("Label.disabledForeground")
                 font = font.deriveFont(font.size - 1f)
             })
+            add(enabledCheck)
         }
 
         return JPanel(BorderLayout(0, 5)).apply {
@@ -204,6 +217,12 @@ class ServicesPanel(
             val hasPreset = active != null
             renameBtn.isEnabled = hasPreset
             deleteBtn.isEnabled = hasPreset && c.servicePresets.size > 1
+
+            ServiceType.entries.forEach { type ->
+                val enabled = c.isServiceTypeEnabled(type)
+                serviceEnabledChecks[type]?.isSelected = enabled
+                serviceComboBoxes[type]?.isEnabled = enabled
+            }
 
             active?.let { preset ->
                 serviceComboBoxes.forEach { (type, combo) ->


### PR DESCRIPTION
## What does this PR do?

Adds settings for enabling or disabling translation, OCR, TTS, dictionary, spell-check, and text-processing service types. Disabled types are excluded from the active service lists while plugin installation state remains unchanged.

Validated with `./gradlew build test`.

## Related issues

Closes #112

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected - no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
## Screenshots (if UI changes)

The controls use the existing Settings checkbox and spacing conventions; no new visual component style is introduced.
