### PR TITLE
feat(api): add batch translation capability

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "1.0.0"  // only bump when the API interface changes
+version = "1.1.0"  // only bump when the API interface changes
 
 plugins {
     id("buildsrc.convention.kotlin-jvm")
@@ -8,6 +8,7 @@ plugins {
 dependencies {
     api(libs.kotlinxCoroutines)
     api(libs.bundles.result)
+    testImplementation(kotlin("test"))
 }
 
 publishing {

--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/core/ApiVersion.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/core/ApiVersion.kt
@@ -56,7 +56,7 @@ object ApiVersion {
     const val MAJOR = 1
 
     /** The minor version. Incrementing this signals new backwards-compatible features. */
-    const val MINOR = 0
+    const val MINOR = 1
 
     /** The patch version. Incrementing this signals backwards-compatible bug fixes. */
     const val PATCH = 0

--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/translator/Translator.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/translator/Translator.kt
@@ -29,6 +29,67 @@ interface Translator : Service {
 }
 
 /**
+ * Optional translator capability for providers that can process multiple independent
+ * text segments in one request. The core discovers this through
+ * [Service.getCapability] and falls back to [Translator.translate] when absent.
+ *
+ * Implementations must preserve input order and return exactly one response per input.
+ * Empty strings are intentionally rejected so result indexes always map unambiguously.
+ */
+interface BatchTranslator : Translator {
+    /** Maximum items accepted by one provider request. */
+    val maxBatchSize: Int
+        get() = 50
+
+    /** Conservative character limit for one provider request. */
+    val maxBatchCharacters: Int
+        get() = 100_000
+
+    /**
+     * Translates the ordered text segments in [request] as one provider operation.
+     *
+     * @return one translation for every input segment in the same order, or a service error.
+     */
+    suspend fun translateBatch(
+        request: BatchTranslationRequest
+    ): Result<BatchTranslationResponse, ServiceError>
+}
+
+/**
+ * Parameters for an ordered batch translation operation.
+ *
+ * @param texts non-blank independent segments whose order must be preserved.
+ * @param sourceLanguage source language, or [LanguageCode.AUTO] for provider detection.
+ * @param targetLanguage target language; must not be [LanguageCode.AUTO].
+ */
+data class BatchTranslationRequest(
+    val texts: List<String>,
+    val sourceLanguage: LanguageCode,
+    val targetLanguage: LanguageCode
+) {
+    init {
+        require(texts.isNotEmpty()) { "Batch translation request must contain at least one text." }
+        require(texts.none(String::isBlank)) { "Batch translation request texts must not be blank." }
+        require(targetLanguage != LanguageCode.AUTO) {
+            "Target language must be a specific language, not AUTO."
+        }
+    }
+}
+
+/**
+ * Result of a batch translation operation.
+ *
+ * [translations] must contain one item for every requested segment in the same order.
+ */
+data class BatchTranslationResponse(
+    val translations: List<TranslationResponse>
+) {
+    init {
+        require(translations.isNotEmpty()) { "Batch translation response must not be empty." }
+    }
+}
+
+/**
  * Parameters for a translation operation.
  *
  * @param text           The source text to translate. Must not be blank.

--- a/api/src/test/kotlin/com/github/ahatem/qtranslate/api/translator/BatchTranslatorTest.kt
+++ b/api/src/test/kotlin/com/github/ahatem/qtranslate/api/translator/BatchTranslatorTest.kt
@@ -1,0 +1,38 @@
+package com.github.ahatem.qtranslate.api.translator
+
+import com.github.ahatem.qtranslate.api.core.ApiVersion
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class BatchTranslatorTest {
+    @Test
+    fun `batch request preserves ordered texts`() {
+        val request = BatchTranslationRequest(
+            texts = listOf("First", "Second"),
+            sourceLanguage = LanguageCode("en"),
+            targetLanguage = LanguageCode("fr")
+        )
+
+        assertEquals(listOf("First", "Second"), request.texts)
+    }
+
+    @Test
+    fun `batch request rejects blank items`() {
+        assertFailsWith<IllegalArgumentException> {
+            BatchTranslationRequest(
+                texts = listOf("First", " "),
+                sourceLanguage = LanguageCode("en"),
+                targetLanguage = LanguageCode("fr")
+            )
+        }
+    }
+
+    @Test
+    fun `host accepts plugins built against the previous minor API`() {
+        assertEquals("1.1.0", ApiVersion.VERSION)
+        assertIs<ApiVersion.CompatibilityResult.Compatible>(ApiVersion.isCompatible("1.0.0"))
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds an optional `BatchTranslator` capability for providers that can translate ordered text segments in one request. The API defines provider limits, validates request/response contracts, preserves fallback compatibility with ordinary `Translator` implementations, and increments the plugin API minor version.

## Related issues

Supports efficient document translation without changing existing translator plugins.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected - no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable. This PR changes the plugin API only.

## Verification

- `./gradlew :api:build`
- Batch request validation, ordering, and API compatibility tests pass.