### PR TITLE
test: add manual runWithPlugins QA launcher

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,3 +66,42 @@ tasks.shadowJar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
 }
+
+val manualQaPluginProjects = rootProject.subprojects.filter {
+    it.path.startsWith(":plugins:") && it.path != ":plugins:common"
+}
+val manualQaDirectory = layout.buildDirectory.dir("manual-qa")
+val externalPluginsDirectory = providers.gradleProperty("pluginsDir")
+    .orElse(rootProject.layout.projectDirectory.dir("plugins").asFile.absolutePath)
+
+val prepareManualQaPlugins by tasks.registering(Sync::class) {
+    group = "application"
+    description = "Builds bundled plugins and stages them with external plugin JARs for manual QA."
+    dependsOn(manualQaPluginProjects.map { "${it.path}:shadowJar" })
+    into(manualQaDirectory.map { it.dir("app-data/plugins") })
+
+    manualQaPluginProjects.forEach { pluginProject ->
+        from(pluginProject.layout.buildDirectory.dir("libs")) {
+            include("*-plugin.jar")
+        }
+    }
+    from(externalPluginsDirectory) {
+        include("*.jar")
+    }
+}
+
+val prepareManualQaRuntime by tasks.registering(Delete::class) {
+    dependsOn(prepareManualQaPlugins)
+    // Always inspect freshly staged JARs while retaining the tester's other settings.
+    delete(manualQaDirectory.map { it.file("app-data/datastore/plugin_registry.preferences_pb") })
+}
+
+tasks.register<JavaExec>("runWithPlugins") {
+    group = "application"
+    description = "Launches the full QTranslate UI with bundled and external plugins for manual QA."
+    dependsOn(prepareManualQaRuntime)
+    classpath = sourceSets.main.get().runtimeClasspath
+    mainClass.set(application.mainClass)
+    standardInput = System.`in`
+    systemProperty("appData", manualQaDirectory.get().dir("app-data").asFile.absolutePath)
+}

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginLoader.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginLoader.kt
@@ -3,6 +3,7 @@ package com.github.ahatem.qtranslate.core.plugin
 import com.github.ahatem.qtranslate.api.core.ApiVersion
 import com.github.ahatem.qtranslate.api.core.Logger
 import com.github.ahatem.qtranslate.api.plugin.Plugin
+import com.github.ahatem.qtranslate.core.plugin.registry.PluginError
 import com.github.ahatem.qtranslate.core.shared.util.Hashing
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -20,6 +21,11 @@ class PluginLoader(
     private val logger: Logger
 ) {
     private val json = Json { ignoreUnknownKeys = true }
+    private val _loadFailures = mutableListOf<PluginError.LoadFailure>()
+
+    /** Failures from the most recent directory scan, retained for UI reporting. */
+    val loadFailures: List<PluginError.LoadFailure>
+        get() = _loadFailures.toList()
 
     /**
      * Scans [directory] for JAR files, loads each one, and returns the results sorted by
@@ -33,6 +39,7 @@ class PluginLoader(
      * between runs. Sorting filenames before loading ensures consistent processing order.
      */
     fun loadPluginsFromDirectory(directory: File): List<LoadedPluginResult> {
+        _loadFailures.clear()
         if (!directory.isDirectory) {
             logger.warn("Plugin directory does not exist or is not a directory: ${directory.absolutePath}")
             return emptyList()
@@ -56,35 +63,56 @@ class PluginLoader(
      *
      * @return A [LoadedPluginResult] on success, or `null` if any step fails.
      */
-    fun loadPluginFromFile(jarFile: File): LoadedPluginResult? = runCatching {
-        val classLoader = URLClassLoader(arrayOf(jarFile.toURI().toURL()), javaClass.classLoader)
-
-        val plugin = ServiceLoader.load(Plugin::class.java, classLoader).firstOrNull()
-            ?: throw IllegalStateException("No Plugin implementation found via ServiceLoader in ${jarFile.name}. " +
-                    "Ensure META-INF/services/com.github.ahatem.qtranslate.api.plugin.Plugin is present.")
-
-        val manifest = getManifestFromJar(jarFile, classLoader)
-            ?: throw IllegalStateException("plugin.json is missing or could not be parsed in ${jarFile.name}")
-
-        // Delegate to ApiVersion — this checks both MAJOR and MINOR, not just MAJOR.
-        when (val compat = ApiVersion.isCompatible(manifest.minApiVersion)) {
-            is ApiVersion.CompatibilityResult.Compatible -> {
-                logger.debug("Plugin '${manifest.id}' API version ${manifest.minApiVersion} is compatible.")
-            }
-            is ApiVersion.CompatibilityResult.Incompatible -> {
-                logger.error(
-                    "Skipping '${manifest.id}' (v${manifest.version}): ${compat.reason}"
-                )
-                return null
-            }
+    fun loadPluginFromFile(jarFile: File): LoadedPluginResult? {
+        val classLoader = runCatching {
+            URLClassLoader(arrayOf(jarFile.toURI().toURL()), javaClass.classLoader)
+        }.getOrElse { error ->
+            recordFailure(jarFile, "Failed to open plugin JAR: ${error.message}", error)
+            return null
         }
 
-        val hash = Hashing.sha256(jarFile)
-        LoadedPluginResult(plugin, manifest, jarFile, hash, classLoader)
+        return try {
+            val plugin = ServiceLoader.load(Plugin::class.java, classLoader).firstOrNull()
+                ?: throw IllegalStateException("No Plugin implementation found via ServiceLoader in ${jarFile.name}. " +
+                        "Ensure META-INF/services/com.github.ahatem.qtranslate.api.plugin.Plugin is present.")
 
-    }.getOrElse { e ->
-        logger.error("Failed to load plugin from ${jarFile.name}: ${e.message}", e)
-        null
+            val manifest = getManifestFromJar(jarFile, classLoader)
+                ?: throw IllegalStateException("plugin.json is missing or could not be parsed in ${jarFile.name}")
+
+        // Delegate to ApiVersion — this checks both MAJOR and MINOR, not just MAJOR.
+            when (val compat = ApiVersion.isCompatible(manifest.minApiVersion)) {
+                is ApiVersion.CompatibilityResult.Compatible -> {
+                    logger.debug("Plugin '${manifest.id}' API version ${manifest.minApiVersion} is compatible.")
+                }
+                is ApiVersion.CompatibilityResult.Incompatible -> {
+                    recordFailure(
+                        jarFile,
+                        "Plugin '${manifest.id}' v${manifest.version} is incompatible: ${compat.reason}",
+                        null,
+                        manifest.id
+                    )
+                    classLoader.close()
+                    return null
+                }
+            }
+
+            val hash = Hashing.sha256(jarFile)
+            LoadedPluginResult(plugin, manifest, jarFile, hash, classLoader)
+        } catch (error: Throwable) {
+            runCatching { classLoader.close() }
+            recordFailure(jarFile, "Failed to load plugin: ${error.message}", error)
+            null
+        }
+    }
+
+    private fun recordFailure(
+        jarFile: File,
+        message: String,
+        cause: Throwable?,
+        pluginId: String = jarFile.nameWithoutExtension
+    ) {
+        _loadFailures += PluginError.LoadFailure(pluginId, message, cause, jarFile.absolutePath)
+        logger.error("PLUGIN FAILED  ${jarFile.name}: $message", cause)
     }
 
     /**

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginManager.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginManager.kt
@@ -5,6 +5,7 @@ import com.github.ahatem.qtranslate.api.plugin.ServiceError
 import com.github.ahatem.qtranslate.core.plugin.installer.PluginInstaller
 import com.github.ahatem.qtranslate.core.plugin.lifecycle.PluginLifecycleHandler
 import com.github.ahatem.qtranslate.core.plugin.registry.PluginContainer
+import com.github.ahatem.qtranslate.core.plugin.registry.PluginError
 import com.github.ahatem.qtranslate.core.plugin.registry.PluginRegistry
 import com.github.ahatem.qtranslate.core.plugin.settings.PluginSettingsManager
 import com.github.ahatem.qtranslate.core.plugin.settings.PluginSettingsModel
@@ -81,6 +82,7 @@ class PluginManager(
 
     private val _plugins = MutableStateFlow<List<PluginState>>(emptyList())
     private val _activeServices = MutableStateFlow<Map<String, Service>>(emptyMap())
+    private var discoveryFailureStates: List<PluginState> = emptyList()
 
     /** Observable list of all loaded plugins with their current state. */
     val plugins: StateFlow<List<PluginState>> = _plugins.asStateFlow()
@@ -107,8 +109,10 @@ class PluginManager(
 
             val rawPlugins = loader.loadPluginsFromDirectory(pluginsDir)
             val loadResult = registry.validateAndFilter(rawPlugins)
+            val discoveryErrors = loader.loadFailures + loadResult.failed + loadResult.skipped
+            discoveryFailureStates = discoveryErrors.mapIndexed(::toFailedPluginState)
 
-            logDiscoverySummary(loadResult)
+            logDiscoverySummary(loadResult, loader.loadFailures)
 
             supervisorScope {
                 loadResult.successful.map { result ->
@@ -132,7 +136,7 @@ class PluginManager(
             // Surface load failures and JAR-change warnings to the UI via NotificationBus.
             // Errors that happened during validateAndFilter are in loadResult.failed —
             // those plugins never made it into the registry so we report them separately.
-            loadResult.failed.forEach { error ->
+            discoveryErrors.forEach { error ->
                 notificationBus.post(
                     AppNotification(
                         type           = com.github.ahatem.qtranslate.api.plugin.NotificationType.ERROR,
@@ -210,6 +214,13 @@ class PluginManager(
         installer.installPlugin(sourceJar).also { updateFlows() }
 
     suspend fun uninstallPlugin(pluginId: String) {
+        val discoveryFailure = discoveryFailureStates.firstOrNull { it.id == pluginId }
+        if (discoveryFailure != null) {
+            withContext(Dispatchers.IO) { File(discoveryFailure.jarPath).delete() }
+            discoveryFailureStates = discoveryFailureStates.filterNot { it.id == pluginId }
+            updateFlows()
+            return
+        }
         installer.uninstallPlugin(pluginId)
         updateFlows()
     }
@@ -280,6 +291,7 @@ class PluginManager(
         }
 
         registry.mutex.withLock { registry.clear() }
+        discoveryFailureStates = emptyList()
         updateFlows()
 
         logger.info("All plugins shut down.")
@@ -347,13 +359,44 @@ class PluginManager(
         logger.info("Saved plugin registry (${fingerprints.size} fingerprint(s)).")
     }
 
-    private fun logDiscoverySummary(loadResult: com.github.ahatem.qtranslate.core.plugin.registry.PluginLoadResult) {
+    private fun logDiscoverySummary(
+        loadResult: com.github.ahatem.qtranslate.core.plugin.registry.PluginLoadResult,
+        loaderFailures: List<PluginError>
+    ) {
         logger.info(
             "Plugin discovery: ${loadResult.successful.size} valid, " +
-                    "${loadResult.failed.size} failed, ${loadResult.skipped.size} skipped"
+                    "${loadResult.failed.size + loaderFailures.size} failed, ${loadResult.skipped.size} skipped"
         )
+        loadResult.successful.forEach {
+            logger.info("  LOADED  ${it.manifest.id} v${it.manifest.version} (${it.jarFile.name})")
+        }
+        loaderFailures.forEach { logger.error("  FAILED  ${it.pluginId}: ${it.message}", it.cause) }
         loadResult.failed.forEach { logger.error("  FAILED  ${it.pluginId}: ${it.message}", it.cause) }
         loadResult.skipped.forEach { logger.warn("  SKIPPED ${it.pluginId}: ${it.message}") }
+    }
+
+    private fun toFailedPluginState(index: Int, error: PluginError): PluginState {
+        val jarPath = when (error) {
+            is PluginError.LoadFailure -> error.jarPath
+            is PluginError.InvalidManifest -> error.jarPath
+            is PluginError.DuplicateId -> File(pluginsDir, error.duplicateJar).absolutePath
+            else -> File(pluginsDir, error.pluginId).absolutePath
+        }
+        val displayName = File(jarPath).name.takeIf { it.isNotBlank() } ?: error.pluginId
+        val safeName = displayName.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+        return PluginState(
+            manifest = PluginManifest(
+                id = "load-failure-$index-$safeName",
+                name = displayName,
+                version = "unknown",
+                author = "unknown",
+                description = "This plugin could not be loaded.",
+                minApiVersion = "1.0.0"
+            ),
+            status = PluginStatus.FAILED,
+            jarPath = jarPath,
+            lastError = error
+        )
     }
 
     /**
@@ -363,7 +406,7 @@ class PluginManager(
      */
     private suspend fun updateFlows() {
         registry.mutex.withLock {
-            _plugins.value = registry.snapshot()
+            _plugins.value = registry.snapshot() + discoveryFailureStates
             _activeServices.value = registry.activeServices()
         }
     }

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginLoaderTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/plugin/PluginLoaderTest.kt
@@ -1,0 +1,36 @@
+package com.github.ahatem.qtranslate.core.plugin
+
+import com.github.ahatem.qtranslate.api.core.Logger
+import java.nio.file.Files
+import java.util.jar.JarOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PluginLoaderTest {
+    @Test
+    fun `directory scan retains malformed jar failure for the plugin manager`() {
+        val directory = Files.createTempDirectory("qtranslate-plugin-loader").toFile()
+        try {
+            val jar = directory.resolve("broken-plugin.jar")
+            JarOutputStream(jar.outputStream()).use { }
+            val loader = PluginLoader(NoOpLogger)
+
+            val plugins = loader.loadPluginsFromDirectory(directory)
+
+            assertTrue(plugins.isEmpty())
+            assertEquals(1, loader.loadFailures.size)
+            assertEquals(jar.absolutePath, loader.loadFailures.single().jarPath)
+            assertTrue(loader.loadFailures.single().message.contains("Plugin implementation"))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    private object NoOpLogger : Logger {
+        override fun debug(message: String) = Unit
+        override fun info(message: String) = Unit
+        override fun warn(message: String) = Unit
+        override fun error(message: String, error: Throwable?) = Unit
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a single `:app:runWithPlugins` command for manual release QA. The task builds and stages every bundled plugin, copies external JARs from the plugins directory (or `-PpluginsDir`), and launches the complete Swing application with isolated QA data.

Plugin discovery now logs every loaded or failed JAR and retains malformed or incompatible plugins as failed entries in Plugin Manager, allowing the application to continue starting while preserving actionable diagnostics.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable; this adds a QA launch task and plugin diagnostics.