### PR TITLE
feat(api): add bilingual dictionary capability

### DIFF
--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/core/ApiVersion.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/core/ApiVersion.kt
@@ -56,7 +56,7 @@ object ApiVersion {
     const val MAJOR = 1
 
     /** The minor version. Incrementing this signals new backwards-compatible features. */
-    const val MINOR = 1
+    const val MINOR = 2
 
     /** The patch version. Incrementing this signals backwards-compatible bug fixes. */
     const val PATCH = 0

--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/dictionary/Dictionary.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/dictionary/Dictionary.kt
@@ -26,6 +26,32 @@ interface Dictionary : Service {
 }
 
 /**
+ * Optional dictionary capability for providers that return bilingual definitions and
+ * usage examples for a selected language pair.
+ *
+ * The core discovers this through [Service.getCapability]. Existing dictionaries retain
+ * the original [DictionaryRequest] ABI and continue to receive monolingual lookups.
+ */
+interface BilingualDictionary : Dictionary {
+    suspend fun lookupBilingual(
+        request: BilingualDictionaryRequest
+    ): Result<DictionaryResponse, ServiceError>
+}
+
+data class BilingualDictionaryRequest(
+    val word: String,
+    val sourceLanguage: LanguageCode,
+    val targetLanguage: LanguageCode
+) {
+    init {
+        require(word.isNotBlank()) { "Dictionary lookup word must not be blank." }
+        require(targetLanguage != LanguageCode.AUTO) {
+            "Dictionary target language must be specific."
+        }
+    }
+}
+
+/**
  * Parameters for a dictionary lookup.
  *
  * @param word     The word to look up. Must not be blank.

--- a/api/src/test/kotlin/com/github/ahatem/qtranslate/api/dictionary/BilingualDictionaryTest.kt
+++ b/api/src/test/kotlin/com/github/ahatem/qtranslate/api/dictionary/BilingualDictionaryTest.kt
@@ -1,0 +1,27 @@
+package com.github.ahatem.qtranslate.api.dictionary
+
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BilingualDictionaryTest {
+    @Test
+    fun `bilingual request preserves the selected language pair`() {
+        val request = BilingualDictionaryRequest(
+            "bank",
+            LanguageCode.ENGLISH,
+            LanguageCode.FRENCH
+        )
+
+        assertEquals(LanguageCode.ENGLISH, request.sourceLanguage)
+        assertEquals(LanguageCode.FRENCH, request.targetLanguage)
+    }
+
+    @Test
+    fun `automatic target language is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            BilingualDictionaryRequest("bank", LanguageCode.ENGLISH, LanguageCode.AUTO)
+        }
+    }
+}

--- a/api/src/test/kotlin/com/github/ahatem/qtranslate/api/translator/BatchTranslatorTest.kt
+++ b/api/src/test/kotlin/com/github/ahatem/qtranslate/api/translator/BatchTranslatorTest.kt
@@ -32,7 +32,7 @@ class BatchTranslatorTest {
 
     @Test
     fun `host accepts plugins built against the previous minor API`() {
-        assertEquals("1.1.0", ApiVersion.VERSION)
+        assertEquals("1.2.0", ApiVersion.VERSION)
         assertIs<ApiVersion.CompatibilityResult.Compatible>(ApiVersion.isCompatible("1.0.0"))
     }
 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/LookupWordUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/LookupWordUseCase.kt
@@ -1,6 +1,8 @@
 package com.github.ahatem.qtranslate.core.main.domain.usecase
 
 import com.github.ahatem.qtranslate.api.core.Logger
+import com.github.ahatem.qtranslate.api.dictionary.BilingualDictionary
+import com.github.ahatem.qtranslate.api.dictionary.BilingualDictionaryRequest
 import com.github.ahatem.qtranslate.api.dictionary.Dictionary
 import com.github.ahatem.qtranslate.api.dictionary.DictionaryRequest
 import com.github.ahatem.qtranslate.api.language.LanguageCode
@@ -29,6 +31,7 @@ class LookupWordUseCase(
     suspend operator fun invoke(
         word: String,
         language: LanguageCode,
+        targetLanguage: LanguageCode? = null,
         updateState: (MainState.() -> MainState) -> Unit,
         onStatusUpdate: suspend (StatusCode, NotificationType, Boolean) -> Unit
     ) {
@@ -62,7 +65,15 @@ class LookupWordUseCase(
                 }
 
                 val result = withTimeoutOrNull(AppConstants.TRANSLATION_TIMEOUT_MS) {
-                    dictionary.lookup(DictionaryRequest(word, language))
+                    val bilingualRequest = targetLanguage?.let { target ->
+                        dictionary.getCapability(BilingualDictionary::class.java)?.let { it to target }
+                    }
+                    if (bilingualRequest != null) {
+                        val (bilingual, target) = bilingualRequest
+                        bilingual.lookupBilingual(BilingualDictionaryRequest(word, language, target))
+                    } else {
+                        dictionary.lookup(DictionaryRequest(word, language))
+                    }
                 }
 
                 if (result == null) {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -438,6 +438,7 @@ class MainStore(
         lookupWordUseCase(
             word = intent.word,
             language = intent.language,
+            targetLanguage = _state.value.targetLanguage,
             updateState = { transform -> _state.update(transform) },
             onStatusUpdate = ::updateStatusBar
         )


### PR DESCRIPTION
## What does this PR do?

Adds an optional bilingual dictionary capability for providers that return definitions and usage examples for a selected source/target language pair.

The existing dictionary request contract remains unchanged. The core detects the optional capability at runtime and falls back to the existing monolingual lookup path for plugins that do not implement it.

The plugin API minor version is bumped to expose the new capability while retaining compatibility with plugins built against the previous minor version.

## Related issues

Preparation for translation providers that expose bilingual dictionary results.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable. This PR has no visual changes.

## Verification

- `./gradlew :api:test :core:test build --no-build-cache`
- 5 API tests passed
- 13 core tests passed
- Full build passed