### PR TITLE
fix(ai): improve OpenRouter defaults and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For longer work: open the main window, type or paste, translate. Switch engines 
 | **Service presets** | Save different engine combinations for different contexts |
 | **Google Services** | Translator, TTS, OCR, Spell Checker, Dictionary — included |
 | **Bing Services** | Translator, TTS, Spell Checker — included |
-| **AI Services** | Translator, Summarizer, Rewriter, Spell Checker, Dictionary, Vision OCR — via [OpenRouter](https://openrouter.ai) (300+ models, one API key) — included |
+| **AI Services** | Translator, Summarizer, Rewriter, Spell Checker, Dictionary, Vision OCR — via [OpenRouter](https://openrouter.ai) (300+ models, one API key) — included. [Setup guide](wiki/AI-Services.md) |
 
 ### Interface
 

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettings.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettings.kt
@@ -62,17 +62,17 @@ data class AISettings(
 
     @field:Setting(
         label       = "Model",
-        description = "Model identifier. OpenRouter examples: google/gemini-flash-1.5-8b · openai/gpt-4o · " +
-                "anthropic/claude-3-5-sonnet · mistralai/mistral-small. " +
-                "Direct provider examples: gpt-4o · gemini-2.5-flash · mistral-small-latest. " +
-                "Append :free to use a free-tier model on OpenRouter, e.g. google/gemini-flash-1.5-8b:free.",
+        description = "Exact model slug for your provider. For OpenRouter, use openrouter/free to " +
+                "automatically select an available free model, or copy a current slug from openrouter.ai/models. " +
+                "A 404 usually means that the model slug was renamed or removed. " +
+                "Direct provider examples: gpt-4o · gemini-2.5-flash · mistral-small-latest.",
         type         = SettingType.TEXT,
-        defaultValue = "google/gemini-flash-1.5-8b",
+        defaultValue = "openrouter/free",
         isRequired   = true,
         group        = "model",
         order        = 10
     )
-    var model: String = "google/gemini-flash-1.5-8b",
+    var model: String = "openrouter/free",
 
     @field:Setting(
         label       = "Temperature",

--- a/plugins/common/src/main/kotlin/com/github/ahatem/qtranslate/plugins/common/KtorHttpClient.kt
+++ b/plugins/common/src/main/kotlin/com/github/ahatem/qtranslate/plugins/common/KtorHttpClient.kt
@@ -342,7 +342,7 @@ class KtorHttpClient(
                     ServiceError.AuthenticationError(
                         "Insufficient credits. " +
                         "If you are using OpenRouter, visit openrouter.ai/settings/credits to top up, " +
-                        "or switch to a free model (append :free to the model name, e.g. google/gemini-flash-1.5-8b:free)."
+                        "or switch the model to openrouter/free."
                     )
                 )
             }

--- a/wiki/AI-Services.md
+++ b/wiki/AI-Services.md
@@ -1,0 +1,24 @@
+# AI Services setup
+
+The bundled AI Services plugin works with OpenRouter by default and can also use any OpenAI-compatible endpoint.
+
+## OpenRouter quick start
+
+1. Create an account at [OpenRouter](https://openrouter.ai/) and create an API key.
+2. In QTranslate, open **Settings > Plugins > AI Services > Configure**.
+3. Keep the Base URL as `https://openrouter.ai/api/v1`.
+4. Paste the API key into **API Key**.
+5. Keep the Model as `openrouter/free` for automatic free-model routing, or copy an exact current model slug from the [OpenRouter model list](https://openrouter.ai/models).
+6. Save the plugin settings and select an AI service under **Settings > Services & Presets**.
+
+No additional OpenRouter site configuration is required. Free accounts are rate-limited, and model availability can change over time.
+
+## Troubleshooting
+
+- **HTTP 401 or 403:** The API key is missing, invalid, or not allowed to use the selected provider.
+- **HTTP 402:** Add credits or use `openrouter/free`.
+- **HTTP 404:** The Base URL is incorrect or the model slug was renamed or removed. Restore the default Base URL and choose a current model slug.
+- **HTTP 429:** The provider or free tier is rate-limiting requests. Wait and retry, or choose another model.
+- **Vision OCR fails:** The selected model must support image input. `openrouter/free` automatically restricts routing according to request capabilities, but a manually selected text-only model cannot perform OCR.
+
+For OpenAI, Gemini, Mistral, Ollama, LM Studio, or another compatible server, replace the Base URL, API key, and model with the values documented by that provider.


### PR DESCRIPTION
## What does this PR do?

Replaces the removed AI Services default model with OpenRouter's maintained `openrouter/free` router. This avoids tying first-time setup to a specific free model slug that can be renamed or removed.

The plugin settings now explain how to select current model slugs and identify a stale model from an HTTP 404 response. Credit errors point users to `openrouter/free`, and a new setup guide covers OpenRouter configuration, common HTTP failures, vision-model requirements, and other OpenAI-compatible providers.

## Related issues

Closes #116

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected - no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable. The existing generated settings dialog displays the updated guidance.

## Verification

- Confirmed `openrouter/free` in OpenRouter's current model API and documentation
- `./gradlew :plugins:ai-services:build :plugins:common:build build --no-build-cache`
- Full build passed
