### PR TITLE
fix(ui): let Java2D select the graphics pipeline

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppUiSetup.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppUiSetup.kt
@@ -14,13 +14,11 @@ import javax.swing.UIManager
 object AppUiSetup {
 
     fun setSystemProperties() {
-        System.setProperty("sun.awt.xembedserver",         "true")
-        System.setProperty("awt.useSystemAAFontSettings",  "lcd")
-        System.setProperty("swing.aatext",                 "true")
-        System.setProperty("sun.java2d.opengl",            "true")
-        System.setProperty("sun.java2d.d3d",               "false")
-        System.setProperty("sun.java2d.noddraw",           "true")
-        System.setProperty("sun.java2d.xrender",           "true")
+        if (System.getProperty("os.name").startsWith("Linux", ignoreCase = true)) {
+            System.setProperty("sun.awt.xembedserver", "true")
+        }
+        System.setProperty("awt.useSystemAAFontSettings", "lcd")
+        System.setProperty("swing.aatext", "true")
     }
 
     fun setRenderingHints() {


### PR DESCRIPTION
## What does this PR do?

Stops forcing incompatible Java2D rendering pipelines globally during application startup.

QTranslate previously enabled OpenGL while explicitly disabling Direct3D and DirectDraw on every operating system. On some Windows and newer Java runtime combinations, that could produce responsive but blank Swing windows and tray menus. Java2D now selects the supported platform pipeline automatically.

Font antialiasing remains enabled, and the XEmbed tray property is now applied only on Linux where it is relevant.

## Related issues

Closes #118

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected - no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable. This restores normal rendering without changing the intended layout.

## Verification

- `./gradlew build --no-build-cache`
- Full build passed
- Launched `QTranslate.jar` directly with GraalVM Java 25 on Windows
- Process remained responsive with main window title `QTranslate`
