### PR TITLE
build: add release artifact variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test --no-daemon
-        continue-on-error: true
 
       - name: Upload test reports
         if: always()
@@ -42,4 +41,44 @@ jobs:
           path: |
             **/build/reports/tests/
             **/build/test-results/
+          retention-days: 7
+
+  release-variants:
+    name: Release variant (${{ matrix.variant }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: app-only
+            task: assembleAppOnly
+          - variant: minimal
+            task: assembleMinimal
+          - variant: full
+            task: assembleFull
+          - variant: plugins
+            task: assembleIndividualPlugins
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Build ${{ matrix.variant }}
+        run: ./gradlew ${{ matrix.task }} -PreleaseVersion=ci --no-daemon
+
+      - name: Upload ${{ matrix.variant }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: qtranslate-${{ matrix.variant }}
+          path: build/release/
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
             - **App only:** QTranslate without plugins
             - **Individual plugins:** independently versioned plugin JARs
 
-            > **Requires Java 17 or later.** [Download Java](https://adoptium.net)
+            > **Requires Java 11 or later.** [Download Java](https://adoptium.net)
 
             ## Verification
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,51 +32,10 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Build app JAR
-        run: ./gradlew :app:shadowJar --no-daemon
+      - name: Build release variants
+        run: ./gradlew assembleReleaseVariants -PreleaseVersion=${{ steps.version.outputs.version }} --no-daemon
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
-
-      - name: Build plugin JARs
-        run: ./gradlew :plugins:bing-services:shadowJar :plugins:google-services:shadowJar :plugins:ai-services:shadowJar :plugins:deepl-services:shadowJar --no-daemon
-        env:
-          APP_VERSION: ${{ steps.version.outputs.version }}
-
-      - name: Assemble release zip
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          mkdir -p dist/QTranslate/plugins
-          mkdir -p dist/QTranslate/languages
-
-          cp app/build/libs/QTranslate.jar \
-             dist/QTranslate/QTranslate.jar
-
-          cp plugins/bing-services/build/libs/bing-services-plugin.jar \
-             dist/QTranslate/plugins/bing-services-plugin.jar
-
-          cp plugins/google-services/build/libs/google-services-plugin.jar \
-             dist/QTranslate/plugins/google-services-plugin.jar
-          
-          cp plugins/ai-services/build/libs/ai-services-plugin.jar \
-             dist/QTranslate/plugins/ai-services-plugin.jar
-          cp plugins/deepl-services/build/libs/deepl-services-plugin.jar \
-             dist/QTranslate/plugins/deepl-services-plugin.jar
-
-          if [ -d languages ]; then
-            cp -R languages/. dist/QTranslate/languages/
-          fi
-
-          mkdir -p dist/QTranslate/themes
-          if [ -d themes ]; then
-            cp -R themes/. dist/QTranslate/themes/
-          fi
-
-          cd dist
-          zip -r "../QTranslate-${VERSION}.zip" QTranslate/
-
-          echo "Built: QTranslate-${VERSION}.zip"
-          ls -lh "../QTranslate-${VERSION}.zip"
 
       - name: Generate changelog
         id: changelog
@@ -115,14 +74,6 @@ jobs:
           printf "%b" "$LOG" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Generate SHA-256 checksum
-        id: checksum
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          sha256sum "QTranslate-${VERSION}.zip" > "SHA256SUMS.txt"
-          echo "Built checksum:"
-          cat SHA256SUMS.txt
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -136,14 +87,12 @@ jobs:
 
             **Full changelog:** https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md
 
-            ## Installation
+            ## Downloads
 
-            1. Download `QTranslate-${{ steps.version.outputs.version }}.zip`
-            2. Extract it — you'll get a `QTranslate/` folder
-            3. Run `QTranslate.jar` inside it
-            4. The `plugins/` folder already contains the bundled plugins
-            5. The `languages/` folder already contains the bundled language files
-            6. The `themes/` folder contains additional community themes (drop more `.theme.json` files here to add themes)
+            - **Minimal:** QTranslate with Google, Bing, and Mozhi
+            - **Full:** QTranslate with every bundled plugin
+            - **App only:** QTranslate without plugins
+            - **Individual plugins:** independently versioned plugin JARs
 
             > **Requires Java 17 or later.** [Download Java](https://adoptium.net)
 
@@ -155,7 +104,11 @@ jobs:
             ```
 
           files: |
-            QTranslate-${{ steps.version.outputs.version }}.zip
-            SHA256SUMS.txt
+            build/release/QTranslate-App-${{ steps.version.outputs.version }}.jar
+            build/release/QTranslate-Minimal-${{ steps.version.outputs.version }}.zip
+            build/release/QTranslate-Full-${{ steps.version.outputs.version }}.zip
+            build/release/plugins/*.jar
+            build/release/release-metadata.json
+            build/release/SHA256SUMS.txt
           prerelease: ${{ contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-rc') }}
           draft: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,40 +1,208 @@
-val smokePluginProjects = subprojects.filter {
-    it.path.startsWith(":plugins:") && it.path != ":plugins:common"
-}
-val smokeDirectory = layout.buildDirectory.dir("plugin-smoke-test")
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.api.tasks.bundling.Zip
 
+plugins {
+    base
+}
+
+data class BundledPlugin(
+    val projectPath: String,
+    val archiveFile: File,
+    val id: String,
+    val name: String,
+    val version: String,
+    val minApiVersion: String,
+) {
+    val releaseFileName = "$id-$version.jar"
+    val bundledFileName = archiveFile.name
+}
+
+val releaseVersion = providers.gradleProperty("releaseVersion")
+    .orElse(providers.environmentVariable("APP_VERSION"))
+    .orElse("dev")
+val releaseOutputDirectory = layout.buildDirectory.dir("release")
+evaluationDependsOn(":app")
+val appProject = project(":app")
+val appArchive = appProject.tasks.named<AbstractArchiveTask>("shadowJar")
+val appArchiveFile = appProject.layout.buildDirectory.file("libs/QTranslate.jar")
+val minimalPluginIds = setOf("google-services", "bing-services", "mozhi-services")
+
+val bundledPlugins = subprojects
+    .filter { it.path.startsWith(":plugins:") && it.name != "common" }
+    .map { pluginProject ->
+        evaluationDependsOn(pluginProject.path)
+        val manifestFile = pluginProject.file("src/main/resources/plugin.json")
+        require(manifestFile.isFile) { "Plugin ${pluginProject.path} is missing plugin.json" }
+        @Suppress("UNCHECKED_CAST")
+        val manifest = JsonSlurper().parse(manifestFile) as Map<String, Any?>
+        BundledPlugin(
+            projectPath = pluginProject.path,
+            archiveFile = pluginProject.layout.buildDirectory.file("libs/${pluginProject.name}-plugin.jar").get().asFile,
+            id = requireNotNull(manifest["id"] as? String) { "Plugin ${pluginProject.path} has no id" },
+            name = requireNotNull(manifest["name"] as? String) { "Plugin ${pluginProject.path} has no name" },
+            version = requireNotNull(manifest["version"] as? String) { "Plugin ${pluginProject.path} has no version" },
+            minApiVersion = requireNotNull(manifest["minApiVersion"] as? String) {
+                "Plugin ${pluginProject.path} has no minApiVersion"
+            },
+        )
+    }
+    .sortedBy { it.id }
+
+val smokeDirectory = layout.buildDirectory.dir("plugin-smoke-test")
 val cleanPluginSmoke by tasks.registering(Delete::class) {
     delete(smokeDirectory)
 }
-
 val preparePluginSmoke by tasks.registering(Sync::class) {
     dependsOn(cleanPluginSmoke)
-    dependsOn(smokePluginProjects.map { "${it.path}:shadowJar" })
+    dependsOn(bundledPlugins.map { "${it.projectPath}:shadowJar" })
     into(smokeDirectory.map { it.dir("app-data/plugins") })
-
-    smokePluginProjects.forEach { pluginProject ->
-        from(pluginProject.layout.buildDirectory.dir("libs")) {
-            include("*-plugin.jar")
-        }
+    bundledPlugins.forEach { plugin ->
+        from(plugin.archiveFile)
     }
 }
-
-evaluationDependsOn(":app")
 
 tasks.register<JavaExec>("smokeTestAllPlugins") {
     group = "verification"
     description = "Loads, configures, toggles, and exercises every bundled plugin."
     dependsOn(preparePluginSmoke, ":app:classes")
-
-    val appProject = project(":app")
     classpath(
         appProject.layout.buildDirectory.dir("classes/kotlin/main"),
         appProject.layout.buildDirectory.dir("resources/main"),
         appProject.configurations.named("runtimeClasspath")
     )
     mainClass.set("com.github.ahatem.qtranslate.app.PluginSmokeTestMainKt")
-
     val root = smokeDirectory.get().asFile
     args(root.resolve("app-data").absolutePath, root.resolve("report.txt").absolutePath)
     systemProperty("java.awt.headless", "true")
+}
+
+fun Zip.configureBundle(plugins: List<BundledPlugin>, variant: String) {
+    group = "distribution"
+    description = "Builds the $variant QTranslate distribution."
+    dependsOn(appArchive)
+    dependsOn(plugins.map { "${it.projectPath}:shadowJar" })
+    destinationDirectory.set(releaseOutputDirectory)
+    archiveFileName.set("QTranslate-${variant.replaceFirstChar(Char::uppercase)}-${releaseVersion.get()}.zip")
+
+    into("QTranslate") {
+        from(appArchiveFile) {
+            rename { "QTranslate.jar" }
+        }
+        from(rootProject.file("languages")) {
+            into("languages")
+        }
+        from(rootProject.file("themes")) {
+            into("themes")
+        }
+        plugins.forEach { plugin ->
+            from(plugin.archiveFile) {
+                into("plugins")
+                rename { plugin.bundledFileName }
+            }
+        }
+    }
+    notCompatibleWithConfigurationCache("Release archives discover plugin manifests at configuration time.")
+}
+
+val cleanRelease by tasks.registering(Delete::class) {
+    delete(releaseOutputDirectory)
+}
+
+val assembleAppOnly by tasks.registering(Copy::class) {
+    group = "distribution"
+    description = "Builds the standalone application JAR without plugins."
+    dependsOn(cleanRelease, appArchive)
+    into(releaseOutputDirectory)
+    from(appArchiveFile)
+    rename("QTranslate.jar", "QTranslate-App-${releaseVersion.get()}.jar")
+}
+
+val minimalPlugins = bundledPlugins.filter { it.id in minimalPluginIds }
+val missingMinimalPluginIds = minimalPluginIds - minimalPlugins.map { it.id }.toSet()
+val assembleMinimal by tasks.registering(Zip::class) {
+    configureBundle(minimalPlugins, "minimal")
+    dependsOn(cleanRelease)
+    doFirst {
+        check(missingMinimalPluginIds.isEmpty()) {
+            "Minimal distribution requires missing plugin module(s): ${missingMinimalPluginIds.sorted().joinToString()}"
+        }
+    }
+}
+
+val assembleFull by tasks.registering(Zip::class) {
+    configureBundle(bundledPlugins, "full")
+    dependsOn(cleanRelease)
+}
+
+val assembleIndividualPlugins by tasks.registering(Copy::class) {
+    group = "distribution"
+    description = "Builds every plugin as an independently versioned JAR."
+    dependsOn(cleanRelease)
+    dependsOn(bundledPlugins.map { "${it.projectPath}:shadowJar" })
+    into(releaseOutputDirectory.map { it.dir("plugins") })
+    bundledPlugins.forEach { plugin ->
+        from(plugin.archiveFile) {
+            rename { plugin.releaseFileName }
+        }
+    }
+    notCompatibleWithConfigurationCache("Plugin archives are discovered from plugin manifests.")
+}
+
+val releaseMetadata = linkedMapOf(
+    "schemaVersion" to 1,
+    "appVersion" to releaseVersion.get(),
+    "variants" to listOf(
+        mapOf("id" to "app-only", "file" to "QTranslate-App-${releaseVersion.get()}.jar", "plugins" to emptyList<String>()),
+        mapOf("id" to "minimal", "file" to "QTranslate-Minimal-${releaseVersion.get()}.zip", "plugins" to minimalPlugins.map { it.id }),
+        mapOf("id" to "full", "file" to "QTranslate-Full-${releaseVersion.get()}.zip", "plugins" to bundledPlugins.map { it.id }),
+    ),
+    "plugins" to bundledPlugins.map { plugin ->
+        linkedMapOf(
+            "id" to plugin.id,
+            "name" to plugin.name,
+            "version" to plugin.version,
+            "minApiVersion" to plugin.minApiVersion,
+            "file" to "plugins/${plugin.releaseFileName}",
+            "bundledIn" to buildList {
+                add("full")
+                if (plugin.id in minimalPluginIds) add("minimal")
+            },
+        )
+    },
+)
+
+val generateReleaseMetadata by tasks.registering(GenerateReleaseMetadataTask::class) {
+    group = "distribution"
+    description = "Writes machine-readable metadata for release variants and plugins."
+    dependsOn(assembleAppOnly, assembleMinimal, assembleFull, assembleIndividualPlugins)
+    metadataJson.set(JsonOutput.toJson(releaseMetadata))
+    releaseDirectory.set(releaseOutputDirectory)
+    artifactFiles.from(
+        releaseOutputDirectory.map { directory ->
+            buildList {
+                add(directory.file("QTranslate-App-${releaseVersion.get()}.jar"))
+                add(directory.file("QTranslate-Minimal-${releaseVersion.get()}.zip"))
+                add(directory.file("QTranslate-Full-${releaseVersion.get()}.zip"))
+                bundledPlugins.forEach { add(directory.file("plugins/${it.releaseFileName}")) }
+            }
+        },
+    )
+    outputFile.set(releaseOutputDirectory.map { it.file("release-metadata.json") })
+}
+
+val generateReleaseChecksums by tasks.registering(GenerateReleaseChecksumsTask::class) {
+    group = "distribution"
+    description = "Writes SHA-256 checksums for every release artifact."
+    dependsOn(generateReleaseMetadata)
+    releaseDirectory.set(releaseOutputDirectory)
+    outputFile.set(releaseOutputDirectory.map { it.file("SHA256SUMS.txt") })
+}
+
+tasks.register("assembleReleaseVariants") {
+    group = "distribution"
+    description = "Builds app-only, minimal, full, and individual plugin release artifacts."
+    dependsOn(generateReleaseChecksums)
+    notCompatibleWithConfigurationCache("Release assembly includes dynamic plugin artifacts.")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,14 +121,12 @@ val assembleAppOnly by tasks.registering(Copy::class) {
 
 val minimalPlugins = bundledPlugins.filter { it.id in minimalPluginIds }
 val missingMinimalPluginIds = minimalPluginIds - minimalPlugins.map { it.id }.toSet()
+val validateMinimalPlugins by tasks.registering(ValidateRequiredPluginsTask::class) {
+    missingPluginIds.set(missingMinimalPluginIds.sorted())
+}
 val assembleMinimal by tasks.registering(Zip::class) {
     configureBundle(minimalPlugins, "minimal")
-    dependsOn(cleanRelease)
-    doFirst {
-        check(missingMinimalPluginIds.isEmpty()) {
-            "Minimal distribution requires missing plugin module(s): ${missingMinimalPluginIds.sorted().joinToString()}"
-        }
-    }
+    dependsOn(cleanRelease, validateMinimalPlugins)
 }
 
 val assembleFull by tasks.registering(Zip::class) {

--- a/buildSrc/src/main/kotlin/GenerateReleaseChecksumsTask.kt
+++ b/buildSrc/src/main/kotlin/GenerateReleaseChecksumsTask.kt
@@ -1,0 +1,37 @@
+import java.security.MessageDigest
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+abstract class GenerateReleaseChecksumsTask : DefaultTask() {
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val releaseDirectory: DirectoryProperty
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val root = releaseDirectory.get().asFile
+        val checksumFile = outputFile.get().asFile
+        val artifacts = root.walkTopDown()
+            .filter { it.isFile && it != checksumFile }
+            .sortedBy { it.relativeTo(root).invariantSeparatorsPath }
+            .toList()
+        val lines = artifacts.map { artifact ->
+            val digest = MessageDigest.getInstance("SHA-256").digest(artifact.readBytes())
+            val hash = digest.joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+            "$hash  ${artifact.relativeTo(root).invariantSeparatorsPath}"
+        }
+        checksumFile.apply {
+            parentFile.mkdirs()
+            writeText(lines.joinToString("\n", postfix = "\n"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/GenerateReleaseMetadataTask.kt
+++ b/buildSrc/src/main/kotlin/GenerateReleaseMetadataTask.kt
@@ -1,0 +1,55 @@
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.security.MessageDigest
+
+abstract class GenerateReleaseMetadataTask : DefaultTask() {
+    @get:Input
+    abstract val metadataJson: Property<String>
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val artifactFiles: ConfigurableFileCollection
+
+    @get:Internal
+    abstract val releaseDirectory: DirectoryProperty
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        @Suppress("UNCHECKED_CAST")
+        val parsed = JsonSlurper().parseText(metadataJson.get()) as MutableMap<String, Any?>
+        val root = releaseDirectory.get().asFile
+        val artifacts = artifactFiles.files.associateBy { it.relativeTo(root).invariantSeparatorsPath }
+        sequenceOf("variants", "plugins").forEach { section ->
+            @Suppress("UNCHECKED_CAST")
+            (parsed[section] as List<MutableMap<String, Any?>>).forEach { item ->
+                val artifact = artifacts[item["file"] as String] ?: return@forEach
+                item["sizeBytes"] = artifact.length()
+                item["sha256"] = sha256(artifact.readBytes())
+            }
+        }
+        outputFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(JsonOutput.prettyPrint(JsonOutput.toJson(parsed)) + "\n")
+        }
+    }
+
+    private fun sha256(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+}

--- a/buildSrc/src/main/kotlin/ValidateRequiredPluginsTask.kt
+++ b/buildSrc/src/main/kotlin/ValidateRequiredPluginsTask.kt
@@ -1,0 +1,17 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+abstract class ValidateRequiredPluginsTask : DefaultTask() {
+    @get:Input
+    abstract val missingPluginIds: ListProperty<String>
+
+    @TaskAction
+    fun validate() {
+        val missing = missingPluginIds.get()
+        check(missing.isEmpty()) {
+            "Minimal distribution requires missing plugin module(s): ${missing.joinToString()}"
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds release builds for the supported distribution variants:

- **App only:** portable application JAR without plugins
- **Minimal:** application with Google, Bing, and Mozhi
- **Full:** application with every bundled plugin discovered from plugin manifests
- **Individual plugins:** independently versioned plugin JARs

CI builds each variant as a separate artifact. Tagged releases publish all variants, individual plugin JARs, machine-readable metadata, and SHA-256 checksums. The minimal plugin set is validated explicitly so a missing required module fails the build.

## Related issues

Related to #41, but does not close it. This PR publishes portable JAR/ZIP variants; the Windows executable requires the separate `jpackage` work.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)` (not applicable; Gradle file operations run inside task actions)
- [x] Public API has KDoc (no application or plugin public API changes)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

Additional verification:
- `./gradlew assembleReleaseVariants -PreleaseVersion=qa --no-build-cache`
- `./gradlew test --no-build-cache`
- Minimal archive contains exactly Google, Bing, and Mozhi (3 plugins)
- Full archive contains all 10 bundled plugins
- Metadata contains all 10 independently versioned plugin JARs
- All metadata and `SHA256SUMS.txt` hashes were recomputed successfully (0 mismatches)
- No new compiler warnings introduced; the build still reports existing project deprecation warnings

## Screenshots (if UI changes)

Not applicable. This PR changes Gradle distribution tasks and GitHub Actions workflows only.