### PR TITLE
fix(release): publish portable Windows executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,74 @@ permissions:
   contents: write
 
 jobs:
+  windows-package:
+    name: Build Windows executable
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Extract version
+        id: version
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}" -replace '^v', ''
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Build full distribution
+        shell: pwsh
+        run: ./gradlew assembleFull -PreleaseVersion=${{ steps.version.outputs.version }} --no-daemon
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Assemble portable Windows app image
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $packageVersion = ($version -split '-')[0]
+          $fullArchive = "build/release/QTranslate-Full-$version.zip"
+
+          Expand-Archive -LiteralPath $fullArchive -DestinationPath full-distribution
+          New-Item -ItemType Directory -Force package-input | Out-Null
+          Copy-Item full-distribution/QTranslate/QTranslate.jar package-input/QTranslate.jar
+
+          jpackage `
+            --type app-image `
+            --name QTranslate `
+            --input package-input `
+            --main-jar QTranslate.jar `
+            --main-class com.github.ahatem.qtranslate.app.MainKt `
+            --app-version $packageVersion `
+            --icon ui-swing/src/main/resources/icons/app/icon.ico `
+            --dest windows-package `
+            --java-options '-Dfile.encoding=UTF-8'
+
+          Copy-Item full-distribution/QTranslate/plugins windows-package/QTranslate/plugins -Recurse
+          Copy-Item full-distribution/QTranslate/languages windows-package/QTranslate/languages -Recurse
+          Copy-Item full-distribution/QTranslate/themes windows-package/QTranslate/themes -Recurse
+          Compress-Archive -Path windows-package/QTranslate -DestinationPath "QTranslate-$version-windows-x64.zip"
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v7
+        with:
+          name: qtranslate-windows-x64
+          path: QTranslate-${{ steps.version.outputs.version }}-windows-x64.zip
+          if-no-files-found: error
+
   release:
     name: Build & Publish Release
     runs-on: ubuntu-latest
+    needs: windows-package
 
     steps:
       - name: Checkout
@@ -36,6 +101,17 @@ jobs:
         run: ./gradlew assembleReleaseVariants -PreleaseVersion=${{ steps.version.outputs.version }} --no-daemon
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Download Windows package
+        uses: actions/download-artifact@v8
+        with:
+          name: qtranslate-windows-x64
+          path: build/release
+
+      - name: Add Windows checksum
+        run: |
+          cd build/release
+          sha256sum "QTranslate-${{ steps.version.outputs.version }}-windows-x64.zip" >> SHA256SUMS.txt
 
       - name: Generate changelog
         id: changelog
@@ -94,7 +170,9 @@ jobs:
             - **App only:** QTranslate without plugins
             - **Individual plugins:** independently versioned plugin JARs
 
-            > **Requires Java 11 or later.** [Download Java](https://adoptium.net)
+            Windows users can download `QTranslate-${{ steps.version.outputs.version }}-windows-x64.zip`, extract it, and run `QTranslate.exe`. The Windows package includes its own Java runtime.
+
+            > Portable JAR/ZIP variants require Java 11 or later. The Windows executable does not require a separate Java installation.
 
             ## Verification
 
@@ -107,6 +185,7 @@ jobs:
             build/release/QTranslate-App-${{ steps.version.outputs.version }}.jar
             build/release/QTranslate-Minimal-${{ steps.version.outputs.version }}.zip
             build/release/QTranslate-Full-${{ steps.version.outputs.version }}.zip
+            build/release/QTranslate-${{ steps.version.outputs.version }}-windows-x64.zip
             build/release/plugins/*.jar
             build/release/release-metadata.json
             build/release/SHA256SUMS.txt

--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDataDirectory.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDataDirectory.kt
@@ -43,6 +43,10 @@ object AppDataDirectory {
             return file.also { f -> f.mkdirs() }
         }
 
+        nativeLauncherDirectory()?.let { directory ->
+            if (directory.canWrite()) return directory.also { it.mkdirs() }
+        }
+
         val jarDir = jarLocation()
         if (jarDir != null && jarDir.canWrite()) {
             return jarDir.also { it.mkdirs() }
@@ -62,6 +66,13 @@ object AppDataDirectory {
             .toURI()
         File(uri).parentFile
     }.getOrNull()
+
+    /** Returns the directory containing a native launcher created by jpackage. */
+    private fun nativeLauncherDirectory(): File? =
+        System.getProperty("jpackage.app-path")
+            ?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?.parentFile
 
     private fun osFallback(): File {
         val base = when {


### PR DESCRIPTION
## What does this PR do?

Publishes a portable Windows x64 package containing `QTranslate.exe`, an embedded Java runtime, every bundled plugin, languages, and themes.

The Windows job builds the dynamic Full distribution first, so newly added bundled plugins are included automatically. It then creates a `jpackage` app image with the QTranslate icon, uploads the ZIP to the release job, adds its SHA-256 checksum, and publishes it alongside the existing app-only, minimal, full, and individual-plugin artifacts.

Native launches store portable settings and plugin data beside `QTranslate.exe` when that directory is writable, with the existing OS data-directory fallback retained for protected locations.

## Related issues

Closes #41.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)` (not applicable; packaging runs in GitHub Actions)
- [x] Public API has KDoc (no public API changes; the launcher helper is private and documented)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

Additional verification:
- `./gradlew assembleFull -PreleaseVersion=qa --no-build-cache`
- Created a real Windows app image locally with `jpackage 25.0.2`
- Confirmed `QTranslate.exe` and the embedded JVM are present
- Confirmed all 10 bundled plugin JARs are present
- Launched the packaged executable and confirmed the UI process remained responsive
- `./gradlew test --no-build-cache`
- Portable JAR/ZIP variants still require Java 11+; the Windows package includes Java

## Screenshots (if UI changes)

Not applicable. This PR adds release packaging without changing application UI layouts.