### PR TITLE
build: reduce bundled package size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           - variant: minimal
             task: assembleMinimal
           - variant: full
-            task: assembleFull
+            task: validateReleaseSizes
           - variant: plugins
             task: assembleIndividualPlugins
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Java 17
+      - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -50,6 +50,20 @@ jobs:
           New-Item -ItemType Directory -Force package-input | Out-Null
           Copy-Item full-distribution/QTranslate/QTranslate.jar package-input/QTranslate.jar
 
+          $modules = @(
+            'java.base', 'java.desktop', 'java.instrument', 'java.logging',
+            'java.management', 'java.naming', 'java.net.http', 'java.prefs',
+            'java.security.jgss', 'java.xml.crypto', 'jdk.charsets', 'jdk.unsupported'
+          ) -join ','
+          jlink `
+            --add-modules $modules `
+            --strip-debug `
+            --no-header-files `
+            --no-man-pages `
+            --strip-native-commands `
+            --compress=2 `
+            --output qtranslate-runtime
+
           jpackage `
             --type app-image `
             --name QTranslate `
@@ -58,6 +72,7 @@ jobs:
             --main-class com.github.ahatem.qtranslate.app.MainKt `
             --app-version $packageVersion `
             --icon ui-swing/src/main/resources/icons/app/icon.ico `
+            --runtime-image qtranslate-runtime `
             --dest windows-package `
             --java-options '-Dfile.encoding=UTF-8'
 
@@ -188,6 +203,7 @@ jobs:
             build/release/QTranslate-${{ steps.version.outputs.version }}-windows-x64.zip
             build/release/plugins/*.jar
             build/release/release-metadata.json
+            build/release/SIZE_REPORT.md
             build/release/SHA256SUMS.txt
           prerelease: ${{ contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-rc') }}
           draft: false

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,12 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":ui-swing"))
 
+    // Bundled plugins are distributed as thin JARs. Keep their shared runtime
+    // dependencies in the host while external plugins remain self-contained.
+    runtimeOnly(project(":plugins:common"))
+    runtimeOnly(libs.jsoup)
+    runtimeOnly(libs.java.diff.utils)
+
     // Coroutines — needed for runBlocking in Main.kt and AppScope
     implementation(libs.kotlinxCoroutines)
 
@@ -77,12 +83,12 @@ val externalPluginsDirectory = providers.gradleProperty("pluginsDir")
 val prepareManualQaPlugins by tasks.registering(Sync::class) {
     group = "application"
     description = "Builds bundled plugins and stages them with external plugin JARs for manual QA."
-    dependsOn(manualQaPluginProjects.map { "${it.path}:shadowJar" })
+    dependsOn(manualQaPluginProjects.map { "${it.path}:jar" })
     into(manualQaDirectory.map { it.dir("app-data/plugins") })
 
     manualQaPluginProjects.forEach { pluginProject ->
-        from(pluginProject.layout.buildDirectory.dir("libs")) {
-            include("*-plugin.jar")
+        from(pluginProject.tasks.named<Jar>("jar").flatMap { it.archiveFile }) {
+            rename { "${pluginProject.name}-plugin.jar" }
         }
     }
     from(externalPluginsDirectory) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,14 +9,15 @@ plugins {
 
 data class BundledPlugin(
     val projectPath: String,
-    val archiveFile: File,
+    val thinArchiveFile: Provider<RegularFile>,
+    val standaloneArchiveFile: Provider<RegularFile>,
     val id: String,
     val name: String,
     val version: String,
     val minApiVersion: String,
 ) {
     val releaseFileName = "$id-$version.jar"
-    val bundledFileName = archiveFile.name
+    val bundledFileName = "${projectPath.substringAfterLast(':')}-plugin.jar"
 }
 
 val releaseVersion = providers.gradleProperty("releaseVersion")
@@ -39,7 +40,8 @@ val bundledPlugins = subprojects
         val manifest = JsonSlurper().parse(manifestFile) as Map<String, Any?>
         BundledPlugin(
             projectPath = pluginProject.path,
-            archiveFile = pluginProject.layout.buildDirectory.file("libs/${pluginProject.name}-plugin.jar").get().asFile,
+            thinArchiveFile = pluginProject.tasks.named<AbstractArchiveTask>("jar").flatMap { it.archiveFile },
+            standaloneArchiveFile = pluginProject.tasks.named<AbstractArchiveTask>("shadowJar").flatMap { it.archiveFile },
             id = requireNotNull(manifest["id"] as? String) { "Plugin ${pluginProject.path} has no id" },
             name = requireNotNull(manifest["name"] as? String) { "Plugin ${pluginProject.path} has no name" },
             version = requireNotNull(manifest["version"] as? String) { "Plugin ${pluginProject.path} has no version" },
@@ -56,10 +58,12 @@ val cleanPluginSmoke by tasks.registering(Delete::class) {
 }
 val preparePluginSmoke by tasks.registering(Sync::class) {
     dependsOn(cleanPluginSmoke)
-    dependsOn(bundledPlugins.map { "${it.projectPath}:shadowJar" })
+    dependsOn(bundledPlugins.map { "${it.projectPath}:jar" })
     into(smokeDirectory.map { it.dir("app-data/plugins") })
     bundledPlugins.forEach { plugin ->
-        from(plugin.archiveFile)
+        from(plugin.thinArchiveFile) {
+            rename { plugin.bundledFileName }
+        }
     }
 }
 
@@ -82,7 +86,7 @@ fun Zip.configureBundle(plugins: List<BundledPlugin>, variant: String) {
     group = "distribution"
     description = "Builds the $variant QTranslate distribution."
     dependsOn(appArchive)
-    dependsOn(plugins.map { "${it.projectPath}:shadowJar" })
+    dependsOn(plugins.map { "${it.projectPath}:jar" })
     destinationDirectory.set(releaseOutputDirectory)
     archiveFileName.set("QTranslate-${variant.replaceFirstChar(Char::uppercase)}-${releaseVersion.get()}.zip")
 
@@ -97,7 +101,7 @@ fun Zip.configureBundle(plugins: List<BundledPlugin>, variant: String) {
             into("themes")
         }
         plugins.forEach { plugin ->
-            from(plugin.archiveFile) {
+            from(plugin.thinArchiveFile) {
                 into("plugins")
                 rename { plugin.bundledFileName }
             }
@@ -141,7 +145,7 @@ val assembleIndividualPlugins by tasks.registering(Copy::class) {
     dependsOn(bundledPlugins.map { "${it.projectPath}:shadowJar" })
     into(releaseOutputDirectory.map { it.dir("plugins") })
     bundledPlugins.forEach { plugin ->
-        from(plugin.archiveFile) {
+        from(plugin.standaloneArchiveFile) {
             rename { plugin.releaseFileName }
         }
     }
@@ -190,10 +194,24 @@ val generateReleaseMetadata by tasks.registering(GenerateReleaseMetadataTask::cl
     outputFile.set(releaseOutputDirectory.map { it.file("release-metadata.json") })
 }
 
+val validateReleaseSizes by tasks.registering(ValidateReleaseSizesTask::class) {
+    group = "verification"
+    description = "Reports release sizes and fails when portable artifacts exceed their budgets."
+    dependsOn(assembleAppOnly, assembleMinimal, assembleFull)
+    appArtifact.set(releaseOutputDirectory.map { it.file("QTranslate-App-${releaseVersion.get()}.jar") })
+    minimalArtifact.set(releaseOutputDirectory.map { it.file("QTranslate-Minimal-${releaseVersion.get()}.zip") })
+    fullArtifact.set(releaseOutputDirectory.map { it.file("QTranslate-Full-${releaseVersion.get()}.zip") })
+    maxAppBytes.set(55L * 1024 * 1024)
+    maxMinimalBytes.set(50L * 1024 * 1024)
+    maxFullBytes.set(52L * 1024 * 1024)
+    maxBundledPluginsBytes.set(3L * 1024 * 1024)
+    reportFile.set(releaseOutputDirectory.map { it.file("SIZE_REPORT.md") })
+}
+
 val generateReleaseChecksums by tasks.registering(GenerateReleaseChecksumsTask::class) {
     group = "distribution"
     description = "Writes SHA-256 checksums for every release artifact."
-    dependsOn(generateReleaseMetadata)
+    dependsOn(generateReleaseMetadata, validateReleaseSizes)
     releaseDirectory.set(releaseOutputDirectory)
     outputFile.set(releaseOutputDirectory.map { it.file("SHA256SUMS.txt") })
 }

--- a/buildSrc/src/main/kotlin/ValidateReleaseSizesTask.kt
+++ b/buildSrc/src/main/kotlin/ValidateReleaseSizesTask.kt
@@ -1,0 +1,80 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.util.Locale
+import java.util.zip.ZipFile
+
+abstract class ValidateReleaseSizesTask : DefaultTask() {
+    @get:InputFile
+    abstract val appArtifact: RegularFileProperty
+
+    @get:InputFile
+    abstract val minimalArtifact: RegularFileProperty
+
+    @get:InputFile
+    abstract val fullArtifact: RegularFileProperty
+
+    @get:Input
+    abstract val maxAppBytes: Property<Long>
+
+    @get:Input
+    abstract val maxMinimalBytes: Property<Long>
+
+    @get:Input
+    abstract val maxFullBytes: Property<Long>
+
+    @get:Input
+    abstract val maxBundledPluginsBytes: Property<Long>
+
+    @get:OutputFile
+    abstract val reportFile: RegularFileProperty
+
+    @TaskAction
+    fun validate() {
+        val app = appArtifact.get().asFile
+        val minimal = minimalArtifact.get().asFile
+        val full = fullArtifact.get().asFile
+        val bundledPluginsBytes = ZipFile(full).use { zip ->
+            zip.entries().asSequence()
+                .filter { !it.isDirectory && it.name.matches(Regex("QTranslate/plugins/.*-plugin\\.jar")) }
+                .sumOf { it.size }
+        }
+        val measurements = listOf(
+            Measurement("App JAR", app.length(), maxAppBytes.get()),
+            Measurement("Minimal ZIP", minimal.length(), maxMinimalBytes.get()),
+            Measurement("Full ZIP", full.length(), maxFullBytes.get()),
+            Measurement("Bundled plugin JARs", bundledPluginsBytes, maxBundledPluginsBytes.get())
+        )
+        val report = buildString {
+            appendLine("# Release size report")
+            appendLine()
+            appendLine("| Artifact | Size | Budget | Status |")
+            appendLine("|---|---:|---:|:---:|")
+            measurements.forEach { measurement ->
+                appendLine(
+                    "| ${measurement.name} | ${measurement.size.toMiB()} MiB | " +
+                        "${measurement.budget.toMiB()} MiB | ${if (measurement.passes) "PASS" else "FAIL"} |"
+                )
+            }
+        }
+        reportFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(report)
+        }
+        logger.lifecycle(report)
+        val failures = measurements.filterNot(Measurement::passes)
+        check(failures.isEmpty()) {
+            "Release size budget exceeded: " + failures.joinToString { "${it.name} ${it.size.toMiB()} MiB" }
+        }
+    }
+
+    private data class Measurement(val name: String, val size: Long, val budget: Long) {
+        val passes get() = size <= budget
+    }
+
+    private fun Long.toMiB(): String = String.format(Locale.ROOT, "%.2f", this / 1024.0 / 1024.0)
+}


### PR DESCRIPTION
## What does this PR do?

Reduces the portable release size by sharing plugin runtime dependencies through the host application instead of duplicating them inside every bundled plugin JAR.

Bundled plugins remain separate JARs and retain the existing plugin lifecycle. Individually downloadable plugin artifacts remain shaded and self-contained for installation into compatible app versions.

The release workflow also builds a trimmed Java 21 runtime for the portable Windows executable. A new release-size report and CI budget prevent dependency duplication from silently returning.

Measured locally:
- Full portable ZIP: about 115.36 MiB to 46.06 MiB
- Minimal portable ZIP: 45.47 MiB
- All bundled plugin JARs combined: 1.15 MiB
- Self-contained Windows ZIP with private runtime: 95.10 MiB
- Individually downloadable plugins remain self-contained

## Related issues

Follow-up to #41.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

Additional verification:
- `./gradlew test smokeTestAllPlugins --no-build-cache`: 40 passed, 0 failed
- `./gradlew validateReleaseSizes -PreleaseVersion=size-final --no-build-cache`: all budgets passed
- Local Windows app image launched and remained responsive with all 10 bundled plugins

## Screenshots (if UI changes)

Not applicable.