### PR TITLE
feat(ui): add document translation button to the history bar

### DIFF
--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -61,6 +61,7 @@ no_translator = "No Translator"
 backward_tooltip = "Go backward in translation history"
 forward_tooltip = "Go forward in translation history"
 image_translate_tooltip = "Capture and translate text from an area on screen"
+document_translate_tooltip = "Translate a document while preserving its formatting"
 
 [main_window_language_bar]
 clear_tooltip = "Clear input text"

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -61,6 +61,7 @@ no_translator = "لا يوجد مترجم"
 backward_tooltip = "الرجوع للخلف في سجل الترجمة"
 forward_tooltip = "التقدم للأمام في سجل الترجمة"
 image_translate_tooltip = "التقاط وترجمة نص من منطقة على الشاشة"
+document_translate_tooltip = "ترجمة مستند مع الحفاظ على تنسيقه"
 
 [main_window_language_bar]
 clear_tooltip = "مسح نص الإدخال"

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -61,6 +61,7 @@ no_translator = "কোন অনুবাদক নেই"
 backward_tooltip = "অনুবাদ ইতিহাসে পেছনে যান"
 forward_tooltip = "অনুবাদ ইতিহাসে সামনে যান"
 image_translate_tooltip = "স্ক্রিনের একটি অংশ থেকে লেখা ক্যাপচার এবং অনুবাদ করুন"
+document_translate_tooltip = "বিন্যাস অক্ষুণ্ন রেখে একটি নথি অনুবাদ করুন"
 
 [main_window_language_bar]
 clear_tooltip = "ইনপুট লেখা মুছুন"

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -61,6 +61,7 @@ no_translator = "Kein Übersetzer"
 backward_tooltip = "Im Verlauf zurückgehen"
 forward_tooltip = "Im Verlauf vorwärtsgehen"
 image_translate_tooltip = "Bildschirmbereich erfassen und Text übersetzen"
+document_translate_tooltip = "Dokument übersetzen und Formatierung beibehalten"
 
 [main_window_language_bar]
 clear_tooltip = "Eingabetext löschen"

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -61,6 +61,7 @@ no_translator = "No Translator"
 backward_tooltip = "Go backward in translation history"
 forward_tooltip = "Go forward in translation history"
 image_translate_tooltip = "Capture and translate text from an area on screen"
+document_translate_tooltip = "Translate a document while preserving its formatting"
 
 [main_window_language_bar]
 clear_tooltip = "Clear input text"

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -61,6 +61,7 @@ no_translator = "Sin traductor"
 backward_tooltip = "Retroceder en el historial de traducción"
 forward_tooltip = "Avanzar en el historial de traducción"
 image_translate_tooltip = "Capturar y traducir texto de un área de la pantalla"
+document_translate_tooltip = "Traducir un documento conservando su formato"
 
 [main_window_language_bar]
 clear_tooltip = "Limpiar texto de entrada"

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -61,6 +61,7 @@ no_translator = "Aucun traducteur"
 backward_tooltip = "Reculer dans l'historique de traduction"
 forward_tooltip = "Avancer dans l'historique de traduction"
 image_translate_tooltip = "Capturer et traduire du texte depuis une zone de l'écran"
+document_translate_tooltip = "Traduire un document en préservant sa mise en forme"
 
 [main_window_language_bar]
 clear_tooltip = "Effacer le texte d'entrée"

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -61,6 +61,7 @@ no_translator = "Nincs fordító"
 backward_tooltip = "Menjen vissza a fordítási előzményekben"
 forward_tooltip = "Menjen előre a fordítási előzményekben"
 image_translate_tooltip = "Szöveg rögzítése és fordítása a képernyőről"
+document_translate_tooltip = "Dokumentum fordítása a formázás megőrzésével"
 
 [main_window_language_bar]
 clear_tooltip = "Törölje a bevitt szöveget"

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -61,6 +61,7 @@ no_translator = "Nessuno traduttore"
 backward_tooltip = "Vai indietro nella cronologia traduzioni"
 forward_tooltip = "Vai avanti nella cronologia traduzioni"
 image_translate_tooltip = "Cattura e traduci il testo in un'area sullo schermo"
+document_translate_tooltip = "Traduci un documento preservandone la formattazione"
 
 [main_window_language_bar]
 clear_tooltip = "Cancella il testo inserito"

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -61,6 +61,7 @@ no_translator = "翻訳エンジン未選択"
 backward_tooltip = "前の翻訳に戻る"
 forward_tooltip = "次の翻訳に進む"
 image_translate_tooltip = "画面上の範囲を指定してテキストを翻訳"
+document_translate_tooltip = "書式を保持したままドキュメントを翻訳"
 
 [main_window_language_bar]
 clear_tooltip = "入力をクリア"

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -61,6 +61,7 @@ no_translator = "Sem Tradutor"
 backward_tooltip = "Voltar no histórico de tradução"
 forward_tooltip = "Avançar no histórico de tradução"
 image_translate_tooltip = "Capturar e traduzir texto de uma área na tela"
+document_translate_tooltip = "Traduzir um documento preservando sua formatação"
 
 [main_window_language_bar]
 clear_tooltip = "Limpar texto de entrada"

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -61,6 +61,7 @@ no_translator = "Переводчик не выбран"
 backward_tooltip = "Назад по истории переводов"
 forward_tooltip = "Вперед по истории переводов"
 image_translate_tooltip = "Захватить и перевести текст из области на экране"
+document_translate_tooltip = "Перевести документ с сохранением форматирования"
 
 [main_window_language_bar]
 clear_tooltip = "Очистить текст"

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -61,6 +61,7 @@ no_translator = "Çevirmen Yok"
 backward_tooltip = "Çeviri geçmişinde geri git"
 forward_tooltip = "Çeviri geçmişinde ileri git"
 image_translate_tooltip = "Ekrandaki bir alandan metin yakala ve çevir"
+document_translate_tooltip = "Bir belgeyi biçimlendirmesini koruyarak çevir"
 
 [main_window_language_bar]
 clear_tooltip = "Giriş metnini temizle"

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -61,6 +61,7 @@ no_translator = "未选择翻译器"
 backward_tooltip = "返回翻译历史"
 forward_tooltip = "前进翻译历史"
 image_translate_tooltip = "截取屏幕区域并翻译文本"
+document_translate_tooltip = "翻译文档并保留其格式"
 
 [main_window_language_bar]
 clear_tooltip = "清除输入文本"

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -185,6 +185,7 @@ class MainAppFrame(
         dispatch = { mainStore.dispatch(it) },
         dispatchSettings = { settingsStore.dispatch(it) },
         onOpenSnippingTool = { openSnippingTool() },
+        onOpenDocumentTranslation = { documentTranslationDialog.open() },
         onNotificationsClicked = { notificationPopover.show(mainContentView.statusBar) },
         onConfigureService = { serviceId -> openPluginConfiguration(serviceId) }
     )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -54,6 +54,7 @@ class MainContentView(
     private val dispatch: (MainIntent) -> Unit,
     private val dispatchSettings: (SettingsIntent) -> Unit,
     private val onOpenSnippingTool: () -> Unit,
+    private val onOpenDocumentTranslation: () -> Unit,
     private val onNotificationsClicked: () -> Unit,
     private val onConfigureService: (String) -> Unit,
 ) : JPanel(BorderLayout(0, 0)) {
@@ -63,6 +64,7 @@ class MainContentView(
         onBackward = { dispatch(MainIntent.UndoTranslation) },
         onForward = { dispatch(MainIntent.RedoTranslation) },
         onImageTranslate = { onOpenSnippingTool() },
+        onDocumentTranslate = { onOpenDocumentTranslation() },
     )
 
     private val translatorSelector = TranslatorSelector(
@@ -425,6 +427,7 @@ class MainContentView(
                     backwardTooltip = localizer.getString("main_window_history_bar.backward_tooltip"),
                     forwardTooltip = localizer.getString("main_window_history_bar.forward_tooltip"),
                     imageTranslateTooltip = localizer.getString("main_window_history_bar.image_translate_tooltip"),
+                    documentTranslateTooltip = localizer.getString("main_window_history_bar.document_translate_tooltip"),
                 ),
             )
         )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/history/TranslationHistoryBar.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/history/TranslationHistoryBar.kt
@@ -15,11 +15,13 @@ class TranslationHistoryBar(
     private val onBackward: () -> Unit,
     private val onForward: () -> Unit,
     private val onImageTranslate: () -> Unit,
+    private val onDocumentTranslate: () -> Unit,
 ) : JPanel(BorderLayout()), Renderable<TranslationHistoryBarState> {
 
     private val backwardButton = createButtonWithIcon(iconManager, "icons/lucide/arrow-left.svg", 16)
     private val forwardButton = createButtonWithIcon(iconManager, "icons/lucide/arrow-right.svg", 16)
     private val imageTranslateButton = createButtonWithIcon(iconManager, "icons/lucide/scan-text.svg", 16)
+    private val documentTranslateButton = createButtonWithIcon(iconManager, "icons/lucide/file-scan.svg", 16)
 
     private val statusLabel = JLabel().apply {
         border = BorderFactory.createEmptyBorder(0, 8, 0, 8)
@@ -35,12 +37,14 @@ class TranslationHistoryBar(
     private val rightGroup = JPanel(FlowLayout(FlowLayout.TRAILING, 2, 0)).apply {
         isOpaque = false
         add(imageTranslateButton)
+        add(documentTranslateButton)
     }
 
     init {
         backwardButton.addActionListener { onBackward() }
         forwardButton.addActionListener { onForward() }
         imageTranslateButton.addActionListener { onImageTranslate() }
+        documentTranslateButton.addActionListener { onDocumentTranslate() }
 
         add(leftGroup, BorderLayout.LINE_START)
         add(rightGroup, BorderLayout.LINE_END)
@@ -70,9 +74,11 @@ class TranslationHistoryBar(
         backwardButton.isEnabled = !state.isLoading && state.canGoBackward
         forwardButton.isEnabled = !state.isLoading && state.canGoForward
         imageTranslateButton.isEnabled = !state.isLoading
+        documentTranslateButton.isEnabled = !state.isLoading
 
         backwardButton.toolTipText = state.strings.backwardTooltip
         forwardButton.toolTipText = state.strings.forwardTooltip
         imageTranslateButton.toolTipText = state.strings.imageTranslateTooltip
+        documentTranslateButton.toolTipText = state.strings.documentTranslateTooltip
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/history/TranslationHistoryBarState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/history/TranslationHistoryBarState.kt
@@ -14,4 +14,5 @@ data class TranslationHistoryBarStrings(
     val backwardTooltip: String,
     val forwardTooltip: String,
     val imageTranslateTooltip: String,
+    val documentTranslateTooltip: String,
 )


### PR DESCRIPTION
## What does this PR do?

Adds a document translation button to the translation history bar, beside the existing screen-capture button.

Document translation shipped in #128 but was only reachable through **Options → Translate Document**. A feature that handles DOCX, PDF, TXT, SRT, and VTT deserves to be visible from the main window rather than buried in a menu.

**Implementation notes**

- The button calls `documentTranslationDialog.open()` — the exact same entry point the existing menu item uses. No second code path was introduced, so both entry points stay in sync automatically.
- Uses `icons/lucide/file-scan.svg`, which pairs visually with the `scan-text.svg` icon already used for screen capture.
- Disabled while a translation is in progress, matching the behaviour of the surrounding buttons.
- The callback is threaded through `MainContentView` as `onOpenDocumentTranslation`, following the same pattern as the existing `onOpenSnippingTool`.

**Localization**

`main_window_history_bar.document_translate_tooltip` was added to `embedded_en.toml` and translated in all 13 bundled locale files — no English fallbacks.

## Related issues

None — follow-up discoverability improvement for the document translation feature added in #128.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Attach a before/after of the history bar showing the new button. -->
