### PR TITLE
fix(release): quote the version property in the Windows package job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Build full distribution
         shell: pwsh
-        run: ./gradlew assembleFull -PreleaseVersion=${{ steps.version.outputs.version }} --no-daemon
+        # The property must be quoted: PowerShell otherwise splits the argument at the
+        # first dot, passing Gradle a bogus ".3.0" task name and failing the build.
+        run: ./gradlew assembleFull "-PreleaseVersion=${{ steps.version.outputs.version }}" --no-daemon
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
 
@@ -113,7 +115,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build release variants
-        run: ./gradlew assembleReleaseVariants -PreleaseVersion=${{ steps.version.outputs.version }} --no-daemon
+        run: ./gradlew assembleReleaseVariants "-PreleaseVersion=${{ steps.version.outputs.version }}" --no-daemon
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
 

--- a/wiki/Building-from-Source.md
+++ b/wiki/Building-from-Source.md
@@ -78,6 +78,13 @@ The QA launcher uses an isolated directory under `app/build/manual-qa/`, prints 
 ./gradlew assembleReleaseVariants -PreleaseVersion=1.3.0
 ```
 
+On PowerShell, quote the property — unquoted, PowerShell splits it at the first dot
+and Gradle fails with `Task '.3.0' not found`:
+
+```powershell
+.\gradlew.bat assembleReleaseVariants "-PreleaseVersion=1.3.0"
+```
+
 Artifacts are written to `build/release/`:
 
 - `QTranslate-App-1.3.0.jar` — app only
@@ -96,7 +103,7 @@ Each plugin is a separate Gradle subproject under `plugins/`:
 
 ```bash
 ./gradlew :plugins:google-services:shadowJar
-./gradlew assembleIndividualPlugins -PreleaseVersion=1.3.0
+./gradlew assembleIndividualPlugins -PreleaseVersion=1.3.0   # quote on PowerShell
 ```
 
 Single-plugin JARs are written to `plugins/<name>/build/libs/`. The aggregate task writes normalized, versioned JARs to `build/release/plugins/`. Install them through the QTranslate UI as described in [Installing Plugins](Installing-Plugins.md).

--- a/wiki/Releasing.md
+++ b/wiki/Releasing.md
@@ -38,8 +38,11 @@ From the exact commit you intend to tag:
 ```powershell
 .\gradlew.bat clean build test --no-daemon
 .\gradlew.bat smokeTestAllPlugins --no-daemon --console=plain
-.\gradlew.bat assembleReleaseVariants -PreleaseVersion=1.3.0 --no-daemon
+.\gradlew.bat assembleReleaseVariants "-PreleaseVersion=1.3.0" --no-daemon
 ```
+
+> Quote `-PreleaseVersion=...` in PowerShell. Unquoted, PowerShell splits the argument
+> at the first dot and Gradle fails with `Task '.3.0' not found`.
 
 Review:
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows packaging job, which failed on the first tag that exercised it.

The `windows-package` job runs under `shell: pwsh`. PowerShell splits an unquoted `-PreleaseVersion=1.3.0` at the first dot, so Gradle received `.3.0` as a task name:

```
Calculating task graph as no cached configuration is available for tasks: assembleFull .3.0-rc.1
Task '.3.0-rc.1' not found in root project 'qtranslate-app' and its subprojects.
```

**This was not limited to prerelease tags.** `-PreleaseVersion=1.3.0` splits identically — the dot is what breaks it, not the `-rc.1` suffix. Any tag would have failed at the Windows job, and because the publish job declares `needs: windows-package`, the release would have been skipped entirely and no assets published.

The job was added in #143, after 1.2.1 shipped, so no tagged release had run it until `v1.3.0-rc.1`.

**Changes**

- Quote `-PreleaseVersion=...` in the `windows-package` job (the actual fix), with a comment explaining why.
- Quote it in the Linux `release` job too. Bash is not affected, but the two jobs should not differ in a way that looks accidental.
- Document the pitfall in `wiki/Releasing.md` and `wiki/Building-from-Source.md`, where these commands are given in PowerShell blocks and would have led maintainers into the same failure.

**Verification**

Reproduced and confirmed fixed locally under PowerShell. Unquoted, the task graph shows a stray `.3.0` entry; quoted, it resolves to the intended task only.

## Related issues

Discovered by the `v1.3.0-rc.1` release candidate — [run 31761545690](https://github.com/ahatem/QTranslate/actions/runs/31761545690).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable — CI and documentation only.
