### PR TITLE
fix(release): add missing crypto and locale modules to the Windows runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,22 @@ jobs:
           New-Item -ItemType Directory -Force package-input | Out-Null
           Copy-Item full-distribution/QTranslate/QTranslate.jar package-input/QTranslate.jar
 
+          # jlink only includes modules listed here. Providers loaded reflectively via
+          # ServiceLoader (JCA crypto, locale data) are invisible to static analysis, so
+          # they must be requested explicitly or they silently vanish from the runtime.
           $modules = @(
             'java.base', 'java.desktop', 'java.instrument', 'java.logging',
             'java.management', 'java.naming', 'java.net.http', 'java.prefs',
-            'java.security.jgss', 'java.xml.crypto', 'jdk.charsets', 'jdk.unsupported'
+            'java.security.jgss', 'java.xml.crypto', 'jdk.charsets', 'jdk.unsupported',
+            # SunEC provider. Without it every ECDHE/ECDSA TLS handshake fails, which
+            # breaks all network services ("EC KeyPairGenerator not available").
+            'jdk.crypto.ec',
+            # Locale data for the 13 bundled languages. Without it the JDK falls back to
+            # ROOT/English number, date, and display-name formatting.
+            'jdk.localedata',
+            # ZIP FileSystem provider. Not required by the app itself, but bundled plugins
+            # are third-party code that may rely on it; the module costs ~100 KB.
+            'jdk.zipfs'
           ) -join ','
           jlink `
             --add-modules $modules `


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows executable, where the app launched but **every network service failed**:

```
Translation failed: Network error: EC KeyPairGenerator not available          (Google)
Translation failed: Network error: SHA256withECDSA Signature not available    (DeepL)
Translation failed: Network error: signature check failed                     (Bing)
```

**Cause:** the `jlink` module list omitted `jdk.crypto.ec`, so the SunEC provider was missing from the bundled runtime. Modern TLS negotiates ECDHE key exchange and ECDSA certificate signatures, so **every HTTPS handshake failed**. The app itself ran fine because nothing else needed EC — only the network path broke, which is why it looked like a per-service problem rather than a runtime problem.

`jlink` resolves modules statically. JCA crypto providers and locale data are loaded reflectively through `ServiceLoader`, so they are invisible to that analysis and are silently dropped unless requested by name.

### Verification

Reproduced against **Temurin 21** (the version the job builds with) using the exact shipped module list:

| Endpoint | Shipped runtime | With `jdk.crypto.ec` |
|---|---|---|
| `translate.googleapis.com` | `SSLHandshakeException` | HTTP 200 |
| `api-free.deepl.com` | `SSLHandshakeException` | HTTP 403 *(no API key — expected)* |
| `www.bing.com` | `SSLHandshakeException` | HTTP 200 |

The lower-level probe matches the reported errors word for word:

```
MISSING EC KeyPairGenerator -> EC KeyPairGenerator not available
MISSING SHA256withECDSA Signature -> SHA256withECDSA Signature not available
```

Note this only reproduces on **Java 21**. On Java 25 the EC implementation lives in `java.base`, so a local check with a newer JDK will not surface it.

### Also added

- **`jdk.localedata`** — without it the runtime only carries ROOT/English locale data. Verified: Russian numbers formatted as `1,234.5` instead of `1 234,5`, and German display names rendered as `German` instead of `Deutsch`. Matters for the 13 bundled locales.
- **`jdk.zipfs`** — precautionary for third-party plugins. Explicitly verified **not** required by the app: POI round-trips DOCX and PDFBox writes PDFs without it. Included because the module costs ~100 KB and plugins are third-party code.

### Size impact

Runtime image grows from ~50 MB to ~61 MB, almost entirely locale data. No artifact size budget covers the Windows package, so no budget changes are needed.

## Related issues

Found during manual QA of the `v1.3.0-rc.2` prerelease.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable — CI packaging only.
