### PR TITLE
perf(translation): show the translation without waiting for extra output

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
@@ -91,7 +91,7 @@ class TranslateTextUseCase(
         translationJob = scope.launch {
             try {
                 onStatusUpdate(StatusCode.Translating, NotificationType.INFO, false)
-                updateState { copy(isLoading = true, translatedText = "", extraOutputText = "") }
+                updateState { copy(isLoading = true, translatedText = "", extraOutputText = "", isExtraOutputLoading = false) }
 
                 val currentState = getState()
                 val rules        = settingsState.value.translationRules
@@ -129,7 +129,7 @@ class TranslateTextUseCase(
 
                 if (result == null) {
                     logger.error("Translation timed out after ${AppConstants.TRANSLATION_TIMEOUT_MS}ms")
-                    updateState { copy(isLoading = false) }
+                    updateState { copy(isLoading = false, isExtraOutputLoading = false) }
                     onStatusUpdate(StatusCode.TranslationTimeout, NotificationType.ERROR, true)
                     return@launch
                 }
@@ -176,36 +176,24 @@ class TranslateTextUseCase(
                             detectedSourceLanguage = detectedLanguage?.tag
                         )
 
-                        val extraOutput = handleExtraOutput(
-                            targetText        = response.translatedText,
+                        // Publish the primary translation before requesting extra output —
+                        // the two are independent and the user should not wait for a second
+                        // round trip to read the first result.
+                        publishPrimaryThenExtraOutput(
+                            translatedText    = response.translatedText,
+                            detectedLanguage  = detectedLanguage,
+                            history           = newHistory,
+                            historyIndex      = newHistoryIndex,
                             sourceForBackward = detectedLanguage ?: currentState.sourceLanguage,
                             targetForBackward = initialTarget,
                             translator        = translator,
+                            updateState       = updateState,
                             onStatusUpdate    = onStatusUpdate
                         )
-
-                        val finalHistory = patchExtraOutput(
-                            newHistory, extraOutput, settingsState.value.extraOutputType.name
-                        )
-
-                        updateState {
-                            copy(
-                                isLoading              = false,
-                                translatedText         = response.translatedText,
-                                detectedSourceLanguage = detectedLanguage,
-                                history                = finalHistory,
-                                historyIndex           = newHistoryIndex,
-                                extraOutputText        = extraOutput
-                            )
-                        }
-
-                        if (settingsState.value.isHistoryEnabled) {
-                            historyRepository.saveHistory(finalHistory)
-                        }
                     },
                     failure = { error ->
                         logger.error("Translation failed: ${error.message}", error.cause)
-                        updateState { copy(isLoading = false) }
+                        updateState { copy(isLoading = false, isExtraOutputLoading = false) }
                         val summary = error.message?.lines()?.firstOrNull()?.take(120) ?: "Unknown error"
                         onStatusUpdate(StatusCode.TranslationFailed(summary), NotificationType.ERROR, true)
                     }
@@ -216,7 +204,7 @@ class TranslateTextUseCase(
                 throw e
             } catch (e: Exception) {
                 logger.error("Unexpected error during translation", e)
-                updateState { copy(isLoading = false) }
+                updateState { copy(isLoading = false, isExtraOutputLoading = false) }
                 val summary = e.message?.lines()?.firstOrNull()?.take(120) ?: "Unknown error"
                 onStatusUpdate(StatusCode.UnexpectedError(summary), NotificationType.ERROR, true)
             }
@@ -251,7 +239,7 @@ class TranslateTextUseCase(
 
         if (retryResult == null) {
             logger.error("Re-translation timed out")
-            updateState { copy(isLoading = false) }
+            updateState { copy(isLoading = false, isExtraOutputLoading = false) }
             onStatusUpdate(StatusCode.TranslationTimeout, NotificationType.ERROR, true)
             return
         }
@@ -266,37 +254,22 @@ class TranslateTextUseCase(
                     detectedSourceLanguage = detectedLanguage.tag
                 )
 
-                val extraOutput = handleExtraOutput(
-                    targetText        = retryResponse.translatedText,
+                publishPrimaryThenExtraOutput(
+                    translatedText    = retryResponse.translatedText,
+                    detectedLanguage  = detectedLanguage,
+                    history           = newHistory,
+                    historyIndex      = newHistoryIndex,
                     sourceForBackward = detectedLanguage,
                     targetForBackward = ruleTarget,
                     translator        = translator,
-                    onStatusUpdate    = onStatusUpdate
+                    updateState       = updateState,
+                    onStatusUpdate    = onStatusUpdate,
+                    ruleTarget        = ruleTarget
                 )
-
-                val finalHistory = patchExtraOutput(
-                    newHistory, extraOutput, settingsState.value.extraOutputType.name
-                )
-
-                updateState {
-                    copy(
-                        isLoading              = false,
-                        translatedText         = retryResponse.translatedText,
-                        detectedSourceLanguage = detectedLanguage,
-                        targetLanguage         = ruleTarget,
-                        history                = finalHistory,
-                        historyIndex           = newHistoryIndex,
-                        extraOutputText        = extraOutput
-                    )
-                }
-
-                if (settingsState.value.isHistoryEnabled) {
-                    historyRepository.saveHistory(finalHistory)
-                }
             },
             failure = { error ->
                 logger.error("Re-translation failed: ${error.message}", error.cause)
-                updateState { copy(isLoading = false) }
+                updateState { copy(isLoading = false, isExtraOutputLoading = false) }
                 val summary = error.message?.lines()?.firstOrNull()?.take(120) ?: "Unknown error"
                 onStatusUpdate(StatusCode.TranslationFailed(summary), NotificationType.ERROR, true)
             }
@@ -364,6 +337,79 @@ class TranslateTextUseCase(
     // -------------------------------------------------------------------------
     // Extra output
     // -------------------------------------------------------------------------
+
+    /**
+     * Publishes the primary translation immediately, then fills in the extra output when it
+     * arrives.
+     *
+     * The two results come from independent requests, so waiting for the second before showing
+     * the first made every translation feel as slow as the slowest of the pair. The primary
+     * result is written first and [MainState.isExtraOutputLoading] carries the secondary
+     * request, letting the extra panel show its own progress while the translation is already
+     * readable.
+     *
+     * Runs inside the caller's `translationJob`, so a new translation cancels an in-flight
+     * extra-output request and a stale result can never overwrite a newer translation.
+     *
+     * History is saved only after the extra output lands, so the persisted snapshot still
+     * contains it.
+     *
+     * @param ruleTarget Set only on the rule-driven path, where the target language changed
+     *   as a result of the detected source language.
+     */
+    private suspend fun publishPrimaryThenExtraOutput(
+        translatedText: String,
+        detectedLanguage: LanguageCode?,
+        history: List<HistorySnapshot>,
+        historyIndex: Int,
+        sourceForBackward: LanguageCode,
+        targetForBackward: LanguageCode,
+        translator: Translator,
+        updateState: (MainState.() -> MainState) -> Unit,
+        onStatusUpdate: suspend (code: StatusCode, type: NotificationType, isTemporary: Boolean) -> Unit,
+        ruleTarget: LanguageCode? = null
+    ) {
+        val extraOutputType = settingsState.value.extraOutputType
+        val expectsExtraOutput = extraOutputType != ExtraOutputType.None
+
+        updateState {
+            copy(
+                isLoading              = false,
+                translatedText         = translatedText,
+                detectedSourceLanguage = detectedLanguage,
+                targetLanguage         = ruleTarget ?: targetLanguage,
+                history                = history,
+                historyIndex           = historyIndex,
+                extraOutputText        = "",
+                isExtraOutputLoading   = expectsExtraOutput
+            )
+        }
+
+        if (!expectsExtraOutput) {
+            if (settingsState.value.isHistoryEnabled) historyRepository.saveHistory(history)
+            return
+        }
+
+        val extraOutput = handleExtraOutput(
+            targetText        = translatedText,
+            sourceForBackward = sourceForBackward,
+            targetForBackward = targetForBackward,
+            translator        = translator,
+            onStatusUpdate    = onStatusUpdate
+        )
+
+        val finalHistory = patchExtraOutput(history, extraOutput, extraOutputType.name)
+
+        updateState {
+            copy(
+                extraOutputText      = extraOutput,
+                isExtraOutputLoading = false,
+                history              = finalHistory
+            )
+        }
+
+        if (settingsState.value.isHistoryEnabled) historyRepository.saveHistory(finalHistory)
+    }
 
     private suspend fun handleExtraOutput(
         targetText: String,

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
@@ -19,6 +19,9 @@ import com.github.ahatem.qtranslate.core.shared.arch.UiState
  * @property inputText The text currently in the source input field.
  * @property translatedText The most recent translation result.
  * @property extraOutputText Secondary output (backward translation, summary, rewrite).
+ * @property isExtraOutputLoading Whether the secondary output is still being produced.
+ *   The primary translation is published as soon as it arrives, so this stays true for a
+ *   short while after [isLoading] has already returned to false.
  * @property sourceLanguage The currently selected source language. May be [LanguageCode.AUTO].
  * @property detectedSourceLanguage The language auto-detected from the last translation.
  *   Only populated when [sourceLanguage] is [LanguageCode.AUTO] and the translator
@@ -39,6 +42,7 @@ data class MainState(
     val inputText: String = "",
     val translatedText: String = "",
     val extraOutputText: String = "",
+    val isExtraOutputLoading: Boolean = false,
     val sourceLanguage: LanguageCode = LanguageCode.AUTO,
     val detectedSourceLanguage: LanguageCode? = null,
     val targetLanguage: LanguageCode = LanguageCode.ARABIC,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -543,7 +543,9 @@ class MainContentView(
             ExtraOutputState(
                 text = mainState.extraOutputText,
                 isVisible = config.extraOutputType != ExtraOutputType.None,
-                isLoading = mainState.isLoading,
+                // Stays loading after the main translation has landed — this panel is fed by
+                // its own request and must not make the main output wait for it.
+                isLoading = mainState.isLoading || mainState.isExtraOutputLoading,
                 fontConfig = config.scaledEditorFont,
                 fallbackFontConfig = config.scaledEditorFallbackFont,
                 activeType = config.extraOutputType,


### PR DESCRIPTION
## What does this PR do?

Makes the primary translation appear as soon as it arrives, instead of waiting for the extra-output request to finish.

With Backward Translate / Summarize / Rewrite enabled, `TranslateTextUseCase` had the translated text in hand and then did this:

```kotlin
val extraOutput = handleExtraOutput(...)   // suspends on a SECOND network round trip
updateState {                               // one write — only after BOTH complete
    copy(translatedText = response.translatedText,
         extraOutputText = extraOutput, ...)
}
```

Two independent results published in a single state write, so every translation felt as slow as the slower of the pair.

### Changes

- The primary result is published first: `translatedText`, `detectedSourceLanguage`, history, `isLoading = false`.
- `MainState.isExtraOutputLoading` is new, so the extra panel shows its own inline spinner while the main output is already readable.
- The extra output patches in on a second state write when it arrives.
- History is still saved only after the extra output lands, so the persisted snapshot stays complete.

### On the race condition

The extra-output request deliberately stays **inside the existing `translationJob`** rather than being launched as a detached coroutine. That job is already cancelled at the top of every new translation (`TranslateTextUseCase.kt:74`), so a superseded request cannot land its result on top of a newer translation. Detaching it would have required a new guard; keeping it in the job means correctness comes for free.

### Both call sites

The same blocking pattern appeared twice — the normal path and the rule-driven re-translation path taken when Auto-Detect reveals a translation-rule match. Both now route through a single `publishPrimaryThenExtraOutput` helper, and every early-return error path clears the new flag.

## Related issues

First of five PRs from the UX and performance audit.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- A recording showing the main output appearing while the extra panel still spins would demonstrate this best. -->
