### PR TITLE
perf(translation): shorten the instant-translation debounce to 350ms

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
@@ -21,8 +21,14 @@ object AppConstants {
     // Timing
     // ============================================================
 
-    /** Debounce delay for instant translation. */
-    const val INSTANT_TRANSLATION_DEBOUNCE_MS = 700L
+    /**
+     * Debounce delay for instant translation.
+     *
+     * Kept short enough that typing still feels connected to the result. Beyond roughly
+     * half a second the translation reads as a separate event rather than a response to
+     * what was just typed, which is what "instant translation" is meant to convey.
+     */
+    const val INSTANT_TRANSLATION_DEBOUNCE_MS = 350L
 
     /** Minimum input length before instant translation fires. */
     const val INSTANT_TRANSLATE_MIN_CHARS = 2


### PR DESCRIPTION
## What does this PR do?

Instant translation waited **700 ms** after the last keystroke before firing. That is past the point where the result still reads as a response to what was just typed — it arrives as a separate event, which undercuts the feature's whole premise.

`AppConstants.INSTANT_TRANSLATION_DEBOUNCE_MS` drops to **350 ms** (consumed at `MainStore.kt:154`).

Spell checking keeps its 750 ms debounce — it is not on the perceived-latency path and firing it less often is preferable.

### Note

This is a judgement call on feel, not a measured defect. 350 ms is the usual band for "connected to my typing", but it is worth trying in the running app before merging; the tradeoff is a somewhat higher request rate while typing.

## Related issues

Second of five PRs from the UX and performance audit.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable — timing constant only.