### PR TITLE
perf(startup): show the main window before plugins finish loading

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
@@ -5,6 +5,7 @@ import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.SettingsRepository
 import com.github.ahatem.qtranslate.core.shared.AppConstants
 import com.github.ahatem.qtranslate.ui.swing.main.MainAppFrame
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
@@ -60,11 +61,6 @@ fun main() = runBlocking {
     )
     AppUiSetup.apply(initialConfig, deps.themeManager)
 
-    logger.info("Loading plugins...")
-    runCatching { deps.pluginManager.loadAndProcessPlugins() }
-        .onSuccess { logger.info("Plugins loaded successfully") }
-        .onFailure { e -> logger.error("Failed to load plugins", e) }
-
     val savedLanguage = if (initialConfig.interfaceLanguage == LanguageCode.ENGLISH.tag) {
         OsLanguageDetector.detect(deps.localizationManager.availableLanguages)
     } else {
@@ -77,6 +73,11 @@ fun main() = runBlocking {
         logger.warn("Failed to load interface language '${initialConfig.interfaceLanguage}': ${e.message}")
     }
 
+    // The window is shown before plugins are loaded. Everything it needs to paint — theme,
+    // scale and interface language — is already resolved, and services reach the UI through
+    // SelectActiveServiceUseCase.observe(), so the selector and Plugins panel fill in on
+    // their own as plugins finish initialising. Waiting here instead would leave the screen
+    // empty for as long as the slowest plugin takes, and several do network work at startup.
     SwingUtilities.invokeLater {
         frame = MainAppFrame(
             mainStore        = deps.mainStore,
@@ -88,6 +89,13 @@ fun main() = runBlocking {
             notificationBus  = deps.notificationBus
         )
         logger.info("Main window launched")
+    }
+
+    logger.info("Loading plugins...")
+    deps.appScope.launch {
+        runCatching { deps.pluginManager.loadAndProcessPlugins() }
+            .onSuccess { logger.info("Plugins loaded successfully") }
+            .onFailure { e -> logger.error("Failed to load plugins", e) }
     }
 
     Thread.currentThread().join()


### PR DESCRIPTION
## What does this PR do?

The app showed **nothing at all** until every plugin had loaded.

`main()` awaited `pluginManager.loadAndProcessPlugins()` before creating `MainAppFrame`. There is no splash screen, so during that window the app appeared to do nothing — and several bundled plugins do network work at init (Mozhi probes instances to pick the fastest).

Plugin initialisation was **already concurrent** internally (`PluginManager.kt:117` — `supervisorScope` + `async` + `joinAll`). The cost was purely that startup blocked on the whole batch.

### Change

Create the window as soon as theme, scale and interface language are resolved, then load plugins on `appScope`.

### Why this is safe

I checked the construction-order risk before making the change, and it does not exist:

- No UI code reads `pluginManager.plugins.value` during construction. The only such read is in `MainAppFrame.openPluginConfiguration()`, which runs on demand from a user action.
- Services reach the UI through `SelectActiveServiceUseCase.observe()`, which is a `combine(activeServices, settingsState, dynamicLanguageCache)` — fully reactive. The service selector and Plugins panel populate on their own as plugins finish.

So nothing had to be restructured to support this.

### Tradeoff

On a cold start the service selector is briefly empty rather than the window being absent entirely. An explicit "loading services" state would be a further improvement, but it needs new strings across all 13 locales, so it is left to a separate PR.

## Related issues

Third of five PRs from the UX and performance audit.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Worth timing cold start before/after with all 10 bundled plugins present. -->