### PR TITLE
feat(ui): confirm clipboard copies and accept documents dropped on the window

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
@@ -43,6 +43,14 @@ sealed interface MainIntent : UiIntent {
     data object CancelTranslation : MainIntent
 
     /**
+     * Text was copied to the clipboard and the user should be told.
+     *
+     * The copy itself happens in the UI, which owns the clipboard; this only reports it so
+     * the confirmation travels through the same status-bar path as every other message.
+     */
+    data object NotifyTextCopied : MainIntent
+
+    /**
      * User stopped TTS playback that is currently in progress.
      * No-op if nothing is playing.
      */

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -262,6 +262,10 @@ class MainStore(
                 }
             }
 
+            MainIntent.NotifyTextCopied -> scope.launch {
+                updateStatusBar(StatusCode.TextCopied, NotificationType.SUCCESS, true)
+            }
+
             MainIntent.StopTTS -> handleTextToSpeechUseCase.stop()
 
             is MainIntent.ReplaceWithTranslation -> scope.launch {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/StatusCode.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/StatusCode.kt
@@ -42,6 +42,9 @@ sealed class StatusCode {
     object NoTextInImage : StatusCode()
     object OcrComplete : StatusCode()
     object OcrTextCopied : StatusCode()
+
+    /** Confirms a copy-to-clipboard action that would otherwise give no visible feedback. */
+    object TextCopied : StatusCode()
     data class OcrFailed(val summary: String) : StatusCode()
 
     // ---- Summarize ----

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -579,6 +579,7 @@ ocr_timeout = "OCR timed out. Please try again with a smaller image."
 no_text_in_image = "No text was found in the captured image."
 ocr_complete = "Text recognized successfully!"
 ocr_text_copied = "Text recognized and copied to clipboard."
+text_copied = "Copied to clipboard."
 ocr_failed = "Text recognition failed: %s"
 # Summarize
 no_summarizer_active = "No summarizer service is active. Install and configure a summarizer plugin."

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -503,6 +503,7 @@ unknown_error = "حدث خطأ غير معروف."
 
 [status_bar]
 ocr_text_copied = "تم التعرف على النص ونسخه إلى الحافظة."
+text_copied = "تم النسخ إلى الحافظة."
 translating = "جاري الترجمة..."
 translation_complete = "اكتملت الترجمة."
 translation_timeout = "انتهت مهلة الترجمة. يرجى المحاولة مجدداً."

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -503,6 +503,7 @@ unknown_error = "একটি অজানা ত্রুটি ঘটেছে
 
 [status_bar]
 ocr_text_copied = "পাঠ্য শনাক্ত করা হয়েছে এবং ক্লিপবোর্ডে কপি করা হয়েছে।"
+text_copied = "ক্লিপবোর্ডে কপি করা হয়েছে।"
 translating = "অনুবাদ হচ্ছে..."
 translation_complete = "অনুবাদ সম্পন্ন।"
 translation_timeout = "অনুবাদের সময়সীমা শেষ। আবার চেষ্টা করুন।"

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -503,6 +503,7 @@ unknown_error = "Ein unbekannter Fehler ist aufgetreten."
 
 [status_bar]
 ocr_text_copied = "Text erkannt und in die Zwischenablage kopiert."
+text_copied = "In die Zwischenablage kopiert."
 translating = "Wird übersetzt..."
 translation_complete = "Übersetzung abgeschlossen."
 translation_timeout = "Übersetzung hat das Zeitlimit überschritten. Bitte erneut versuchen."

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -501,6 +501,7 @@ unknown_error = "An unknown error occurred."
 
 [status_bar]
 ocr_text_copied = "Text recognized and copied to clipboard."
+text_copied = "Copied to clipboard."
 translating = "Translating..."
 translation_complete = "Translation complete."
 translation_cancelled = "Translation cancelled."

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -503,6 +503,7 @@ unknown_error = "Ha ocurrido un error desconocido."
 
 [status_bar]
 ocr_text_copied = "Texto reconocido y copiado al portapapeles."
+text_copied = "Copiado al portapapeles."
 translating = "Traduciendo..."
 translation_complete = "Traducción completada."
 translation_timeout = "La traducción superó el tiempo de espera. Inténtalo de nuevo."

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -501,6 +501,7 @@ unknown_error = "Une erreur inconnue est survenue."
 
 [status_bar]
 ocr_text_copied = "Texte reconnu et copié dans le presse-papier."
+text_copied = "Copié dans le presse-papier."
 translating = "Traduction en cours..."
 translation_complete = "Traduction terminée."
 translation_timeout = "La traduction a expiré. Veuillez réessayer."

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -501,6 +501,7 @@ unknown_error = "Ismeretlen hiba történt."
 
 [status_bar]
 ocr_text_copied = "Felismert szöveg a vágólapra másolva."
+text_copied = "A vágólapra másolva."
 translating = "Fordítás folyamatban..."
 translation_complete = "A fordítás kész."
 translation_timeout = "A fordítás időtúllépés miatt megszakadt. Kérjük, próbálja újra."

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -501,6 +501,7 @@ unknown_error = "Si è verificato un errore sconosciuto."
 
 [status_bar]
 ocr_text_copied = "Testo riconosciuto e copiato negli appunti."
+text_copied = "Copiato negli appunti."
 translating = "Traduzione in corso..."
 translation_complete = "Traduzione completata."
 translation_timeout = "Traduzione scaduta. Riprova."

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -501,6 +501,7 @@ unknown_error = "不明なエラーが発生しました。"
 
 [status_bar]
 ocr_text_copied = "テキスト認識され、クリップボードにコピーされました。"
+text_copied = "クリップボードにコピーしました。"
 translating = "翻訳中..."
 translation_complete = "翻訳完了。"
 translation_timeout = "翻訳がタイムアウトしました。もう一度お試しください。"

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -502,6 +502,7 @@ unknown_error = "Ocorreu um erro desconhecido."
 
 [status_bar]
 ocr_text_copied = "Texto reconhecido e copiado para a área de transferência."
+text_copied = "Copiado para a área de transferência."
 translating = "Traduzindo..."
 translation_complete = "Tradução concluída."
 translation_timeout = "A tradução expirou. Por favor, tente novamente."

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -502,6 +502,7 @@ unknown_error = "Произошла неизвестная ошибка."
 
 [status_bar]
 ocr_text_copied = "Текст распознан и скопирован в буфер обмена."
+text_copied = "Скопировано в буфер обмена."
 translating = "Перевод..."
 translation_complete = "Перевод выполнен."
 translation_timeout = "Время перевода истекло. Попробуйте снова."

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -502,6 +502,7 @@ unknown_error = "Bilinmeyen bir hata oluştu."
 
 [status_bar]
 ocr_text_copied = "Metin tanındı ve panoya kopyalandı."
+text_copied = "Panoya kopyalandı."
 translating = "Çevriliyor..."
 translation_complete = "Çeviri tamamlandı."
 translation_timeout = "Çeviri zaman aşımına uğradı. Lütfen tekrar deneyin."

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -502,6 +502,7 @@ unknown_error = "发生了未知错误。"
 
 [status_bar]
 ocr_text_copied = "文本已识别并复制到剪贴板。"
+text_copied = "已复制到剪贴板。"
 translating = "正在翻译..."
 translation_complete = "翻译完成。"
 translation_timeout = "翻译超时。请重试。"

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/document/DocumentTranslationDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/document/DocumentTranslationDialog.kt
@@ -265,17 +265,32 @@ class DocumentTranslationDialog(
         }
     }
 
+    /**
+     * Opens the dialog with [file] already selected, for documents dropped onto the main
+     * window. Callers are expected to have checked [DocumentFormat.from] first; an
+     * unsupported file is ignored rather than opening an unusable dialog.
+     */
+    fun openWith(file: File) {
+        if (DocumentFormat.from(file) == null) return
+        applyInput(file)
+        open()
+    }
+
     private fun chooseInput() {
         val chooser = JFileChooser().apply {
             dialogTitle = strings.chooseInput
             fileFilter = FileNameExtensionFilter("DOCX, PDF, TXT, SRT, VTT", "docx", "pdf", "txt", "srt", "vtt")
         }
         if (chooser.showOpenDialog(this) != JFileChooser.APPROVE_OPTION) return
-        inputFile = chooser.selectedFile
-        inputField.text = chooser.selectedFile.absolutePath
-        inputField.toolTipText = chooser.selectedFile.absolutePath
-        pdfOptionsPanel.isVisible = DocumentFormat.from(chooser.selectedFile) == DocumentFormat.PDF
-        updateSuggestedOutput(chooser.selectedFile)
+        applyInput(chooser.selectedFile)
+    }
+
+    private fun applyInput(file: File) {
+        inputFile = file
+        inputField.text = file.absolutePath
+        inputField.toolTipText = file.absolutePath
+        pdfOptionsPanel.isVisible = DocumentFormat.from(file) == DocumentFormat.PDF
+        updateSuggestedOutput(file)
         outputButton.isEnabled = true
         showState(ViewState.READY, strings.ready)
         resizeToContent()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -53,7 +53,10 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.swing.Swing
 import java.awt.*
+import com.github.ahatem.qtranslate.core.document.DocumentFormat
+import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import java.io.File
 import java.awt.event.*
 import java.net.URI
 import java.util.*
@@ -328,6 +331,7 @@ class MainAppFrame(
             setupMenuBar()
             setupTrayMenu()
             setupGlobalHotkeys()
+            setupDocumentDropTarget()
 
             observeStateAndEvents()
             isVisible = true
@@ -1300,6 +1304,33 @@ class MainAppFrame(
         )
     }
 
+    /**
+     * Opens the document translation dialog when a supported file is dropped on the window.
+     *
+     * Document translation was otherwise reachable only through a menu item and a toolbar
+     * button, even though dropping a file on the window is the obvious gesture for it.
+     * Unsupported files are ignored so dropping an image or an archive does nothing rather
+     * than opening a dialog that cannot proceed.
+     */
+    private fun setupDocumentDropTarget() {
+        transferHandler = object : TransferHandler() {
+            override fun canImport(support: TransferSupport): Boolean =
+                support.isDataFlavorSupported(DataFlavor.javaFileListFlavor) && firstSupportedDocument(support) != null
+
+            override fun importData(support: TransferSupport): Boolean {
+                val file = firstSupportedDocument(support) ?: return false
+                SwingUtilities.invokeLater { documentTranslationDialog.openWith(file) }
+                return true
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            private fun firstSupportedDocument(support: TransferSupport): File? = runCatching {
+                (support.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<File>)
+                    .firstOrNull { DocumentFormat.from(it) != null }
+            }.getOrNull()
+        }
+    }
+
     private fun setupGlobalHotkeys() {
         addWindowListener(object : WindowAdapter() {
             override fun windowOpened(e: WindowEvent?) {
@@ -1691,6 +1722,7 @@ class MainAppFrame(
             StatusCode.NoTextInImage                -> localizer.getString("status_bar.no_text_in_image")
             StatusCode.OcrComplete                  -> localizer.getString("status_bar.ocr_complete")
             StatusCode.OcrTextCopied               -> localizer.getString("status_bar.ocr_text_copied")
+            StatusCode.TextCopied                  -> localizer.getString("status_bar.text_copied")
             is StatusCode.OcrFailed                 -> localizer.getString("status_bar.ocr_failed", code.summary)
             StatusCode.NoSummarizerActive           -> localizer.getString("status_bar.no_summarizer_active")
             StatusCode.Summarizing                  -> localizer.getString("status_bar.summarizing")

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -476,7 +476,7 @@ class MainContentView(
                     tooltip = localizer.getString("main_window_editor_context_menu.copy"),
                     isEnabled = hasInputText && !mainState.isLoading,
                     isVisible = true,
-                    onClick = { mainState.inputText.copyToClipboard() }
+                    onClick = { mainState.inputText.copyToClipboard(); dispatch(MainIntent.NotifyTextCopied) }
                 ),
                 Action(
                     id = if (isTtsPlaying) "stop_tts_input" else "listen_input",
@@ -521,7 +521,7 @@ class MainContentView(
                             tooltip = localizer.getString("main_window_editor_context_menu.copy"),
                             isEnabled = hasOutputText && !mainState.isLoading,
                             isVisible = true,
-                            onClick = { mainState.translatedText.copyToClipboard() }
+                            onClick = { mainState.translatedText.copyToClipboard(); dispatch(MainIntent.NotifyTextCopied) }
                         ),
                         Action(
                             id = if (isTtsPlaying) "stop_tts_output" else "listen_output",
@@ -602,7 +602,7 @@ class MainContentView(
                             tooltip = localizer.getString("main_window_editor_context_menu.copy"),
                             isEnabled = hasExtraText && !mainState.isLoading,
                             isVisible = true,
-                            onClick = { mainState.extraOutputText.copyToClipboard() }
+                            onClick = { mainState.extraOutputText.copyToClipboard(); dispatch(MainIntent.NotifyTextCopied) }
                         ),
                         Action(
                             id = if (isTtsPlaying) "stop_tts_extra" else "listen_extra",


### PR DESCRIPTION
## What does this PR do?

Two feedback/affordance gaps found in the UX audit.

### 1. Copying gave no confirmation

The copy buttons on the input, output and extra-output panels (`MainContentView.kt:479, 524, 605`) wrote to the clipboard silently — a click that worked looked identical to one that did not.

Copying now reports through the same status-bar path as every other message: a new `StatusCode.TextCopied` and a `MainIntent.NotifyTextCopied`. The clipboard write stays in the UI, which owns it; only the notification travels through the store, so MVI separation holds.

### 2. Documents could not be dropped on the window

Document translation shipped this cycle but was reachable only from the Options menu and the toolbar button. Dropping a file on the window — the obvious gesture — did nothing. Drag-and-drop existed only for plugin JARs (`PluginsPanel`) and images (`AdvancedTextPane`).

The main frame now accepts **DOCX, PDF, TXT, SRT and VTT** drops and opens the dialog with the file already selected.

- Unsupported files are rejected in `canImport`, so dropping an image or an archive leaves the window alone rather than opening a dialog that cannot proceed.
- `DocumentTranslationDialog` gains `openWith(file)`, and the existing file-chooser path was refactored onto a shared `applyInput()` helper so both entry points cannot drift.

### Localization

`status_bar.text_copied` added to the embedded English strings and all 13 bundled locales — no English fallbacks.

## Related issues

Fourth of five PRs from the UX and performance audit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Worth showing the status-bar confirmation and a document being dropped onto the window. -->