### PR TITLE
fix(ui): add tooltips to the remaining icon-only buttons

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -1292,6 +1292,7 @@ class MainAppFrame(
             ),
             strings = DialogStrings(
                 copyTooltip = localizer.getString("common.copy"),
+                closeTooltip = localizer.getString("common.close"),
                 listenTooltip = localizer.getString("common.listen"),
                 pinTooltip = localizer.getString("common.pin"),
                 unpinTooltip = localizer.getString("common.unpin"),
@@ -1590,6 +1591,7 @@ class MainAppFrame(
             errorDetailPopup.warningLabel = localizer.getString("main_window_status_bar.error_detail_warning")
             errorDetailPopup.copyLabel    = localizer.getString("main_window_status_bar.error_detail_copy")
             errorDetailPopup.copiedLabel  = localizer.getString("main_window_status_bar.error_detail_copied")
+            errorDetailPopup.closeLabel   = localizer.getString("common.close")
 
             statusBar.onErrorClicked = { message ->
                 shownDetailMessage = message

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/ErrorDetailPopup.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/ErrorDetailPopup.kt
@@ -50,6 +50,13 @@ class ErrorDetailPopup(private val iconManager: IconManager) {
     var copyLabel: String    = "Copy"
     var copiedLabel: String  = "Copied!"
 
+    /** Tooltip for the icon-only close button, which otherwise gives no hint of its purpose. */
+    var closeLabel: String   = "Close"
+        set(value) {
+            field = value
+            closeButton.toolTipText = value
+        }
+
     // -----------------------------------------------------------------------
     // UI components
     // -----------------------------------------------------------------------

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -203,6 +203,7 @@ class QuickTranslateDialog(
         pinButton.toolTipText = if (state.isPinned) state.strings.unpinTooltip else state.strings.pinTooltip
         listenButton.toolTipText = state.strings.listenTooltip
         copyButton.toolTipText = state.strings.copyTooltip
+        closeButton.toolTipText = state.strings.closeTooltip
 
         listenButton.isEnabled = state.actionsState.canListen && !state.isLoading
         copyButton.isEnabled = state.actionsState.canCopy && !state.isLoading

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
@@ -55,6 +55,7 @@ data class QuickTranslateActionsState(
 /** All user-facing strings for the dialog. */
 data class DialogStrings(
     val copyTooltip: String,
+    val closeTooltip: String,
     val listenTooltip: String,
     val pinTooltip: String,
     val unpinTooltip: String,


### PR DESCRIPTION
## What does this PR do?

Two icon-only buttons had no tooltip, leaving their purpose to guesswork:

- the close button on the **error detail popup** (`ErrorDetailPopup`)
- the close button on the **Quick Translate popup** (`QuickTranslateDialog`)

Both reuse the existing `common.close` string, so **no new translations are needed** — all 13 locales are already covered.

`ErrorDetailPopup` gains a `closeLabel` property alongside its existing `errorLabel` / `warningLabel` / `copyLabel`, applying the tooltip on assignment so it follows the same pattern as the other labels. `QuickTranslateDialogState` gains `closeTooltip` to match the pin, listen and copy tooltips it already carried.

### False positives from the audit

My initial scan compared `createButtonWithIcon` counts against `toolTipText` counts per file, which over-reported:

- `ExtraOutputPanel` — its only icon button already has a tooltip; the extra count was the import line.
- `TranslationHistoryBar` — same, an import line inflated the count.

Both were checked individually and need no change.

## Related issues

Fifth of five PRs from the UX and performance audit.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable — tooltips only.