### PR TITLE
feat(hotkeys): add shortcuts for copy, clear, swap, settings, history and documents

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
@@ -17,7 +17,7 @@ import com.github.ahatem.qtranslate.api.core.Logger
 object ConfigMigrator {
 
     /** Must match the default value of [Configuration.configVersion]. */
-    private const val CURRENT_VERSION = 2
+    private const val CURRENT_VERSION = 3
 
     /**
      * Applies all pending migrations to [config] in order and returns the result.
@@ -52,6 +52,19 @@ object ConfigMigrator {
                 val missingDefaults = HotkeyBinding.DEFAULTS.filter { it.action !in existingActions }
                 config.copy(
                     configVersion = 2,
+                    hotkeys = config.hotkeys + missingDefaults
+                )
+            }
+            2 -> {
+                // v2 → v3: same patch for the actions added after v2 (COPY_TRANSLATION,
+                // CLEAR_INPUT, SWAP_LANGUAGES, OPEN_SETTINGS, SHOW_HISTORY,
+                // TRANSLATE_DOCUMENT). Without this step existing users would keep their
+                // saved hotkey list and never receive the new bindings at all.
+                logger.info("ConfigMigrator: migrating v2 → v3 — patching missing hotkey defaults")
+                val existingActions = config.hotkeys.map { it.action }.toSet()
+                val missingDefaults = HotkeyBinding.DEFAULTS.filter { it.action !in existingActions }
+                config.copy(
+                    configVersion = 3,
                     hotkeys = config.hotkeys + missingDefaults
                 )
             }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -90,7 +90,13 @@ enum class HotkeyAction {
     TRANSLATE,                 // trigger translation (default: Ctrl+Enter, LOCAL)
     FOCUS_INPUT,               // move keyboard focus to the input text pane (default: Alt+1, LOCAL)
     FOCUS_OUTPUT,              // move keyboard focus to the output text pane (default: Alt+2, LOCAL)
-    FOCUS_EXTRA_OUTPUT         // move keyboard focus to the extra-output pane (default: Alt+3, LOCAL)
+    FOCUS_EXTRA_OUTPUT,        // move keyboard focus to the extra-output pane (default: Alt+3, LOCAL)
+    COPY_TRANSLATION,          // copy the translated text (default: Ctrl+Shift+C, LOCAL)
+    CLEAR_INPUT,               // clear the input pane (default: Ctrl+Shift+X, LOCAL)
+    SWAP_LANGUAGES,            // swap source and target languages (default: Ctrl+Shift+S, LOCAL)
+    OPEN_SETTINGS,             // open the settings dialog (default: Ctrl+Comma, LOCAL)
+    SHOW_HISTORY,              // open the translation history dialog (default: Ctrl+Shift+H, LOCAL)
+    TRANSLATE_DOCUMENT         // open the document translation dialog (default: Ctrl+Shift+D, LOCAL)
 }
 
 /**
@@ -166,6 +172,14 @@ data class HotkeyBinding(
             HotkeyBinding(HotkeyAction.FOCUS_INPUT,              keyCode = java.awt.event.KeyEvent.VK_1,                modifiers = java.awt.event.InputEvent.ALT_DOWN_MASK,   scope = HotkeyScope.LOCAL),
             HotkeyBinding(HotkeyAction.FOCUS_OUTPUT,             keyCode = java.awt.event.KeyEvent.VK_2,                modifiers = java.awt.event.InputEvent.ALT_DOWN_MASK,   scope = HotkeyScope.LOCAL),
             HotkeyBinding(HotkeyAction.FOCUS_EXTRA_OUTPUT,       keyCode = java.awt.event.KeyEvent.VK_3,                modifiers = java.awt.event.InputEvent.ALT_DOWN_MASK,   scope = HotkeyScope.LOCAL),
+            // All LOCAL — these act on the focused window, so they must not take the key
+            // combination away from other applications the way a GLOBAL binding would.
+            HotkeyBinding(HotkeyAction.COPY_TRANSLATION,         keyCode = java.awt.event.KeyEvent.VK_C,                modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK, scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.CLEAR_INPUT,              keyCode = java.awt.event.KeyEvent.VK_X,                modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK, scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.SWAP_LANGUAGES,           keyCode = java.awt.event.KeyEvent.VK_S,                modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK, scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.OPEN_SETTINGS,            keyCode = java.awt.event.KeyEvent.VK_COMMA,            modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK,  scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.SHOW_HISTORY,             keyCode = java.awt.event.KeyEvent.VK_H,                modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK, scope = HotkeyScope.LOCAL),
+            HotkeyBinding(HotkeyAction.TRANSLATE_DOCUMENT,       keyCode = java.awt.event.KeyEvent.VK_D,                modifiers = java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK, scope = HotkeyScope.LOCAL),
         )
     }
 }

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -317,6 +317,7 @@ action_translate = "Translate"
 action_focus_input = "Focus Input Pane"
 action_focus_output = "Focus Output Pane"
 action_focus_extra_output = "Focus Extra Output Pane"
+action_copy_translation = "Copy translation"action_clear_input = "Clear input"action_swap_languages = "Swap languages"action_open_settings = "Open settings"action_show_history = "Show history"action_translate_document = "Translate document"
 scope_toggle_hint = "Click to toggle between Global and Local"
 
 # Default Actions Descriptions

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -277,6 +277,7 @@ action_translate = "ترجمة"
 action_focus_input = "التركيز على لوحة الإدخال"
 action_focus_output = "التركيز على لوحة الإخراج"
 action_focus_extra_output = "التركيز على لوحة الإخراج الإضافي"
+action_copy_translation = "نسخ الترجمة"action_clear_input = "مسح الإدخال"action_swap_languages = "تبديل اللغات"action_open_settings = "فتح الإعدادات"action_show_history = "إظهار السجل"action_translate_document = "ترجمة مستند"
 scope_toggle_hint = "انقر للتبديل بين العالمي والمحلي"
 
 # Default Actions Descriptions

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -277,6 +277,7 @@ action_translate = "অনুবাদ করুন"
 action_focus_input = "ইনপুট প্যানেলে ফোকাস করুন"
 action_focus_output = "আউটপুট প্যানেলে ফোকাস করুন"
 action_focus_extra_output = "অতিরিক্ত আউটপুট প্যানেলে ফোকাস করুন"
+action_copy_translation = "অনুবাদ কপি করুন"action_clear_input = "ইনপুট সাফ করুন"action_swap_languages = "ভাষা অদলবদল করুন"action_open_settings = "সেটিংস খুলুন"action_show_history = "ইতিহাস দেখান"action_translate_document = "নথি অনুবাদ করুন"
 scope_toggle_hint = "গ্লোবাল এবং লোকাল এর মধ্যে পরিবর্তন করতে ক্লিক করুন"
 
 # Default Actions Descriptions

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -277,6 +277,7 @@ action_translate = "Übersetzen"
 action_focus_input = "Eingabebereich fokussieren"
 action_focus_output = "Ausgabebereich fokussieren"
 action_focus_extra_output = "Zusatzausgabe fokussieren"
+action_copy_translation = "Übersetzung kopieren"action_clear_input = "Eingabe löschen"action_swap_languages = "Sprachen tauschen"action_open_settings = "Einstellungen öffnen"action_show_history = "Verlauf anzeigen"action_translate_document = "Dokument übersetzen"
 scope_toggle_hint = "Klicken, um zwischen Global und Lokal zu wechseln"
 
 # Default Actions Descriptions

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -277,6 +277,7 @@ action_translate = "Translate"
 action_focus_input = "Focus Input Pane"
 action_focus_output = "Focus Output Pane"
 action_focus_extra_output = "Focus Extra Output Pane"
+action_copy_translation = "Copy translation"action_clear_input = "Clear input"action_swap_languages = "Swap languages"action_open_settings = "Open settings"action_show_history = "Show history"action_translate_document = "Translate document"
 scope_toggle_hint = "Click to toggle between Global and Local"
 
 # Default Actions Descriptions

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -277,6 +277,7 @@ action_translate = "Traducir"
 action_focus_input = "Enfocar panel de entrada"
 action_focus_output = "Enfocar panel de salida"
 action_focus_extra_output = "Enfocar panel de salida adicional"
+action_copy_translation = "Copiar traducción"action_clear_input = "Borrar entrada"action_swap_languages = "Intercambiar idiomas"action_open_settings = "Abrir ajustes"action_show_history = "Mostrar historial"action_translate_document = "Traducir documento"
 scope_toggle_hint = "Haga clic para cambiar entre Global y Local"
 
 # Default Actions Descriptions

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -277,6 +277,7 @@ action_translate = "Traduire"
 action_focus_input = "Mettre le focus sur le panneau d'entrée"
 action_focus_output = "Mettre le focus sur le panneau de sortie"
 action_focus_extra_output = "Mettre le focus sur le panneau de sortie supplémentaire"
+action_copy_translation = "Copier la traduction"action_clear_input = "Effacer la saisie"action_swap_languages = "Inverser les langues"action_open_settings = "Ouvrir les paramètres"action_show_history = "Afficher l'historique"action_translate_document = "Traduire un document"
 scope_toggle_hint = "Cliquez pour basculer entre Global et Local"
 
 # Default Actions Descriptions

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -277,6 +277,7 @@ action_translate = "Fordítás"
 action_focus_input = "Fókusz a beviteli panelre"
 action_focus_output = "Fókusz a kimeneti panelre"
 action_focus_extra_output = "Fókusz a kiegészítő kimeneti panelre"
+action_copy_translation = "Fordítás másolása"action_clear_input = "Bevitel törlése"action_swap_languages = "Nyelvek cseréje"action_open_settings = "Beállítások megnyitása"action_show_history = "Előzmények megjelenítése"action_translate_document = "Dokumentum fordítása"
 scope_toggle_hint = "Kattintson a Globális és a Helyi közötti váltáshoz"
 
 # Default Actions Descriptions

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -277,6 +277,7 @@ action_translate = "Traduci"
 action_focus_input = "Metti il fuoco sul pannello di input"
 action_focus_output = "Metti il fuoco sul pannello di output"
 action_focus_extra_output = "Metti il fuoco sul pannello di output extra"
+action_copy_translation = "Copia traduzione"action_clear_input = "Cancella input"action_swap_languages = "Scambia lingue"action_open_settings = "Apri impostazioni"action_show_history = "Mostra cronologia"action_translate_document = "Traduci documento"
 scope_toggle_hint = "Fai clic per cambiare da globale a locale"
 
 # Default Actions Descriptions

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -277,6 +277,7 @@ action_translate = "翻訳"
 action_focus_input = "入力ペインにフォーカス"
 action_focus_output = "出力ペインにフォーカス"
 action_focus_extra_output = "追加出力ペインにフォーカス"
+action_copy_translation = "翻訳をコピー"action_clear_input = "入力をクリア"action_swap_languages = "言語を入れ替え"action_open_settings = "設定を開く"action_show_history = "履歴を表示"action_translate_document = "ドキュメントを翻訳"
 scope_toggle_hint = "クリックしてグローバルとローカルを切り替え"
 
 # Default Actions Descriptions

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -277,6 +277,7 @@ action_translate = "Traduzir"
 action_focus_input = "Focar painel de entrada"
 action_focus_output = "Focar painel de saída"
 action_focus_extra_output = "Focar painel de saída extra"
+action_copy_translation = "Copiar tradução"action_clear_input = "Limpar entrada"action_swap_languages = "Inverter idiomas"action_open_settings = "Abrir configurações"action_show_history = "Mostrar histórico"action_translate_document = "Traduzir documento"
 scope_toggle_hint = "Clique para alternar entre Global e Local"
 
 # Default Actions Descriptions

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -277,6 +277,7 @@ action_translate = "Перевести"
 action_focus_input = "Фокус на панели ввода"
 action_focus_output = "Фокус на панели вывода"
 action_focus_extra_output = "Фокус на дополнительной панели вывода"
+action_copy_translation = "Копировать перевод"action_clear_input = "Очистить ввод"action_swap_languages = "Поменять языки"action_open_settings = "Открыть настройки"action_show_history = "Показать историю"action_translate_document = "Перевести документ"
 scope_toggle_hint = "Нажмите для переключения между Глобально и Локально"
 
 # Default Actions Descriptions

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -277,6 +277,7 @@ action_translate = "Çevir"
 action_focus_input = "Giriş paneline odaklan"
 action_focus_output = "Çıkış paneline odaklan"
 action_focus_extra_output = "Ekstra çıkış paneline odaklan"
+action_copy_translation = "Çeviriyi kopyala"action_clear_input = "Girişi temizle"action_swap_languages = "Dilleri değiştir"action_open_settings = "Ayarları aç"action_show_history = "Geçmişi göster"action_translate_document = "Belge çevir"
 scope_toggle_hint = "Küresel ve Yerel arasında geçiş yapmak için tıklayın"
 
 # Default Actions Descriptions

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -277,6 +277,7 @@ action_translate = "翻译"
 action_focus_input = "聚焦输入窗格"
 action_focus_output = "聚焦输出窗格"
 action_focus_extra_output = "聚焦额外输出窗格"
+action_copy_translation = "复制译文"action_clear_input = "清除输入"action_swap_languages = "交换语言"action_open_settings = "打开设置"action_show_history = "显示历史"action_translate_document = "翻译文档"
 scope_toggle_hint = "点击在全局和本地范围之间切换"
 
 # Default Actions Descriptions

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.swing.Swing
 import java.awt.*
 import com.github.ahatem.qtranslate.core.document.DocumentFormat
+import com.github.ahatem.qtranslate.ui.swing.shared.util.copyToClipboard
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.io.File
@@ -806,6 +807,26 @@ class MainAppFrame(
                         HotkeyAction.FOCUS_INPUT        -> mainContentView.switchToAndFocusInput()
                         HotkeyAction.FOCUS_OUTPUT       -> mainContentView.switchToAndFocusOutput()
                         HotkeyAction.FOCUS_EXTRA_OUTPUT -> mainContentView.switchToAndFocusExtraOutput()
+
+                        // Also LOCAL-only, and every one of these needs something the frame
+                        // owns — a dialog, the clipboard, or the content view — so they are
+                        // handled here for the same reason FOCUS_* is.
+                        HotkeyAction.COPY_TRANSLATION -> {
+                            val text = mainStore.state.value.translatedText
+                            if (text.isNotBlank()) {
+                                text.copyToClipboard()
+                                mainStore.dispatch(MainIntent.NotifyTextCopied)
+                            }
+                        }
+                        HotkeyAction.CLEAR_INPUT -> {
+                            mainStore.dispatch(MainIntent.UpdateInputText(""))
+                            mainContentView.switchToAndFocusInput()
+                        }
+                        HotkeyAction.SWAP_LANGUAGES     -> mainStore.dispatch(MainIntent.SwapLanguages)
+                        HotkeyAction.OPEN_SETTINGS      -> openSettingsDialog()
+                        HotkeyAction.SHOW_HISTORY       -> showHistoryDialog()
+                        HotkeyAction.TRANSLATE_DOCUMENT -> documentTranslationDialog.open()
+
                         else -> globalKeyListener.dispatchAction(binding.action)
                     }
                 }
@@ -901,14 +922,7 @@ class MainAppFrame(
             onShowDictionary = { showDictionaryDialog() },
             onShowHistory = { showHistoryDialog() },
             onTranslateDocument = { documentTranslationDialog.open() },
-            onShowSettings = {
-                val dialog = createSettingsDialog()
-                dialog.applyComponentOrientation(
-                    if (localizer.isRtl) ComponentOrientation.RIGHT_TO_LEFT
-                    else ComponentOrientation.LEFT_TO_RIGHT
-                )
-                dialog.isVisible = true
-            },
+            onShowSettings = { openSettingsDialog() },
             onShowHowToUse = { openUrl("https://github.com/ahatem/QTranslate/wiki") },
             onShowAboutQTranslate = { onShowAboutDialog() },
             onContactUs = { openUrl("https://github.com/ahatem/QTranslate/issues/new") },
@@ -1313,6 +1327,16 @@ class MainAppFrame(
      * Unsupported files are ignored so dropping an image or an archive does nothing rather
      * than opening a dialog that cannot proceed.
      */
+    /** Opens Settings with the correct orientation. Shared by the menu and the Ctrl+Comma binding. */
+    private fun openSettingsDialog() {
+        val dialog = createSettingsDialog()
+        dialog.applyComponentOrientation(
+            if (localizer.isRtl) ComponentOrientation.RIGHT_TO_LEFT
+            else ComponentOrientation.LEFT_TO_RIGHT
+        )
+        dialog.isVisible = true
+    }
+
     private fun setupDocumentDropTarget() {
         transferHandler = object : TransferHandler() {
             override fun canImport(support: TransferSupport): Boolean =

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
@@ -197,7 +197,15 @@ class MainGlobalKeyListener(
             // Nothing to do here; the branch is required for exhaustive when.
             HotkeyAction.FOCUS_INPUT,
             HotkeyAction.FOCUS_OUTPUT,
-            HotkeyAction.FOCUS_EXTRA_OUTPUT -> Unit
+            HotkeyAction.FOCUS_EXTRA_OUTPUT,
+            // Likewise LOCAL-only; MainAppFrame handles these because each needs a dialog,
+            // the clipboard, or the content view.
+            HotkeyAction.COPY_TRANSLATION,
+            HotkeyAction.CLEAR_INPUT,
+            HotkeyAction.SWAP_LANGUAGES,
+            HotkeyAction.OPEN_SETTINGS,
+            HotkeyAction.SHOW_HISTORY,
+            HotkeyAction.TRANSLATE_DOCUMENT -> Unit
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
@@ -265,6 +265,12 @@ class KeyboardPanel(
         HotkeyAction.FOCUS_INPUT              -> localizationManager.getString("settings_hotkeys.action_focus_input")
         HotkeyAction.FOCUS_OUTPUT             -> localizationManager.getString("settings_hotkeys.action_focus_output")
         HotkeyAction.FOCUS_EXTRA_OUTPUT       -> localizationManager.getString("settings_hotkeys.action_focus_extra_output")
+        HotkeyAction.COPY_TRANSLATION         -> localizationManager.getString("settings_hotkeys.action_copy_translation")
+        HotkeyAction.CLEAR_INPUT              -> localizationManager.getString("settings_hotkeys.action_clear_input")
+        HotkeyAction.SWAP_LANGUAGES           -> localizationManager.getString("settings_hotkeys.action_swap_languages")
+        HotkeyAction.OPEN_SETTINGS            -> localizationManager.getString("settings_hotkeys.action_open_settings")
+        HotkeyAction.SHOW_HISTORY             -> localizationManager.getString("settings_hotkeys.action_show_history")
+        HotkeyAction.TRANSLATE_DOCUMENT       -> localizationManager.getString("settings_hotkeys.action_translate_document")
     }
 
     private fun scopeLabel(scope: HotkeyScope): String = when (scope) {
@@ -495,6 +501,12 @@ object HotkeyRecorderDialog {
             HotkeyAction.FOCUS_INPUT              -> localizer.getString("settings_hotkeys.action_focus_input")
             HotkeyAction.FOCUS_OUTPUT             -> localizer.getString("settings_hotkeys.action_focus_output")
             HotkeyAction.FOCUS_EXTRA_OUTPUT       -> localizer.getString("settings_hotkeys.action_focus_extra_output")
+            HotkeyAction.COPY_TRANSLATION         -> localizer.getString("settings_hotkeys.action_copy_translation")
+            HotkeyAction.CLEAR_INPUT              -> localizer.getString("settings_hotkeys.action_clear_input")
+            HotkeyAction.SWAP_LANGUAGES           -> localizer.getString("settings_hotkeys.action_swap_languages")
+            HotkeyAction.OPEN_SETTINGS            -> localizer.getString("settings_hotkeys.action_open_settings")
+            HotkeyAction.SHOW_HISTORY             -> localizer.getString("settings_hotkeys.action_show_history")
+            HotkeyAction.TRANSLATE_DOCUMENT       -> localizer.getString("settings_hotkeys.action_translate_document")
         }
 
         // ── colours ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Six common actions had **no keyboard shortcut at all**. All six are now bound and appear in Settings → Keyboard & Hotkeys like every other action.

| Action | Binding |
|---|---|
| Copy translation | `Ctrl+Shift+C` |
| Clear input | `Ctrl+Shift+X` |
| Swap languages | `Ctrl+Shift+S` |
| Open settings | `Ctrl+Comma` |
| Show history | `Ctrl+Shift+H` |
| Translate document | `Ctrl+Shift+D` |

All six are **LOCAL** scope — they act on the focused window, so they must not take their key combination away from other applications the way a GLOBAL binding would.

### Conflict checking

Each was checked against the existing bindings (`Ctrl+Q/E/I/D`, `Ctrl+Shift+T`, `Ctrl+L`, `Ctrl+Enter`, `Alt+1-3`). Two needed adjusting:

- **`Ctrl+Shift+H` rather than `Ctrl+H`** — `AdvancedTextPane` already binds `Ctrl+H` inside the editor.
- **`Ctrl+Shift+D` rather than `Ctrl+D`** — `Ctrl+D` is the global dictionary hotkey.

### Existing users would have got nothing without a migration

This is the part that would have silently shipped broken. Saved configurations sit at `configVersion = 2` and carry their own persisted hotkey list, so the new actions would exist but stay **permanently unbound for everyone who has already run the app** — only brand-new installs would see them.

`ConfigMigrator` gains a **v2 → v3** step that patches in any default whose action is missing from the saved list, the same approach the existing v1 → v2 step uses. `CURRENT_VERSION` bumped accordingly.

### Implementation

Handled in `MainAppFrame` alongside the existing `FOCUS_*` actions, since each needs a dialog, the clipboard, or the content view — the same reason those are handled there rather than in `dispatchAction`.

Two small reuse wins:
- Copy reuses the `NotifyTextCopied` intent, so it reports through the status bar exactly like the copy buttons.
- Opening settings now goes through a shared `openSettingsDialog()` instead of a third copy of the orientation setup.

### Localization

Six action names added to the embedded English strings and all 13 bundled locales, so the Hotkeys settings table reads correctly everywhere.

## Related issues

Follow-up to the UX and performance audit (PRs #154–#158).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- The Hotkeys settings table showing the six new rows would be the useful shot. -->