### PR TITLE
feat(ui): explain when no translation service is configured

### DIFF
--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -56,6 +56,7 @@ auto_detect = "Auto-Detect"
 [main_window]
 status_format = "Using %s: %s → %s"
 no_translator = "No Translator"
+no_service_message = "No translation service is configured."no_service_action = "Open Services settings"
 
 [main_window_history_bar]
 backward_tooltip = "Go backward in translation history"

--- a/languages/ar-SA.toml
+++ b/languages/ar-SA.toml
@@ -56,6 +56,7 @@ auto_detect = "اكتشاف تلقائي"
 [main_window]
 status_format = "باستخدام %s: %s ← %s"
 no_translator = "لا يوجد مترجم"
+no_service_message = "لم يتم تكوين أي خدمة ترجمة."no_service_action = "فتح إعدادات الخدمات"
 
 [main_window_history_bar]
 backward_tooltip = "الرجوع للخلف في سجل الترجمة"

--- a/languages/bn-BD.toml
+++ b/languages/bn-BD.toml
@@ -56,6 +56,7 @@ auto_detect = "স্বয়ংক্রিয় সনাক্তকরণ"
 [main_window]
 status_format = "%s ব্যবহার করে: %s → %s"
 no_translator = "কোন অনুবাদক নেই"
+no_service_message = "কোনো অনুবাদ পরিষেবা কনফিগার করা হয়নি।"no_service_action = "পরিষেবা সেটিংস খুলুন"
 
 [main_window_history_bar]
 backward_tooltip = "অনুবাদ ইতিহাসে পেছনে যান"

--- a/languages/de-DE.toml
+++ b/languages/de-DE.toml
@@ -56,6 +56,7 @@ auto_detect = "Automatisch erkennen"
 [main_window]
 status_format = "Verwendet %s: %s → %s"
 no_translator = "Kein Übersetzer"
+no_service_message = "Kein Übersetzungsdienst konfiguriert."no_service_action = "Dienste-Einstellungen öffnen"
 
 [main_window_history_bar]
 backward_tooltip = "Im Verlauf zurückgehen"

--- a/languages/en-GB.toml
+++ b/languages/en-GB.toml
@@ -56,6 +56,7 @@ auto_detect = "Auto-Detect"
 [main_window]
 status_format = "Using %s: %s → %s"
 no_translator = "No Translator"
+no_service_message = "No translation service is configured."no_service_action = "Open Services settings"
 
 [main_window_history_bar]
 backward_tooltip = "Go backward in translation history"

--- a/languages/es-ES.toml
+++ b/languages/es-ES.toml
@@ -56,6 +56,7 @@ auto_detect = "Detectar automáticamente"
 [main_window]
 status_format = "Usando %s: %s → %s"
 no_translator = "Sin traductor"
+no_service_message = "No hay ningún servicio de traducción configurado."no_service_action = "Abrir ajustes de Servicios"
 
 [main_window_history_bar]
 backward_tooltip = "Retroceder en el historial de traducción"

--- a/languages/fr-FR.toml
+++ b/languages/fr-FR.toml
@@ -56,6 +56,7 @@ auto_detect = "Détection automatique"
 [main_window]
 status_format = "Utilisation de %s : %s → %s"
 no_translator = "Aucun traducteur"
+no_service_message = "Aucun service de traduction configuré."no_service_action = "Ouvrir les paramètres des services"
 
 [main_window_history_bar]
 backward_tooltip = "Reculer dans l'historique de traduction"

--- a/languages/hu-HU.toml
+++ b/languages/hu-HU.toml
@@ -56,6 +56,7 @@ auto_detect = "Automatikus felismerés"
 [main_window]
 status_format = "%s használatban: %s → %s"
 no_translator = "Nincs fordító"
+no_service_message = "Nincs beállítva fordítási szolgáltatás."no_service_action = "Szolgáltatások beállításai"
 
 [main_window_history_bar]
 backward_tooltip = "Menjen vissza a fordítási előzményekben"

--- a/languages/it-IT.toml
+++ b/languages/it-IT.toml
@@ -56,6 +56,7 @@ auto_detect = "Rilevamento automatico"
 [main_window]
 status_format = "Motore traduzione: %s - %s → %s"
 no_translator = "Nessuno traduttore"
+no_service_message = "Nessun servizio di traduzione configurato."no_service_action = "Apri impostazioni Servizi"
 
 [main_window_history_bar]
 backward_tooltip = "Vai indietro nella cronologia traduzioni"

--- a/languages/ja-JP.toml
+++ b/languages/ja-JP.toml
@@ -56,6 +56,7 @@ auto_detect = "自動検出"
 [main_window]
 status_format = "%s を使用中: %s → %s"
 no_translator = "翻訳エンジン未選択"
+no_service_message = "翻訳サービスが設定されていません。"no_service_action = "サービス設定を開く"
 
 [main_window_history_bar]
 backward_tooltip = "前の翻訳に戻る"

--- a/languages/pt-BR.toml
+++ b/languages/pt-BR.toml
@@ -56,6 +56,7 @@ auto_detect = "Detectar automaticamente"
 [main_window]
 status_format = "Usando %s: %s → %s"
 no_translator = "Sem Tradutor"
+no_service_message = "Nenhum serviço de tradução configurado."no_service_action = "Abrir configurações de Serviços"
 
 [main_window_history_bar]
 backward_tooltip = "Voltar no histórico de tradução"

--- a/languages/ru-RU.toml
+++ b/languages/ru-RU.toml
@@ -56,6 +56,7 @@ auto_detect = "Автоопределение"
 [main_window]
 status_format = "Используется %s: %s → %s"
 no_translator = "Переводчик не выбран"
+no_service_message = "Служба перевода не настроена."no_service_action = "Открыть настройки служб"
 
 [main_window_history_bar]
 backward_tooltip = "Назад по истории переводов"

--- a/languages/tr-TR.toml
+++ b/languages/tr-TR.toml
@@ -56,6 +56,7 @@ auto_detect = "Otomatik Algıla"
 [main_window]
 status_format = "Kullanılan %s: %s → %s"
 no_translator = "Çevirmen Yok"
+no_service_message = "Yapılandırılmış çeviri servisi yok."no_service_action = "Servis ayarlarını aç"
 
 [main_window_history_bar]
 backward_tooltip = "Çeviri geçmişinde geri git"

--- a/languages/zh-CN.toml
+++ b/languages/zh-CN.toml
@@ -56,6 +56,7 @@ auto_detect = "自动检测"
 [main_window]
 status_format = "正在使用 %s: %s → %s"
 no_translator = "未选择翻译器"
+no_service_message = "未配置翻译服务。"no_service_action = "打开服务设置"
 
 [main_window_history_bar]
 backward_tooltip = "返回翻译历史"

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -192,7 +192,15 @@ class MainAppFrame(
         onOpenSnippingTool = { openSnippingTool() },
         onOpenDocumentTranslation = { documentTranslationDialog.open() },
         onNotificationsClicked = { notificationPopover.show(mainContentView.statusBar) },
-        onConfigureService = { serviceId -> openPluginConfiguration(serviceId) }
+        onConfigureService = { serviceId -> openPluginConfiguration(serviceId) },
+        onOpenServiceSettings = {
+            val dialog = createSettingsDialog()
+            dialog.applyComponentOrientation(
+                if (localizer.isRtl) ComponentOrientation.RIGHT_TO_LEFT
+                else ComponentOrientation.LEFT_TO_RIGHT
+            )
+            dialog.isVisible = true
+        }
     )
 
     private val selectionTranslateButton = SelectionTranslateButton(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -25,6 +25,7 @@ import com.github.ahatem.qtranslate.ui.swing.main.layout.LayoutManager
 import com.github.ahatem.qtranslate.ui.swing.main.output.ExtraOutputPanel
 import com.github.ahatem.qtranslate.ui.swing.main.output.ExtraOutputState
 import com.github.ahatem.qtranslate.ui.swing.main.output.OutputTextPanel
+import com.github.ahatem.qtranslate.ui.swing.main.output.NoServiceState
 import com.github.ahatem.qtranslate.ui.swing.main.output.OutputTextState
 import com.github.ahatem.qtranslate.ui.swing.main.selector.TranslatorSelector
 import com.github.ahatem.qtranslate.ui.swing.main.selector.TranslatorSelectorState
@@ -57,6 +58,7 @@ class MainContentView(
     private val onOpenDocumentTranslation: () -> Unit,
     private val onNotificationsClicked: () -> Unit,
     private val onConfigureService: (String) -> Unit,
+    private val onOpenServiceSettings: () -> Unit,
 ) : JPanel(BorderLayout(0, 0)) {
 
     private val translationHistoryBar: TranslationHistoryBar = TranslationHistoryBar(
@@ -507,9 +509,20 @@ class MainContentView(
         val hasOutputText = mainState.translatedText.isNotBlank()
         val hasExtraText = mainState.extraOutputText.isNotBlank()
 
+        // Nothing can be translated without a translator, and an empty window gives a new
+        // user no clue why. Point them at the setting that fixes it.
+        val noService = if (mainState.getAvailableServicesFor(ServiceType.TRANSLATOR).isEmpty()) {
+            NoServiceState(
+                message = localizer.getString("main_window.no_service_message"),
+                actionLabel = localizer.getString("main_window.no_service_action"),
+                onAction = onOpenServiceSettings
+            )
+        } else null
+
         outputTextPanel.render(
             OutputTextState(
                 text = mainState.translatedText,
+                noService = noService,
                 isLoading = mainState.isLoading,
                 fontConfig = config.scaledEditorFont,
                 fallbackFontConfig = config.scaledEditorFallbackFont,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -8,16 +8,21 @@ import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.AdvancedTextPane
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.FlowLayout
 import java.awt.Point
 import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
 import javax.swing.AbstractAction
+import javax.swing.JButton
 import javax.swing.JComponent
+import javax.swing.JLabel
 import javax.swing.JMenuItem
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JSeparator
 import javax.swing.KeyStroke
+import javax.swing.UIManager
 
 class OutputTextPanel(
     iconManager: IconManager,
@@ -37,6 +42,19 @@ class OutputTextPanel(
     private val actionsPanel = TextActionsPanel(iconManager)
     private val readOnlyPanel = ReadOnlyTextPanel(textPane, actionsPanel)
 
+    private val noServiceLabel = JLabel()
+    private val noServiceAction = JButton().apply {
+        putClientProperty("JButton.buttonType", "toolBarButton")
+        isFocusable = false
+        foreground = UIManager.getColor("Component.linkColor") ?: UIManager.getColor("Component.accentColor")
+    }
+    private val noServiceBanner = JPanel(FlowLayout(FlowLayout.LEADING, 8, 6)).apply {
+        isVisible = false
+        isOpaque = true
+        add(noServiceLabel)
+        add(noServiceAction)
+    }
+
     private var dictMenuItem: JMenuItem? = null
     private var dictMenuSeparator: JSeparator? = null
     private var setAsInputMenuItem: JMenuItem? = null
@@ -50,6 +68,7 @@ class OutputTextPanel(
     val textPaneComponent: JComponent get() = textPane
 
     init {
+        add(noServiceBanner, BorderLayout.NORTH)
         add(readOnlyPanel, BorderLayout.CENTER)
 
         textPane.hintText = localizationManager.getString("main_window_editor_context_menu.output_hint")
@@ -72,6 +91,7 @@ class OutputTextPanel(
     }
 
     override fun render(state: OutputTextState) {
+        renderNoServiceBanner(state.noService)
         readOnlyPanel.render(
             ReadOnlyTextPanelState(
                 text = state.text,
@@ -83,6 +103,41 @@ class OutputTextPanel(
                 isEditable = state.isEditable
             )
         )
+    }
+
+    /**
+     * Shows or hides the "no translator configured" banner.
+     *
+     * Sits above the output rather than replacing it, so it never fights the layout manager
+     * and the pane keeps working the moment a service becomes available. Colours are read
+     * from [UIManager] at build time and refreshed on each render so the banner follows theme
+     * changes.
+     */
+    private fun renderNoServiceBanner(state: NoServiceState?) {
+        if (state == null) {
+            if (noServiceBanner.isVisible) {
+                noServiceBanner.isVisible = false
+                revalidate()
+                repaint()
+            }
+            return
+        }
+
+        noServiceLabel.text = state.message
+        noServiceAction.text = state.actionLabel
+        noServiceAction.actionListeners.forEach(noServiceAction::removeActionListener)
+        noServiceAction.addActionListener { state.onAction() }
+
+        noServiceBanner.background = UIManager.getColor("Component.warningFocusColor")
+            ?.let { Color(it.red, it.green, it.blue, 28) }
+            ?: UIManager.getColor("Panel.background")
+        noServiceLabel.foreground = UIManager.getColor("Label.foreground")
+
+        if (!noServiceBanner.isVisible) {
+            noServiceBanner.isVisible = true
+            revalidate()
+            repaint()
+        }
     }
 
     private fun addFindInDictionaryItem(menu: JPopupMenu, clickPosition: Point) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
@@ -7,13 +7,29 @@ import com.github.ahatem.qtranslate.core.settings.data.FontConfig
 import com.github.ahatem.qtranslate.core.shared.arch.UiState
 import com.github.ahatem.qtranslate.ui.swing.main.widgets.TextActionsState
 
+/**
+ * Shown above the output when no translator is configured, so a new user is told what to do
+ * instead of facing a window that silently does nothing.
+ *
+ * @property message     What is wrong, in one line.
+ * @property actionLabel Label for the button that opens Services settings.
+ * @property onAction    Opens the settings dialog.
+ */
+data class NoServiceState(
+    val message: String,
+    val actionLabel: String,
+    val onAction: () -> Unit
+)
+
 data class OutputTextState(
     val text: String,
     val fontConfig: FontConfig,
     val fallbackFontConfig: FontConfig,
     val isLoading: Boolean,
     val actionsState: TextActionsState,
-    val isEditable: Boolean = false
+    val isEditable: Boolean = false,
+    /** Non-null only when there is no translator to translate with. */
+    val noService: NoServiceState? = null
 ) : UiState
 
 data class ExtraOutputState(


### PR DESCRIPTION
## What does this PR do?

With no translator available, the main window looked completely normal but did nothing — typing produced no result and nothing on screen said why. The only empty state anywhere in the app was in the Plugins settings panel (`PluginsPanel.kt:532`).

The output pane now shows a banner when no translator service is available, stating the problem and offering a button that opens the settings dialog.

### Why a banner rather than replacing the pane

Swapping the output pane out for an empty-state view would mean fighting `LayoutManager`, which detaches and re-attaches these panels whenever the layout preset changes (Classic / Side-by-side / Compact). Adding a normally-hidden component to the pane's north edge avoids that entirely, and the output keeps working the moment a service becomes available.

### Self-clearing

The condition is derived from `MainState.getAvailableServicesFor(TRANSLATOR)`, so the banner disappears on its own as soon as a plugin finishes loading. That matters now that #156 shows the window *before* plugin loading completes — on a cold start the banner may appear briefly and then clear itself, which is the correct behaviour rather than a stale warning.

### Theming

Colours are read from `UIManager` on each render, so the banner follows theme changes like the rest of the UI.

### Localization

`main_window.no_service_message` and `main_window.no_service_action` added to the embedded English strings and all 13 bundled locales.

## Related issues

Closes the "no service configured" empty state — roadmap item 2-A, and the last open item from the UX and performance audit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

<!-- Best shown by starting with the plugins folder emptied. -->