### PR TITLE
chore(release): prepare 1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,17 +196,18 @@ jobs:
 
             | Download | Who it is for | Java needed |
             |---|---|---|
-            | `QTranslate-${{ steps.version.outputs.version }}-windows-x64.zip` | **Windows users — start here.** Extract and run `QTranslate.exe`. | No — runtime included |
-            | `QTranslate-${{ steps.version.outputs.version }}.zip` | Portable build for macOS, Linux, or Windows without an installer. Extract and run `QTranslate.jar`. | Java 11+ |
-            | `QTranslate-App-${{ steps.version.outputs.version }}.jar` | App only, no plugins. For custom setups and plugin development. | Java 11+ |
+            | **[⬇ Windows (.exe)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/QTranslate-${{ steps.version.outputs.version }}-windows-x64.zip)** | **Start here on Windows.** Extract and run `QTranslate.exe`. | No — runtime included |
+            | **[⬇ Portable (all platforms)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/QTranslate-${{ steps.version.outputs.version }}.zip)** | macOS, Linux, or Windows without an installer. Extract and run `QTranslate.jar`. | Java 11+ |
+            | **[⬇ App only (.jar)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/QTranslate-App-${{ steps.version.outputs.version }}.jar)** | No plugins. For custom setups and plugin development. | Java 11+ |
 
             The portable ZIP already contains every bundled plugin. The individual
-            plugin JARs below are only needed to add or update a single plugin in an
-            existing installation — most users can ignore them.
+            plugin JARs in the assets below are only needed to add or update a single
+            plugin in an existing installation — most users can ignore them.
 
             ## Verification
 
-            Verify the integrity of your download using the `SHA256SUMS.txt` file:
+            Optional. Download [SHA256SUMS.txt](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/SHA256SUMS.txt)
+            into the same folder as your download and run:
             ```
             sha256sum -c SHA256SUMS.txt
             ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [1.3.0] — 2026-08-14
+
 ### Added
-- **QTranslate Light and QTranslate Dark** — purpose-built default themes with comfortable neutral surfaces, teal accents, OS light/dark synchronization, and tested WCAG contrast
+- **QTranslate Light and QTranslate Dark** — purpose-built default themes built on the project's own palette: warm parchment and gold in the light theme, near-black and gold in the dark one, with OS light/dark synchronization and every colour verified against WCAG contrast targets
 - **Format-preserving document translation** for DOCX, PDF, TXT, SRT, and VTT, including progress, cancellation, DOCX structure preservation, subtitle timing preservation, and best-effort PDF appearance mode
 - **Modern plugin manager** — searchable and filterable installed-plugin list, inline enable/configure actions, drag-and-drop installation, detailed metadata and service lists, failure states, and complete plugin/service icon coverage
 - **Configurable service selectors** — classic and enhanced layouts, icons/text display modes, overflow handling, automatic scrolling, and quick access to plugin configuration
@@ -20,6 +24,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Batch translation and bilingual dictionary plugin API capabilities** for efficient document translation and contextual dictionary results
 - **Release variants** — app-only JAR, portable ZIP, independently versioned plugin JARs, machine-readable metadata, SHA-256 checksums, and size reports
 - **Portable Windows x64 package** with `QTranslate.exe` and a bundled trimmed Java runtime
+- **Document translation button** in the history bar, and dropping a DOCX, PDF, TXT, SRT or VTT file on the window opens the translation dialog with it already selected
+- **Six new keyboard shortcuts** — copy translation, clear input, swap languages, open settings, show history and translate document, all rebindable under Settings → Keyboard & Hotkeys
+- **Guidance when no translation service is configured**, with a direct link to the Services settings, instead of a window that silently does nothing
 - `runWithPlugins` manual QA launcher and `smokeTestAllPlugins` automated plugin lifecycle/service check
 
 ### Changed
@@ -28,8 +35,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Mozhi settings provide known public instances, endpoint tests, and automatic fastest-instance selection
 - OpenRouter defaults and setup guidance are clearer for first-time AI Services users
 - Release archives are size-budgeted to keep portable downloads practical
+- Copying a translation now confirms in the status bar instead of giving no feedback at all
+
+### Performance
+- **The translation appears as soon as it arrives.** With extra output enabled it was held back until the second request finished, so every translation felt as slow as the slower of the pair; the extra panel now loads on its own
+- **The window opens before plugins finish loading.** Startup previously waited for every plugin to initialise — including ones that make network calls — leaving nothing on screen in the meantime
+- Instant translation responds after 350 ms instead of 700 ms, so the result still reads as a response to what was typed
 
 ### Fixed
+- **Every network service failed in the Windows package.** The bundled Java runtime was missing its elliptic-curve crypto provider, so every HTTPS connection failed and translation, dictionary and TTS all appeared broken
 - Selected-text capture is more reliable across desktop applications
 - Quick Translate now reads the original text aloud instead of the translation, so Listen can be used to check pronunciation of the word you selected
 - Global hotkeys support non-US keyboard layouts
@@ -38,6 +52,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Service types can be disabled independently
 - Java2D selects the appropriate rendering pipeline instead of forcing one globally
 - A malformed plugin is represented as a failure in the plugin manager without preventing app startup
+- Non-English interface languages format numbers and dates correctly in the Windows package, which was missing its locale data
+- The error detail popup and Quick Translate close buttons have tooltips
 
 ---
 
@@ -152,7 +168,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/ahatem/QTranslate/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/ahatem/QTranslate/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/ahatem/QTranslate/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/ahatem/QTranslate/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/ahatem/QTranslate/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ahatem/QTranslate/compare/v1.0.0...v1.1.0

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
@@ -15,7 +15,7 @@ object AppConstants {
      * Used by [com.github.ahatem.qtranslate.core.main.domain.usecase.CheckForUpdatesUseCase]
      * to compare against the latest release.
      */
-    const val APP_VERSION = "1.2.1"
+    const val APP_VERSION = "1.3.0"
 
     // ============================================================
     // Timing


### PR DESCRIPTION
## What does this PR do?

Release preparation for 1.3.0.

- `CHANGELOG.md` — `[Unreleased]` becomes `[1.3.0] — 2026-08-14`, with the compare links added.
- `AppConstants.APP_VERSION` — `1.2.1` → `1.3.0`, so the in-app updater compares against the right version.
- Release notes now link each download directly instead of naming files the user has to find among sixteen assets.

### Changelog corrections

The Unreleased section was written partway through the cycle and had gone stale:

- The default themes were described as having **teal accents**. They shipped on the project's own gold palette.
- Everything from #148 and #153–160 was missing.
- Added a **Performance** section for the three changes users will actually feel — the translation no longer waiting on extra output, the window opening before plugins load, and the shorter instant-translation delay.
- Pulled the Windows runtime fix to the top of Fixed. Every network service failed in that package, which makes it the most consequential fix in the release.

## Related issues

Ships everything merged since v1.2.1 — 41 commits.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable — changelog, version constant and release-note template.