### PR TITLE
fix(ui): render at the display's scale, not at 100%

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialog.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.dictionary
 
+import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceInfo
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -140,8 +141,8 @@ class DictionaryDialog(owner: Frame) : JDialog(owner, false) {
 
         if (!isVisible) {
             pack()
-            minimumSize = Dimension(480, 400)
-            preferredSize = Dimension(560, 520)
+            minimumSize = Dimension(UIScale.scale(480), UIScale.scale(400))
+            preferredSize = Dimension(UIScale.scale(560), UIScale.scale(520))
             pack()
             setLocationRelativeTo(owner)
         }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.dictionary
 
+import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.api.dictionary.DictionaryEntry
 import java.awt.*
 import javax.swing.*
@@ -127,7 +128,7 @@ class DictionaryResultView : JScrollPane() {
             add(JLabel("$num.").apply {
                 foreground = muted
                 verticalAlignment = SwingConstants.TOP
-                preferredSize = Dimension(22, preferredSize.height)
+                preferredSize = Dimension(UIScale.scale(22), preferredSize.height)
             }, BorderLayout.LINE_START)
             add(wrappingArea(text), BorderLayout.CENTER)
         }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.dictionary
 
+import com.formdev.flatlaf.util.UIScale
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceInfo
 import com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource
@@ -139,7 +140,7 @@ class QuickDictionaryDialog(
     init {
         isUndecorated = true
         isAlwaysOnTop = true
-        minimumSize = Dimension(320, 200)
+        minimumSize = Dimension(UIScale.scale(320), UIScale.scale(200))
         focusableWindowState = false
 
         val wrapperPanel = JPanel(BorderLayout()).apply {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/history/HistoryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/history/HistoryDialog.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.history
 
+import com.formdev.flatlaf.util.UIScale
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.Frame
@@ -16,7 +17,7 @@ class HistoryDialog(owner: Frame) : JDialog(owner, false) {
     private val tableModel = HistoryTableModel()
     private val table = JTable(tableModel).apply {
         setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-        rowHeight = 28
+        rowHeight = UIScale.scale(28)
         showHorizontalLines = true
         showVerticalLines = false
         tableHeader.reorderingAllowed = false
@@ -103,8 +104,8 @@ class HistoryDialog(owner: Frame) : JDialog(owner, false) {
 
         if (!isVisible) {
             pack()
-            minimumSize = Dimension(640, 400)
-            preferredSize = Dimension(760, 480)
+            minimumSize = Dimension(UIScale.scale(640), UIScale.scale(400))
+            preferredSize = Dimension(UIScale.scale(760), UIScale.scale(480))
             pack()
             setLocationRelativeTo(owner)
         }
@@ -117,11 +118,11 @@ class HistoryDialog(owner: Frame) : JDialog(owner, false) {
 
     private fun applyColumnRenderers(centerRenderer: DefaultTableCellRenderer) {
         if (table.columnCount < 5) return
-        table.columnModel.getColumn(0).apply { preferredWidth = 110; maxWidth = 140; cellRenderer = centerRenderer }
-        table.columnModel.getColumn(1).preferredWidth = 220
-        table.columnModel.getColumn(2).preferredWidth = 220
-        table.columnModel.getColumn(3).apply { preferredWidth = 90; maxWidth = 120; cellRenderer = centerRenderer }
-        table.columnModel.getColumn(4).apply { preferredWidth = 100; maxWidth = 140; cellRenderer = centerRenderer }
+        table.columnModel.getColumn(0).apply { preferredWidth = UIScale.scale(110); maxWidth = UIScale.scale(140); cellRenderer = centerRenderer }
+        table.columnModel.getColumn(1).preferredWidth = UIScale.scale(220)
+        table.columnModel.getColumn(2).preferredWidth = UIScale.scale(220)
+        table.columnModel.getColumn(3).apply { preferredWidth = UIScale.scale(90); maxWidth = UIScale.scale(120); cellRenderer = centerRenderer }
+        table.columnModel.getColumn(4).apply { preferredWidth = UIScale.scale(100); maxWidth = UIScale.scale(140); cellRenderer = centerRenderer }
     }
 
     private class HistoryTableModel : AbstractTableModel() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -3,6 +3,7 @@ package com.github.ahatem.qtranslate.ui.swing.main
 import com.formdev.flatlaf.FlatLaf
 import com.formdev.flatlaf.extras.components.FlatButton
 import com.formdev.flatlaf.util.FontUtils
+import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.api.language.LanguageCode
 import com.github.ahatem.qtranslate.api.plugin.NotificationType
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
@@ -307,17 +308,22 @@ class MainAppFrame(
             val config = settingsStore.state.value.workingConfiguration
             val scale = config.uiScale / 100f
 
+            // The constants are authored against a 100% display, while everything drawn inside the
+            // window — fonts, icons, insets — is scaled by FlatLaf to the display's density. Without
+            // UIScale the window opens at its 100% size on a 150% or 200% screen and clips its own
+            // controls. A saved size is already in device pixels, so it is used as-is; scaling it
+            // again would grow the window on every launch.
             minimumSize = Dimension(
-                (AppConstants.MIN_WINDOW_WIDTH * scale).toInt(),
-                (AppConstants.MIN_WINDOW_HEIGHT * scale).toInt()
+                UIScale.scale((AppConstants.MIN_WINDOW_WIDTH * scale).toInt()),
+                UIScale.scale((AppConstants.MIN_WINDOW_HEIGHT * scale).toInt())
             )
             val savedSize = config.mainWindowSize
             preferredSize = if (savedSize != null) {
                 Dimension(savedSize.width, savedSize.height)
             } else {
                 Dimension(
-                    (AppConstants.DEFAULT_WINDOW_WIDTH * scale).toInt(),
-                    (AppConstants.DEFAULT_WINDOW_HEIGHT * scale).toInt()
+                    UIScale.scale((AppConstants.DEFAULT_WINDOW_WIDTH * scale).toInt()),
+                    UIScale.scale((AppConstants.DEFAULT_WINDOW_HEIGHT * scale).toInt())
                 )
             }
 
@@ -1226,7 +1232,7 @@ class MainAppFrame(
         )
 
         dialog.pack()
-        dialog.minimumSize = Dimension(320, dialog.height)
+        dialog.minimumSize = Dimension(UIScale.scale(320), dialog.height)
         dialog.setLocationRelativeTo(this)
         dialog.isVisible = true
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.main
 
+import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.api.language.LanguageCode
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.localization.getDisplayName
@@ -162,7 +163,7 @@ class MainContentView(
         },
         onClose  = { dispatch(MainIntent.ToggleDictionaryPanel) },
     ).apply {
-        minimumSize = Dimension(220, 0)
+        minimumSize = Dimension(UIScale.scale(220), 0)
     }
 
     // Separate wrapper so LayoutManager.switchLayout()'s removeAll() never touches dictionaryPanel.

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/UISpacing.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/UISpacing.kt
@@ -1,11 +1,30 @@
 package com.github.ahatem.qtranslate.ui.swing.main.layout
 
+import com.formdev.flatlaf.util.UIScale
+
+/**
+ * Layout metrics, authored against a 100% display and scaled to the one in use.
+ *
+ * These are handed straight to `EmptyBorder`, `Dimension` and `dividerSize`, none of which scale
+ * on their own — unlike the look-and-feel's own metrics, which FlatLaf already scales. Left
+ * unscaled they would come out at half their intended size on a 200% display, next to text and
+ * icons drawn at full density.
+ *
+ * Getters rather than constants so the scale factor is read after the look and feel has resolved
+ * it, not whenever this object first happens to be touched.
+ */
 object UISpacing {
-    const val PADDING = 12 // Padding for the main window frame
-    const val H_GAP = 12 // Horizontal gap for content
-    const val V_GAP = 8  // Vertical gap between stacked components
-    const val DIVIDER_SIZE = 8
-    const val MIN_PANEL_HEIGHT = 150
-    const val MIN_PANEL_WIDTH = 200
-    const val MIN_EXTRA_HEIGHT = 100
+    /** Padding for the main window frame. */
+    val PADDING get() = UIScale.scale(12)
+
+    /** Horizontal gap for content. */
+    val H_GAP get() = UIScale.scale(12)
+
+    /** Vertical gap between stacked components. */
+    val V_GAP get() = UIScale.scale(8)
+
+    val DIVIDER_SIZE get() = UIScale.scale(8)
+    val MIN_PANEL_HEIGHT get() = UIScale.scale(150)
+    val MIN_PANEL_WIDTH get() = UIScale.scale(200)
+    val MIN_EXTRA_HEIGHT get() = UIScale.scale(100)
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/NotificationPopover.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/statusbar/NotificationPopover.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.main.statusbar
 
+import com.formdev.flatlaf.util.UIScale
 import com.formdev.flatlaf.FlatClientProperties
 import com.github.ahatem.qtranslate.api.plugin.NotificationType
 import java.awt.BorderLayout
@@ -34,7 +35,7 @@ class NotificationPopover(
         list.isOpaque = false
 
         val scrollPane = JScrollPane(list).apply {
-            preferredSize = Dimension(360, 240)
+            preferredSize = Dimension(UIScale.scale(360), UIScale.scale(240))
             border = BorderFactory.createEmptyBorder()
         }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
+import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.api.plugin.PluginSettings
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.plugin.settings.*
@@ -105,7 +106,7 @@ class DynamicPluginSettingsDialog(
 
         defaultCloseOperation = DISPOSE_ON_CLOSE
         minimumSize = Dimension(520, 320)
-        preferredSize = Dimension(640, 500)
+        preferredSize = Dimension(UIScale.scale(640), UIScale.scale(500))
         pack()
         setLocationRelativeTo(owner)
     }
@@ -390,7 +391,7 @@ class DynamicPluginSettingsDialog(
                 }
                 val fm = area.getFontMetrics(area.font)
                 val targetH = (fm.height * rows + 8).coerceAtLeast(60)
-                scroll.preferredSize = Dimension(300, targetH)
+                scroll.preferredSize = Dimension(UIScale.scale(300), targetH)
                 scroll.minimumSize = Dimension(0, targetH)
                 SettingComponent(placeholder, scroll) { area.text }
             }
@@ -435,7 +436,7 @@ class DynamicPluginSettingsDialog(
                 }
                 val fmt = "%.${decimalPlaces}f"
                 val valueLabel = JLabel(fmt.format(intVal.toDouble() / scale)).apply {
-                    preferredSize = Dimension(48, preferredSize.height)
+                    preferredSize = Dimension(UIScale.scale(48), preferredSize.height)
                     horizontalAlignment = SwingConstants.TRAILING
                     font = font.deriveFont(Font.BOLD)
                 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/KeyboardPanel.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
+import com.formdev.flatlaf.util.UIScale
 import com.formdev.flatlaf.FlatClientProperties
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.settings.data.HotkeyAction
@@ -91,14 +92,14 @@ class KeyboardPanel(
             setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
             putClientProperty("FlatLaf.style", "showCellFocusIndicator: false")
 
-            columnModel.getColumn(COL_ACTION).apply { preferredWidth = 200; minWidth = 150 }
+            columnModel.getColumn(COL_ACTION).apply { preferredWidth = UIScale.scale(200); minWidth = UIScale.scale(150) }
             columnModel.getColumn(COL_HOTKEY).apply {
-                preferredWidth = 150
+                preferredWidth = UIScale.scale(150)
                 minWidth       = 110
                 cellRenderer   = HotkeyColumnRenderer()
             }
             columnModel.getColumn(COL_SCOPE).apply {
-                preferredWidth = 130
+                preferredWidth = UIScale.scale(130)
                 minWidth       = 80
                 cellRenderer   = ScopeColumnRenderer()
             }
@@ -129,7 +130,7 @@ class KeyboardPanel(
         gb.nextRow().spanLine().weightX(1.0).fill(GridBagConstraints.HORIZONTAL)
             .insets(4, 0, 0, 0)
             .add(JScrollPane(table).apply {
-                preferredSize = Dimension(580, actionOrder.size * 34 + 4)
+                preferredSize = Dimension(UIScale.scale(580), UIScale.scale(actionOrder.size * 34 + 4))
                 border = themeAwareBorder()
             })
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/LanguagesPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/LanguagesPanel.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
+import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.api.language.LanguageCode
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource
@@ -91,7 +92,7 @@ class LanguagesPanel(
         gb.nextRow().spanLine().weightX(1.0).fill(GridBagConstraints.HORIZONTAL)
             .insets(4, 0, 0, 0)
             .add(JScrollPane(checkBoxPanel).apply {
-                preferredSize = Dimension(580, 200)
+                preferredSize = Dimension(UIScale.scale(580), UIScale.scale(200))
                 verticalScrollBarPolicy   = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
                 horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
                 border = themeAwareBorder()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
+import com.formdev.flatlaf.util.UIScale
 import com.formdev.flatlaf.FlatClientProperties
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.github.ahatem.qtranslate.api.plugin.SupportedLanguages
@@ -189,7 +190,7 @@ class PluginsPanel(
         }
 
         leftPanel = JPanel(BorderLayout()).apply {
-            preferredSize = Dimension(320, 0)
+            preferredSize = Dimension(UIScale.scale(320), 0)
             minimumSize   = Dimension(270, 0)
             maximumSize   = Dimension(350, Int.MAX_VALUE)
             add(listHeader, BorderLayout.NORTH)
@@ -302,7 +303,7 @@ class PluginsPanel(
             }
         }.apply {
             maximumSize = Dimension(Int.MAX_VALUE, 62)
-            preferredSize = Dimension(290, 62)
+            preferredSize = Dimension(UIScale.scale(290), UIScale.scale(62))
             isOpaque = false
             border = BorderFactory.createEmptyBorder(7, 9, 7, 7)
             cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ConfigurationExtensions.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ConfigurationExtensions.kt
@@ -1,19 +1,29 @@
 package com.github.ahatem.qtranslate.ui.swing.shared.util
 
+import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.FontConfig
 
+/**
+ * The point size actually used for [size], given the user's zoom and the display's density.
+ *
+ * Two independent factors: `uiScale` is the app's own zoom setting, and [UIScale] is how many
+ * device pixels the display puts behind one logical pixel. The configured size is authored against
+ * a 100% display, so without the second factor the fonts stay physically small on a 150% or 200%
+ * screen while every icon, inset and border around them is scaled up — text ends up looking like
+ * it belongs to a different window than its own chrome.
+ *
+ * These sizes are installed directly as `defaultFont` and on the editors, which is why the scaling
+ * has to happen here: a font handed to Swing verbatim is used verbatim.
+ */
+private fun FontConfig.scaledTo(uiScale: Int): FontConfig =
+    copy(size = UIScale.scale((size * (uiScale / 100f)).toInt()))
+
 val Configuration.scaledUiFont: FontConfig
-    get() = uiFontConfig.copy(
-        size = (uiFontConfig.size * (uiScale / 100f)).toInt()
-    )
+    get() = uiFontConfig.scaledTo(uiScale)
 
 val Configuration.scaledEditorFont: FontConfig
-    get() = editorFontConfig.copy(
-        size = (editorFontConfig.size * (uiScale / 100f)).toInt()
-    )
+    get() = editorFontConfig.scaledTo(uiScale)
 
 val Configuration.scaledEditorFallbackFont: FontConfig
-    get() = editorFallbackFontConfig.copy(
-        size = (editorFallbackFontConfig.size * (uiScale / 100f)).toInt()
-    )
+    get() = editorFallbackFontConfig.scaledTo(uiScale)


### PR DESCRIPTION
## What does this PR do?

On a 150% or 200% display QTranslate drew scaled chrome around unscaled everything else. Icons, borders and the look-and-feel's own metrics came out at the display's density because FlatLaf scales those, while text, paddings, panel widths, table rows and the window itself stayed at their 100% pixel values.

Every case is the same mistake — a number authored against a 100% display used as a device pixel count:

- **Fonts.** The sizes are installed directly as `defaultFont` and on the editors, and a font handed to Swing verbatim is used verbatim, so the configured point size was never scaled. Fixed at the single point where the configured size is converted (`ConfigurationExtensions`), covering the UI font, the editor font and its fallback.
- **The window.** The default and minimum sizes were computed from `AppConstants` and used as-is, so the window opened at roughly half the size its own contents needed — clipping the language selectors to "Eng…" and "Ara…" and leaving the output pane no usable height.
- **Layout metrics.** `UISpacing` paddings, gaps, divider size and panel minimums go straight into `EmptyBorder` and `Dimension`, neither of which scales on its own. These became getters so the factor is read after the look and feel resolves it rather than whenever the object is first touched.
- **Panel and dialog sizes.** Minimums and preferred sizes across the dictionary panel and the dictionary, quick dictionary, history and plugin-settings dialogs, plus the fixed widths in the keyboard, languages and plugins settings panels.
- **The history table.** Row height and column widths, which clipped its headers to "Date …", "Lan…" and "Servi…".

The dictionary panel is the most visible: docked beside a translation it was pinned to half its intended width, wrapping definitions one word per line.

`DocumentTranslationDialog` and `UpdateDialog` already scaled their minimums, so this brings the rest in line with them.

A saved window size is deliberately left untouched — it is already in device pixels from a previous session, and scaling it again would grow the window on every launch.

**At 100% the scale factor is 1, so nothing changes for existing users on unscaled displays.**

## Related issues

<!-- none -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)` — n/a, no I/O added
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Needs testing on a scaled display — the change is invisible at 100%. On a 200% display, before this the fonts rendered at half the size of the surrounding icons and chrome, and the window opened too small for its own controls.

Also verified with `./gradlew smokeTestAllPlugins` — 40 passed, 0 failed.