### PR TITLE
fix(ui): keep borderless panels borderless after a theme change

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryChipController.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryChipController.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.dictionary
 
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import java.awt.Dimension
 import javax.swing.*
 
@@ -22,7 +23,7 @@ class DictionaryChipController(
     val scrollPane: JScrollPane = JScrollPane(chipsPanel).apply {
         horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED
         verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_NEVER
-        border = null
+        clearBorder()
         isOpaque = false
         viewport.isOpaque = false
         isVisible = false

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
@@ -1,6 +1,7 @@
 package com.github.ahatem.qtranslate.ui.swing.dictionary
 
 import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import com.github.ahatem.qtranslate.api.dictionary.DictionaryEntry
 import java.awt.*
 import javax.swing.*
@@ -33,7 +34,7 @@ class DictionaryResultView : JScrollPane() {
 
     init {
         setViewportView(content)
-        border = null
+        clearBorder()
         horizontalScrollBarPolicy = HORIZONTAL_SCROLLBAR_NEVER
         verticalScrollBarPolicy = VERTICAL_SCROLLBAR_AS_NEEDED
         verticalScrollBar.unitIncrement = 16
@@ -178,7 +179,7 @@ class DictionaryResultView : JScrollPane() {
             isEditable = false
             isOpaque = false
             isFocusable = false
-            border = null
+            clearBorder()
             background = null
             if (muted) foreground = UIManager.getColor("Label.disabledForeground")
             if (italic) font = font.deriveFont(Font.ITALIC)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/Layouts.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/Layouts.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.main.layout
 
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import java.awt.*
 import javax.swing.*
 
@@ -153,7 +154,7 @@ object LayoutBuilders {
             isContinuousLayout = true
             this.resizeWeight = resizeWeight
             dividerSize = UISpacing.DIVIDER_SIZE
-            border = null
+            clearBorder()
         }
     }
 
@@ -174,7 +175,7 @@ object LayoutBuilders {
             isContinuousLayout = true
             this.resizeWeight = weight
             dividerSize = UISpacing.DIVIDER_SIZE
-            border = null
+            clearBorder()
         }
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/selector/TranslatorSelector.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/selector/TranslatorSelector.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.main.selector
 
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import com.formdev.flatlaf.FlatClientProperties
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceInfo
 import com.github.ahatem.qtranslate.core.settings.data.ServiceSelectorAppearance
@@ -22,7 +23,7 @@ class TranslatorSelector(
     private var state = TranslatorSelectorState(emptyList(), null, false)
     private val classicButtons = JPanel(FlowLayout(FlowLayout.LEADING, 2, 0)).apply { isOpaque = false }
     private val classicScroll = JScrollPane(classicButtons).apply {
-        border = null; isOpaque = false; viewport.isOpaque = false
+        clearBorder(); isOpaque = false; viewport.isOpaque = false
         verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_NEVER
         horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
         horizontalScrollBar.unitIncrement = 24

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.quciktranslate
 
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import com.formdev.flatlaf.FlatClientProperties
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.github.ahatem.qtranslate.core.settings.data.Position
@@ -123,11 +124,14 @@ class QuickTranslateDialog(
         wrapperPanel.add(mainPanel, BorderLayout.CENTER)
 
         val textScrollPane = JScrollPane(outputTextArea).apply {
+            // Styled rather than cleared: `borderWidth` addresses the look and feel's own border,
+            // so it is reapplied on a theme change and there is nothing to restore. Replacing the
+            // border outright would leave this style with no border to act on.
             putClientProperty(
                 FlatClientProperties.STYLE,
                 "borderWidth: 0; focusWidth: 0; innerFocusWidth: 0; innerOutlineWidth: 0;"
             )
-            border = null
+            // JViewport rejects any border but null, and never installs one of its own.
             viewport.border = null
 
             verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
@@ -1,5 +1,6 @@
 package com.github.ahatem.qtranslate.ui.swing.settings
 
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.github.ahatem.qtranslate.api.plugin.NotificationType
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
@@ -236,7 +237,7 @@ class SettingsDialog(
 
     private fun buildSidebar(): JPanel {
         val treeScroll = JScrollPane(tree).apply {
-            border = null
+            clearBorder()
             horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
             verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
         }
@@ -258,7 +259,7 @@ class SettingsDialog(
 
         contentArea.components.filterIsInstance<JScrollPane>().forEach { contentArea.remove(it) }
         contentArea.add(JScrollPane(panel).apply {
-            border = null
+            clearBorder()
             horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
             verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
             verticalScrollBar.unitIncrement = 16

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
@@ -1,6 +1,7 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
 import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import com.github.ahatem.qtranslate.api.plugin.PluginSettings
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.plugin.settings.*
@@ -77,7 +78,7 @@ class DynamicPluginSettingsDialog(
         formPanel.add(Box.createVerticalGlue(), glueConstraints)
 
         val scroll = JScrollPane(formPanel).apply {
-            border = null
+            clearBorder()
             verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
             horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
             viewport.isOpaque = false

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
@@ -1,6 +1,7 @@
 package com.github.ahatem.qtranslate.ui.swing.settings.panels
 
 import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
 import com.formdev.flatlaf.FlatClientProperties
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.github.ahatem.qtranslate.api.plugin.SupportedLanguages
@@ -140,7 +141,7 @@ class PluginsPanel(
 
         val dropHandler = PluginJarTransferHandler()
         val listScroll = JScrollPane(pluginRows).apply {
-            border = null
+            clearBorder()
             viewportBorder = null
             horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
             verticalScrollBar.unitIncrement = 16
@@ -204,7 +205,7 @@ class PluginsPanel(
         // ── Right: detail scroll + fixed action bar ───────────────────────────
         // Placeholder empty content — replaced by rebuildDetail()
         detailScroll = JScrollPane().apply {
-            border = null
+            clearBorder()
             viewportBorder = null
             horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
             verticalScrollBar.unitIncrement = 16
@@ -705,7 +706,7 @@ class PluginsPanel(
             wrapStyleWord = true
             rows = 1
             columns = 18
-            border = null
+            clearBorder()
             font = UIManager.getFont("Label.font").deriveFont(Font.BOLD)
             foreground = UIManager.getColor("Label.foreground")
             toolTipText = tooltip

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/SwingUtils.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/SwingUtils.kt
@@ -91,3 +91,15 @@ fun BufferedImage.toImageData(format: String): ImageData {
         height = this.height
     )
 }
+/**
+ * Removes this component's border so that a look-and-feel change cannot bring it back.
+ *
+ * `border = null` looks like it does the same thing, but [javax.swing.LookAndFeel.installBorder]
+ * reinstalls the look-and-feel default whenever the current border is `null` or a `UIResource` —
+ * and every component's `updateUI()` runs that on a theme change. Scroll panes and split panes
+ * that were built borderless would suddenly draw a frame around themselves the first time the
+ * user switched themes. An empty border is neither `null` nor a `UIResource`, so it survives.
+ */
+fun JComponent.clearBorder() {
+    border = BorderFactory.createEmptyBorder()
+}


### PR DESCRIPTION
## What does this PR do?

Switching themes drew a frame around the service selector, the dictionary panel, the plugin lists and the settings content area — components that are built deliberately borderless.

`border = null` was the cause. `LookAndFeel.installBorder` reinstalls the look-and-feel default whenever the current border is `null` **or** a `UIResource`, and a theme change runs `updateUI()` on every component, so each of these got its default border back. An empty border is neither, so it survives.

Adds `JComponent.clearBorder()` and uses it at all fourteen sites rather than repeating the reasoning — the `null` form reads as correct and will be reached for again otherwise.

Two deliberate exceptions:

- `JViewport` rejects any border but `null` and never installs one of its own, so that one site keeps `null` with a comment saying why.
- The quick translate scroll pane removes its border through FlatLaf's `borderWidth: 0` style instead. That style addresses the look-and-feel's own border, so it is reapplied on a theme change anyway — and replacing the border outright leaves the style with nothing to act on, which throws `UnknownStyleException`.

## Related issues

<!-- none -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)` — n/a, no I/O added
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

To reproduce on `develop`: open the app, switch between the light and dark themes, and watch the service selector at the bottom gain a rounded box around it. The dictionary panel and the settings content area pick one up the same way.

Also verified with `./gradlew smokeTestAllPlugins` — 40 passed, 0 failed.