### PR TITLE
fix(ui): make split panes work in a right-to-left interface

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanel.kt
@@ -158,10 +158,19 @@ class DictionaryPanel(
             ?: UIManager.getColor("Panel.background")?.darker()
             ?: Color.GRAY
 
+        // The rule separates this panel from the content it is docked beside, so it belongs on
+        // whichever edge faces that content — the left in a left-to-right interface, the right in
+        // a right-to-left one, where the panel sits on the other side of the divider.
+        val facingContent = if (componentOrientation.isLeftToRight) 1 else 0
         border = BorderFactory.createCompoundBorder(
-            BorderFactory.createMatteBorder(0, 1, 0, 0, borderColor),
+            BorderFactory.createMatteBorder(0, facingContent, 0, 1 - facingContent, borderColor),
             BorderFactory.createEmptyBorder(12, 12, 12, 12)
         )
+    }
+
+    override fun setComponentOrientation(orientation: java.awt.ComponentOrientation) {
+        super.setComponentOrientation(orientation)
+        refreshBorder()
     }
 
     private fun refreshLabelColors() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -1,6 +1,7 @@
 package com.github.ahatem.qtranslate.ui.swing.main
 
 import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.ui.swing.main.layout.MirroredSplitPane
 import com.github.ahatem.qtranslate.api.language.LanguageCode
 import com.github.ahatem.qtranslate.core.localization.LocalizationManager
 import com.github.ahatem.qtranslate.core.localization.getDisplayName
@@ -181,12 +182,16 @@ class MainContentView(
         ), contentWrapper
     )
 
-    private val splitPane = javax.swing.JSplitPane(
+    // MirroredSplitPane rather than a plain JSplitPane: with the interface in Arabic the whole
+    // window is flipped to right-to-left, and Swing implements that on a split pane by inverting
+    // the axis its divider is dragged along — the dictionary could not be resized. This mirrors by
+    // exchanging the two sides instead, so the divider still follows the mouse.
+    private val splitPane = MirroredSplitPane(
         javax.swing.JSplitPane.HORIZONTAL_SPLIT, true, contentWrapper, dictionaryPanel
     ).apply {
-        resizeWeight = 1.0   // main content gets all extra space when window is resized
-        dividerSize  = 0     // collapsed until panel is first shown
-        border       = null
+        leadingResizeWeight = 1.0 // main content gets all extra space when window is resized
+        dividerSize = 0           // collapsed until panel is first shown
+        border = null
         dictionaryPanel.isVisible = false
     }
 
@@ -234,6 +239,10 @@ class MainContentView(
 
     fun render(mainState: MainState, settingsState: SettingsState) {
         val config = settingsState.workingConfiguration
+
+        // Told outright rather than left to the orientation cascade, which reaches the split pane
+        // at a point in startup that depends on when this view was added to the window.
+        splitPane.isMirrored = localizer.isRtl
 
         if (lastState == null || lastState?.second?.workingConfiguration?.layoutPresetId != config.layoutPresetId) {
             layoutManager.switchLayout(config.layoutPresetId, localizer.isRtl)
@@ -354,7 +363,9 @@ class MainContentView(
                     // Defer via invokeLater so it fires after the layout pass — otherwise
                     // splitPane.width is still 0 and the panel opens with the wrong size.
                     javax.swing.SwingUtilities.invokeLater {
-                        splitPane.setDividerLocation(0.65)
+                        // Leading proportion, not a raw one: in a right-to-left interface the
+                        // dictionary sits on the other side of the divider.
+                        splitPane.setLeadingProportion(0.65)
                     }
                 }
             } else {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/Layouts.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/Layouts.kt
@@ -149,30 +149,29 @@ object LayoutBuilders {
     ): JSplitPane {
         top.minimumSize = Dimension(0, topMinHeight)
         bottom.minimumSize = Dimension(0, bottomMinHeight)
-        return JSplitPane(JSplitPane.VERTICAL_SPLIT, top, bottom).apply {
-            isContinuousLayout = true
-            this.resizeWeight = resizeWeight
+        return MirroredSplitPane(JSplitPane.VERTICAL_SPLIT, true, top, bottom).apply {
+            leadingResizeWeight = resizeWeight
             dividerSize = UISpacing.DIVIDER_SIZE
             border = null
         }
     }
 
+    /**
+     * @param leading  the pane shown first in reading order — left in a left-to-right interface,
+     *                 right in a right-to-left one. [MirroredSplitPane] handles the exchange, so
+     *                 callers pass reading order and never check the direction themselves.
+     */
     fun createHorizontalSplit(
-        left: JComponent,
-        right: JComponent,
+        leading: JComponent,
+        trailing: JComponent,
         resizeWeight: Double = 0.5,
-        leftMinWidth: Int = UISpacing.MIN_PANEL_WIDTH,
-        rightMinWidth: Int = UISpacing.MIN_PANEL_WIDTH,
-        rtl: Boolean = false
+        leadingMinWidth: Int = UISpacing.MIN_PANEL_WIDTH,
+        trailingMinWidth: Int = UISpacing.MIN_PANEL_WIDTH,
     ): JSplitPane {
-        val first = if (rtl) right else left
-        val second = if (rtl) left else right
-        val weight = if (rtl) 1.0 - resizeWeight else resizeWeight
-        first.minimumSize = Dimension(leftMinWidth, 0)
-        second.minimumSize = Dimension(rightMinWidth, 0)
-        return JSplitPane(JSplitPane.HORIZONTAL_SPLIT, first, second).apply {
-            isContinuousLayout = true
-            this.resizeWeight = weight
+        leading.minimumSize = Dimension(leadingMinWidth, 0)
+        trailing.minimumSize = Dimension(trailingMinWidth, 0)
+        return MirroredSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, leading, trailing).apply {
+            leadingResizeWeight = resizeWeight
             dividerSize = UISpacing.DIVIDER_SIZE
             border = null
         }
@@ -228,8 +227,8 @@ object SideBySideLayout : LayoutStrategy {
         val bottomBar = LayoutBuilders.createBottomBar(components.translatorSelector, components.statusBar)
 
         val mainSplit = LayoutBuilders.createHorizontalSplit(
-            left = components.inputPanel, right = components.outputPanel,
-            resizeWeight = 0.5, rtl = isRtl
+            leading = components.inputPanel, trailing = components.outputPanel,
+            resizeWeight = 0.5
         )
         val extraSplit = LayoutBuilders.createVerticalSplit(
             top = mainSplit,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/MirroredSplitPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/layout/MirroredSplitPane.kt
@@ -1,0 +1,108 @@
+package com.github.ahatem.qtranslate.ui.swing.main.layout
+
+import java.awt.Component
+import java.awt.ComponentOrientation
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import javax.swing.JSplitPane
+
+
+/**
+ * A [JSplitPane] that mirrors by swapping its children, not by component orientation.
+ *
+ * Swing lays out both split orientations with the same implementation, and that implementation
+ * inverts its coordinates when the component orientation is right-to-left. Two things go wrong
+ * when the orientation is applied to a whole window:
+ *
+ * - **Vertical splits reverse.** A vertical split has no leading or trailing side, but it inherits
+ *   the inversion anyway, so the bottom component is drawn on top. With the interface in Arabic
+ *   the output pane sat above the input.
+ * - **Horizontal splits stop dragging correctly.** The divider's position is computed from the
+ *   inverted axis while the mouse reports normal coordinates, so dragging the docked dictionary
+ *   moves the wrong way or refuses to move, and [setResizeWeight] favours the wrong side when the
+ *   window is resized.
+ *
+ * This pane keeps itself left-to-right whatever the cascade asks for, and implements a right-to-
+ * left arrangement by exchanging the two children instead. Layout and dragging then run on
+ * coordinates that match the mouse, while the children still receive the orientation themselves —
+ * text alignment, toolbars and the title bar mirror as they should.
+ *
+ * @param leading  the component shown first in reading order — left in a left-to-right interface,
+ *                 right in a right-to-left one.
+ * @param trailing the component shown second.
+ */
+class MirroredSplitPane(
+    orientation: Int,
+    continuousLayout: Boolean,
+    private val leading: Component,
+    private val trailing: Component,
+) : JSplitPane(orientation, continuousLayout, leading, trailing) {
+
+    /** Share of the space given to [leading] when the window is resized. */
+    var leadingResizeWeight: Double = 0.5
+        set(value) {
+            field = value
+            resizeWeight = if (isMirrored) 1.0 - value else value
+        }
+
+    /**
+     * Whether the children are exchanged, i.e. whether the interface reads right to left.
+     *
+     * Set explicitly by the owner rather than inferred from [setComponentOrientation]. The
+     * orientation cascade reaches this pane at a point in startup that depends on when the
+     * enclosing view was added to the window, so relying on it left the arrangement unset in some
+     * orders. The owner knows the interface direction outright.
+     */
+    var isMirrored: Boolean = false
+        set(value) {
+            if (field == value) return
+            field = value
+            resizeWeight = if (value) 1.0 - leadingResizeWeight else leadingResizeWeight
+            rearrange()
+        }
+
+    override fun setComponentOrientation(orientation: ComponentOrientation) {
+        super.setComponentOrientation(ComponentOrientation.LEFT_TO_RIGHT)
+    }
+
+    /**
+     * Gives [leading] the requested share of the width.
+     *
+     * Callers think in reading order, so the proportion is for the leading component and is
+     * converted here — passing it raw would put the panel on the wrong side of the divider in a
+     * right-to-left interface.
+     *
+     * [setDividerLocation] with a proportion is silently ignored while the pane has no size,
+     * which is the usual reason a panel opens pinned to its minimum width instead of the share it
+     * asked for. If the size is not known yet the request is held until the first layout.
+     */
+    fun setLeadingProportion(proportion: Double) {
+        val wanted = if (isMirrored) 1.0 - proportion else proportion
+        if (isShowing && width > 0) {
+            setDividerLocation(wanted)
+        } else {
+            addComponentListener(object : ComponentAdapter() {
+                override fun componentResized(e: ComponentEvent) {
+                    if (width <= 0) return
+                    removeComponentListener(this)
+                    setDividerLocation(wanted)
+                }
+            })
+        }
+    }
+
+    private fun rearrange() {
+        val proportion = if (width > 0) dividerLocation.toDouble() / width else -1.0
+
+        // JSplitPane refuses a component that is still installed in the other slot, so both have
+        // to be detached before either is put back.
+        leftComponent = null
+        rightComponent = null
+        leftComponent = if (isMirrored) trailing else leading
+        rightComponent = if (isMirrored) leading else trailing
+
+        revalidate()
+        if (proportion > 0.0 && proportion < 1.0) setDividerLocation(1.0 - proportion)
+        repaint()
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Swing lays out both split orientations with one implementation, and that implementation inverts its coordinates under a right-to-left component orientation. Applying the orientation to the window broke both kinds:

- **Vertical splits reversed.** A vertical split has no leading or trailing side, but it inherited the inversion anyway, so with the interface in Arabic the output pane sat *above* the input and the extra pane above both.
- **The horizontal split holding the dictionary could not be dragged.** The divider position was computed on the inverted axis while the mouse reported normal coordinates, so the dictionary refused to resize, and the resize weight favoured the wrong side when the window grew.

Adds `MirroredSplitPane`, which keeps itself left-to-right whatever the cascade asks for and implements a right-to-left arrangement by **exchanging its two children** instead. Layout and dragging then run on coordinates that match the mouse, while the children still receive the orientation themselves — text, toolbars and the title bar mirror as they should.

The direction is set by the owner rather than read from the orientation cascade: the cascade reaches the split pane at a point in startup that depends on when the enclosing view was added to the window, which left the arrangement unset in some orders.

Callers now pass `leading`/`trailing` in reading order and no longer check the direction themselves — which surfaced that the side-by-side layout was already swapping its panes by hand, cancelling out against Swing's own inversion.

Two related fixes in the same area:

- **The dictionary opened at its minimum width.** `setDividerLocation(double)` is silently ignored while the pane has no size, and the deferred call it relied on could still land before the first layout. The request is now held until the pane actually has a width.
- **The dictionary's separator was on the wrong edge.** The rule that divides the panel from the translation was pinned to its left edge, so in a right-to-left interface — panel on the other side of the divider — it ended up on the outer edge and the two areas ran together with nothing between them. The edge is now chosen from the component orientation.

## Related issues

<!-- none -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)` — n/a, no I/O added
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

To reproduce on `develop`: Settings → Appearance → Interface Language → العربية. The output pane appears above the input, and the docked dictionary cannot be resized by dragging its divider.

Worth checking after merge: that a left-to-right interface is completely unchanged — the side-by-side layout is the one to watch, since its manual swap was removed.

Also verified with `./gradlew smokeTestAllPlugins` — 40 passed, 0 failed.