### PR TITLE
Popup and dialog overhaul

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDependencies.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/AppDependencies.kt
@@ -11,6 +11,7 @@ import com.github.ahatem.qtranslate.core.main.domain.usecase.SelectActiveService
 import com.github.ahatem.qtranslate.core.main.domain.usecase.SwapLanguagesUseCase
 import com.github.ahatem.qtranslate.core.main.domain.usecase.LookupWordUseCase
 import com.github.ahatem.qtranslate.core.main.domain.usecase.SearchImagesUseCase
+import com.github.ahatem.qtranslate.core.main.domain.usecase.FetchInlineDefinitionUseCase
 import com.github.ahatem.qtranslate.core.main.domain.usecase.RewriteUseCase
 import com.github.ahatem.qtranslate.core.main.domain.usecase.SummarizeUseCase
 import com.github.ahatem.qtranslate.core.main.domain.usecase.TranslateTextUseCase
@@ -233,6 +234,12 @@ suspend fun buildDependencies(
         loggerFactory        = loggerFactory
     )
 
+    val fetchInlineDefinitionUseCase = FetchInlineDefinitionUseCase(
+        scope                = appScope,
+        activeServiceManager = activeServiceManager,
+        loggerFactory        = loggerFactory
+    )
+
     val searchImagesUseCase = SearchImagesUseCase(
         scope                = appScope,
         activeServiceManager = activeServiceManager,
@@ -262,6 +269,7 @@ suspend fun buildDependencies(
         rewriteUseCase             = rewriteUseCase,
         lookupWordUseCase          = lookupWordUseCase,
         searchImagesUseCase        = searchImagesUseCase,
+        fetchInlineDefinitionUseCase = fetchInlineDefinitionUseCase,
         documentTranslationUseCase = DocumentTranslationUseCase(activeServiceManager, loggerFactory)
     )
 

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/FetchInlineDefinitionUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/FetchInlineDefinitionUseCase.kt
@@ -35,37 +35,59 @@ class FetchInlineDefinitionUseCase(
     operator fun invoke(
         word: String,
         language: LanguageCode,
+        alternateWord: String,
+        alternateLanguage: LanguageCode,
         updateState: (MainState.() -> MainState) -> Unit
     ) {
         job?.cancel(CancellationException("New inline definition requested"))
         updateState { copy(inlineDefinition = "") }
 
         val dictionary = activeServiceManager.getActiveService<Dictionary>(ServiceType.DICTIONARY)
-            ?: return
+        if (dictionary == null) {
+            logger.debug("No dictionary service active — no inline definition")
+            return
+        }
+
+        val candidates = listOf(word to language, alternateWord to alternateLanguage)
+            .filter { (candidate, _) -> candidate.isNotBlank() }
+            .distinctBy { (candidate, lang) -> candidate.lowercase() to lang.tag }
 
         job = scope.launch {
-            val response = runCatching {
-                // Shorter than a normal lookup's patience. This is a detail beside the
-                // translation; if it has not arrived by now the reader has already moved on.
-                withTimeoutOrNull(TIMEOUT_MS) {
-                    dictionary.lookup(DictionaryRequest(word, language)).get()
-                }
-            }.getOrNull() ?: return@launch
-
-            val summary = response.entries.firstOrNull()?.let { entry ->
-                val meanings = entry.definitions.take(MAX_MEANINGS)
-                    .map { it.text.trim() }
-                    .filter { it.isNotEmpty() }
-                if (meanings.isEmpty()) return@let null
-
-                val partOfSpeech = entry.partOfSpeech?.trim().orEmpty()
-                val body = meanings.joinToString(" · ")
-                if (partOfSpeech.isEmpty()) body else "$partOfSpeech — $body"
-            }.orEmpty()
-
-            if (summary.isNotBlank()) logger.debug("Inline definition ready for '$word'")
-            updateState { copy(inlineDefinition = summary) }
+            // Tried in turn, first hit wins. The translated word is asked about first because it
+            // is what the reader is looking at; the source word is the fallback because it is
+            // usually English, which is the language dictionaries actually cover.
+            for ((candidate, candidateLanguage) in candidates) {
+                val summary = summarise(dictionary, candidate, candidateLanguage) ?: continue
+                logger.debug("Inline definition ready for '$candidate' (${candidateLanguage.tag})")
+                updateState { copy(inlineDefinition = summary) }
+                return@launch
+            }
+            logger.debug("No inline definition for ${candidates.joinToString { it.first }}")
         }
+    }
+
+    private suspend fun summarise(
+        dictionary: Dictionary,
+        word: String,
+        language: LanguageCode
+    ): String? {
+        val response = runCatching {
+            // Shorter than a normal lookup's patience. This is a detail beside the translation;
+            // if it has not arrived by now the reader has already moved on.
+            withTimeoutOrNull(TIMEOUT_MS) {
+                dictionary.lookup(DictionaryRequest(word, language)).get()
+            }
+        }.getOrNull() ?: return null
+
+        val entry = response.entries.firstOrNull() ?: return null
+        val meanings = entry.definitions.take(MAX_MEANINGS)
+            .map { it.text.trim() }
+            .filter { it.isNotEmpty() }
+        if (meanings.isEmpty()) return null
+
+        val partOfSpeech = entry.partOfSpeech?.trim().orEmpty()
+        val body = meanings.joinToString(" · ")
+        return if (partOfSpeech.isEmpty()) body else "$partOfSpeech — $body"
     }
 
     /** Clears the line, for when the translation is no longer a single word. */

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/FetchInlineDefinitionUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/FetchInlineDefinitionUseCase.kt
@@ -1,0 +1,83 @@
+package com.github.ahatem.qtranslate.core.main.domain.usecase
+
+import com.github.ahatem.qtranslate.api.core.Logger
+import com.github.ahatem.qtranslate.api.dictionary.Dictionary
+import com.github.ahatem.qtranslate.api.dictionary.DictionaryRequest
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import com.github.ahatem.qtranslate.core.main.mvi.MainState
+import com.github.ahatem.qtranslate.core.settings.data.ActiveServiceManager
+import com.github.ahatem.qtranslate.core.shared.arch.ServiceType
+import com.github.ahatem.qtranslate.core.shared.logging.LoggerFactory
+import com.github.michaelbull.result.get
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Fetches a one-line definition to sit under a single-word translation.
+ *
+ * Separate from [LookupWordUseCase] rather than sharing its state, because the two answer
+ * different questions. That one fills a dictionary the user opened and is entitled to take its
+ * time and show everything it found. This one is a glance — it runs unasked, so it must be quick,
+ * quiet, and easy to ignore, and it must never put an error where the reader expected a
+ * translation. Every failure here ends the same way: no definition, and nothing said about it.
+ */
+class FetchInlineDefinitionUseCase(
+    private val scope: CoroutineScope,
+    private val activeServiceManager: ActiveServiceManager,
+    loggerFactory: LoggerFactory
+) {
+    private val logger: Logger = loggerFactory.getLogger("FetchInlineDefinitionUseCase")
+    private var job: Job? = null
+
+    operator fun invoke(
+        word: String,
+        language: LanguageCode,
+        updateState: (MainState.() -> MainState) -> Unit
+    ) {
+        job?.cancel(CancellationException("New inline definition requested"))
+        updateState { copy(inlineDefinition = "") }
+
+        val dictionary = activeServiceManager.getActiveService<Dictionary>(ServiceType.DICTIONARY)
+            ?: return
+
+        job = scope.launch {
+            val response = runCatching {
+                // Shorter than a normal lookup's patience. This is a detail beside the
+                // translation; if it has not arrived by now the reader has already moved on.
+                withTimeoutOrNull(TIMEOUT_MS) {
+                    dictionary.lookup(DictionaryRequest(word, language)).get()
+                }
+            }.getOrNull() ?: return@launch
+
+            val summary = response.entries.firstOrNull()?.let { entry ->
+                val meanings = entry.definitions.take(MAX_MEANINGS)
+                    .map { it.text.trim() }
+                    .filter { it.isNotEmpty() }
+                if (meanings.isEmpty()) return@let null
+
+                val partOfSpeech = entry.partOfSpeech?.trim().orEmpty()
+                val body = meanings.joinToString(" · ")
+                if (partOfSpeech.isEmpty()) body else "$partOfSpeech — $body"
+            }.orEmpty()
+
+            if (summary.isNotBlank()) logger.debug("Inline definition ready for '$word'")
+            updateState { copy(inlineDefinition = summary) }
+        }
+    }
+
+    /** Clears the line, for when the translation is no longer a single word. */
+    fun clear(updateState: (MainState.() -> MainState) -> Unit) {
+        job?.cancel(CancellationException("Inline definition no longer applicable"))
+        updateState { copy(inlineDefinition = "") }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 6_000L
+
+        /** Two senses is a glance; more is a dictionary, which is what the panel is for. */
+        const val MAX_MEANINGS = 2
+    }
+}

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/FetchInlineDefinitionUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/FetchInlineDefinitionUseCase.kt
@@ -80,14 +80,50 @@ class FetchInlineDefinitionUseCase(
         }.getOrNull() ?: return null
 
         val entry = response.entries.firstOrNull() ?: return null
-        val meanings = entry.definitions.take(MAX_MEANINGS)
+        val meanings = entry.definitions
             .map { it.text.trim() }
             .filter { it.isNotEmpty() }
         if (meanings.isEmpty()) return null
 
         val partOfSpeech = entry.partOfSpeech?.trim().orEmpty()
-        val body = meanings.joinToString(" · ")
+        val body = withinBudget(meanings)
         return if (partOfSpeech.isEmpty()) body else "$partOfSpeech — $body"
+    }
+
+    /**
+     * Fits the senses into a glance.
+     *
+     * The first sense always appears, shortened if it runs long. A second is added only when the
+     * first was brief enough that both still fit — taking a fixed two senses regardless of length
+     * is what turned a one-line note into a paragraph, and something you have to read is a
+     * different thing from something you can take in at a glance. Anything past that belongs in
+     * the dictionary, which is a keystroke away.
+     */
+    private fun withinBudget(meanings: List<String>): String {
+        val first = elide(meanings.first(), FIRST_SENSE_BUDGET)
+        if (meanings.size == 1 || first.length > SECOND_SENSE_THRESHOLD) return first
+
+        val combined = first + separatorAfter(first) + meanings[1]
+        return if (combined.length <= TOTAL_BUDGET) combined else first
+    }
+
+    /**
+     * What goes between two senses.
+     *
+     * A sense that already ends in punctuation separates itself; putting a bullet after a full
+     * stop is clutter, and reads as though the two halves were fragments of one thought rather
+     * than two complete ones.
+     */
+    private fun separatorAfter(previous: String): String =
+        if (previous.lastOrNull() in SENTENCE_ENDINGS) " " else " · "
+
+    /** Cut at a word boundary rather than mid-word, and never leave dangling punctuation. */
+    private fun elide(text: String, budget: Int): String {
+        if (text.length <= budget) return text
+        val cut = text.take(budget)
+        val boundary = cut.lastIndexOf(' ')
+        val kept = if (boundary > budget / 2) cut.take(boundary) else cut
+        return kept.trimEnd().trimEnd(',', ';', ':', '،', '؛') + "…"
     }
 
     /** Clears the line, for when the translation is no longer a single word. */
@@ -99,7 +135,22 @@ class FetchInlineDefinitionUseCase(
     private companion object {
         const val TIMEOUT_MS = 6_000L
 
-        /** Two senses is a glance; more is a dictionary, which is what the panel is for. */
-        const val MAX_MEANINGS = 2
+        /**
+         * Budgets in characters rather than pixels.
+         *
+         * The strip does not know how wide it will be drawn, and the popup and the main window
+         * differ anyway. Characters are a coarse proxy, but the decision being made here is only
+         * "one sense or two", which does not need pixel accuracy — and a rule that holds in both
+         * places is worth more than one tuned for either.
+         */
+        const val FIRST_SENSE_BUDGET = 120
+
+        /** A first sense longer than this leaves no room for a second worth reading. */
+        const val SECOND_SENSE_THRESHOLD = 60
+
+        const val TOTAL_BUDGET = 150
+
+        /** Latin and Arabic sentence endings — both scripts turn up here routinely. */
+        val SENTENCE_ENDINGS = setOf('.', '!', '?', '۔', '؟', '…')
     }
 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/LookupWordUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/LookupWordUseCase.kt
@@ -46,7 +46,7 @@ class LookupWordUseCase(
         if (dictionary == null) {
             logger.warn("No dictionary service available")
             onStatusUpdate(StatusCode.NoDictionaryServiceActive, NotificationType.ERROR, true)
-            updateState { copy(isDictionaryLoading = false, dictionaryFailed = true) }
+            updateState { copy(isDictionaryLoading = false, dictionaryFailed = true, dictionaryEntries = emptyList()) }
             return
         }
 
@@ -55,10 +55,14 @@ class LookupWordUseCase(
         lookupJob = scope.launch {
             try {
                 onStatusUpdate(StatusCode.LookingUpWord, NotificationType.INFO, false)
+                // The previous definitions stay up while this one runs. They are still readable,
+                // and a popup that empties itself the moment you ask it for something else takes
+                // away what you were reading in exchange for a blank panel. They are replaced
+                // when the new result lands, and cleared only if it turns out there is nothing
+                // to replace them with.
                 updateState {
                     copy(
                         isDictionaryLoading = true,
-                        dictionaryEntries = emptyList(),
                         dictionaryWord = word,
                         dictionaryFailed = false
                     )
@@ -79,7 +83,7 @@ class LookupWordUseCase(
                 if (result == null) {
                     logger.warn("Dictionary lookup timed out for '$word'")
                     onStatusUpdate(StatusCode.DictionaryTimeout, NotificationType.WARNING, true)
-                    updateState { copy(isDictionaryLoading = false, dictionaryFailed = true) }
+                    updateState { copy(isDictionaryLoading = false, dictionaryFailed = true, dictionaryEntries = emptyList()) }
                     return@launch
                 }
 
@@ -105,7 +109,7 @@ class LookupWordUseCase(
                         val msg = error.toString()
                         logger.warn("Dictionary lookup failed for '$word': $msg")
                         onStatusUpdate(StatusCode.DictionaryFailed(msg), NotificationType.ERROR, true)
-                        updateState { copy(isDictionaryLoading = false, dictionaryFailed = true) }
+                        updateState { copy(isDictionaryLoading = false, dictionaryFailed = true, dictionaryEntries = emptyList()) }
                     }
                 )
             } catch (e: CancellationException) {
@@ -114,7 +118,7 @@ class LookupWordUseCase(
                 val msg = e.message ?: "Unknown error"
                 logger.warn("Unexpected error during dictionary lookup: $msg")
                 onStatusUpdate(StatusCode.DictionaryFailed(msg), NotificationType.ERROR, true)
-                updateState { copy(isDictionaryLoading = false, dictionaryFailed = true) }
+                updateState { copy(isDictionaryLoading = false, dictionaryFailed = true, dictionaryEntries = emptyList()) }
             }
         }
     }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/SearchImagesUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/SearchImagesUseCase.kt
@@ -53,7 +53,7 @@ class SearchImagesUseCase(
         if (service == null) {
             logger.warn("No image search service available")
             onStatusUpdate(StatusCode.NoImageSearchServiceActive, NotificationType.ERROR, true)
-            updateState { copy(isImageSearchLoading = false, imageSearchFailed = true) }
+            updateState { copy(isImageSearchLoading = false, imageSearchFailed = true, imageResults = emptyList()) }
             return
         }
 
@@ -63,9 +63,9 @@ class SearchImagesUseCase(
             try {
                 onStatusUpdate(StatusCode.SearchingImages, NotificationType.INFO, false)
                 updateState {
+                    // Existing thumbnails stay up while the new search runs -- see LookupWordUseCase.
                     copy(
                         isImageSearchLoading = true,
-                        imageResults = emptyList(),
                         imageSearchTerm = term,
                         imageSearchFailed = false
                     )
@@ -78,7 +78,7 @@ class SearchImagesUseCase(
                 if (result == null) {
                     logger.warn("Image search timed out for '$term'")
                     onStatusUpdate(StatusCode.ImageSearchTimeout, NotificationType.WARNING, true)
-                    updateState { copy(isImageSearchLoading = false, imageSearchFailed = true) }
+                    updateState { copy(isImageSearchLoading = false, imageSearchFailed = true, imageResults = emptyList()) }
                     return@launch
                 }
 
@@ -104,7 +104,7 @@ class SearchImagesUseCase(
                         val summary = error.toString()
                         logger.warn("Image search failed for '$term': $summary")
                         onStatusUpdate(StatusCode.ImageSearchFailed(summary), NotificationType.ERROR, true)
-                        updateState { copy(isImageSearchLoading = false, imageSearchFailed = true) }
+                        updateState { copy(isImageSearchLoading = false, imageSearchFailed = true, imageResults = emptyList()) }
                     }
                 )
             } catch (e: CancellationException) {
@@ -113,7 +113,7 @@ class SearchImagesUseCase(
                 val summary = e.message ?: "Unknown error"
                 logger.warn("Unexpected error during image search: $summary")
                 onStatusUpdate(StatusCode.ImageSearchFailed(summary), NotificationType.ERROR, true)
-                updateState { copy(isImageSearchLoading = false, imageSearchFailed = true) }
+                updateState { copy(isImageSearchLoading = false, imageSearchFailed = true, imageResults = emptyList()) }
             }
         }
     }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
@@ -210,6 +210,16 @@ sealed interface MainIntent : UiIntent {
      */
     data class UpdateInlineDefinition(
         val word: String,
-        val language: LanguageCode = LanguageCode("en")
+        val language: LanguageCode = LanguageCode("en"),
+        /**
+         * The other word worth defining, tried when [word] yields nothing.
+         *
+         * A translation has two sides and dictionaries are lopsided: the common ones cover English
+         * thoroughly and most other languages barely at all. Defining only the translated word
+         * means a reader translating into Arabic, or Hindi, or Vietnamese, sees no definition ever
+         * — the lookup is simply asking a dictionary for a language it does not hold.
+         */
+        val alternateWord: String = "",
+        val alternateLanguage: LanguageCode = LanguageCode("en")
     ) : MainIntent
 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
@@ -203,4 +203,13 @@ sealed interface MainIntent : UiIntent {
 
     /** User toggled the pin state of the floating image popup. */
     data object ToggleImageSearchPin : MainIntent
+
+    /**
+     * A translation finished and its result is a single word, so a short definition belongs
+     * beneath it. A blank [word] clears whatever is showing.
+     */
+    data class UpdateInlineDefinition(
+        val word: String,
+        val language: LanguageCode = LanguageCode("en")
+    ) : MainIntent
 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
@@ -68,6 +68,16 @@ data class MainState(
     val isQuickTranslateDialogPinned: Boolean = false,
     val isQuickDictionaryVisible: Boolean = false,
     val isQuickDictionaryPinned: Boolean = false,
+    /**
+     * Incremented every time the user asks for a popup that is already open.
+     *
+     * A dialog cannot otherwise tell "the user pressed the hotkey again" from any of the dozens
+     * of unrelated state changes it is re-rendered for, and the two call for different things:
+     * one should restart the auto-hide countdown, the rest should not.
+     */
+    val quickTranslateTriggerCount: Int = 0,
+    val quickDictionaryTriggerCount: Int = 0,
+    val imageSearchTriggerCount: Int = 0,
     val imageResults: List<ImageResult> = emptyList(),
     val isImageSearchLoading: Boolean = false,
     val imageSearchTerm: String = "",

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
@@ -78,6 +78,14 @@ data class MainState(
     val quickTranslateTriggerCount: Int = 0,
     val quickDictionaryTriggerCount: Int = 0,
     val imageSearchTriggerCount: Int = 0,
+    /**
+     * A short definition shown beneath a single-word translation, or empty.
+     *
+     * Kept apart from [dictionaryEntries], which belongs to the dictionary the user opened. This
+     * is a secondary detail attached to a translation, and conflating the two would let a glance
+     * overwrite what someone was reading in the dictionary panel.
+     */
+    val inlineDefinition: String = "",
     val imageResults: List<ImageResult> = emptyList(),
     val isImageSearchLoading: Boolean = false,
     val imageSearchTerm: String = "",

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -56,6 +56,7 @@ class MainStore(
     private val rewriteUseCase: RewriteUseCase,
     private val lookupWordUseCase: LookupWordUseCase,
     private val searchImagesUseCase: SearchImagesUseCase,
+    private val fetchInlineDefinitionUseCase: FetchInlineDefinitionUseCase,
     private val documentTranslationUseCase: DocumentTranslationUseCase
 ) : Store<MainState, MainIntent, MainEvent> {
 
@@ -355,6 +356,17 @@ class MainStore(
             is MainIntent.ToggleImageSearchPin -> _state.update {
                 it.copy(isImageSearchPinned = !it.isImageSearchPinned)
             }
+
+            is MainIntent.UpdateInlineDefinition ->
+                if (intent.word.isBlank()) {
+                    fetchInlineDefinitionUseCase.clear { transform -> _state.update(transform) }
+                } else {
+                    fetchInlineDefinitionUseCase(
+                        word = intent.word,
+                        language = intent.language,
+                        updateState = { transform -> _state.update(transform) }
+                    )
+                }
         }
     }
 
@@ -459,9 +471,18 @@ class MainStore(
             }
         } else {
             // Open a fresh popup — never pinned, whatever the last one was left as.
+            //
+            // isLoading and the cleared text are set here rather than left to the use case that
+            // follows. The popup withholds itself until there is something to show, and it decides
+            // that from this state; without it the popup saw "not loading, no text" for the moment
+            // between being asked for and the request starting, took that for a finished result,
+            // and opened empty — which is the loading state the user was seeing inside the popup
+            // instead of the marker that should have covered the wait.
             _state.update {
                 it.copy(
                     inputText = intent.selectedText,
+                    translatedText = "",
+                    isLoading = true,
                     isQuickTranslateDialogPinned = false,
                     isQuickTranslateDialogVisible = true,
                     quickTranslateTriggerCount = it.quickTranslateTriggerCount + 1

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -364,6 +364,8 @@ class MainStore(
                     fetchInlineDefinitionUseCase(
                         word = intent.word,
                         language = intent.language,
+                        alternateWord = intent.alternateWord,
+                        alternateLanguage = intent.alternateLanguage,
                         updateState = { transform -> _state.update(transform) }
                     )
                 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -230,8 +230,13 @@ class MainStore(
             is MainIntent.ApplyCorrection ->
                 _state.update { it.copy(inputText = it.inputText.replaceFirst(intent.original, intent.suggestion)) }
 
+            // Closing clears the pin. A pin says "keep this one around", not "and every one
+            // after it" — leaving it set meant the next popup opened wearing the pinned border
+            // and then auto-hid anyway, which is the worst of both.
             MainIntent.HideQuickTranslate ->
-                _state.update { it.copy(isQuickTranslateDialogVisible = false) }
+                _state.update {
+                    it.copy(isQuickTranslateDialogVisible = false, isQuickTranslateDialogPinned = false)
+                }
 
             MainIntent.ToggleQuickTranslateDialogPin ->
                 // Use `it` from the update lambda — not _state.value — to avoid
@@ -302,8 +307,12 @@ class MainStore(
                 _state.update {
                     it.copy(
                         isQuickDictionaryVisible = true,
+                        // A pin belongs to the popup that was pinned, not to the next one.
+                        isQuickDictionaryPinned =
+                            if (it.isQuickDictionaryVisible) it.isQuickDictionaryPinned else false,
                         dictionaryWord   = if (intent.selectedText.isNotBlank()) intent.selectedText else it.dictionaryWord,
-                        isDictionaryLoading = intent.selectedText.isNotBlank()
+                        isDictionaryLoading = intent.selectedText.isNotBlank(),
+                        quickDictionaryTriggerCount = it.quickDictionaryTriggerCount + 1
                     )
                 }
                 if (intent.selectedText.isNotBlank()) {
@@ -312,7 +321,7 @@ class MainStore(
             }
 
             is MainIntent.HideQuickDictionary -> _state.update {
-                it.copy(isQuickDictionaryVisible = false)
+                it.copy(isQuickDictionaryVisible = false, isQuickDictionaryPinned = false)
             }
 
             is MainIntent.ToggleQuickDictionaryPin -> _state.update {
@@ -327,8 +336,11 @@ class MainStore(
                 _state.update {
                     it.copy(
                         isImageSearchVisible = true,
+                        isImageSearchPinned =
+                            if (it.isImageSearchVisible) it.isImageSearchPinned else false,
                         imageSearchTerm = intent.selectedText.ifBlank { it.imageSearchTerm },
-                        isImageSearchLoading = intent.selectedText.isNotBlank()
+                        isImageSearchLoading = intent.selectedText.isNotBlank(),
+                        imageSearchTriggerCount = it.imageSearchTriggerCount + 1
                     )
                 }
                 if (intent.selectedText.isNotBlank()) {
@@ -337,7 +349,7 @@ class MainStore(
             }
 
             is MainIntent.HideImageSearch -> _state.update {
-                it.copy(isImageSearchVisible = false)
+                it.copy(isImageSearchVisible = false, isImageSearchPinned = false)
             }
 
             is MainIntent.ToggleImageSearchPin -> _state.update {
@@ -435,19 +447,24 @@ class MainStore(
     private suspend fun handleShowQuickTranslate(intent: MainIntent.ShowQuickTranslate) {
         if (intent.selectedText.isBlank()) return
 
-        val current = _state.value
-        val isPinnedAndVisible = current.isQuickTranslateDialogVisible && current.isQuickTranslateDialogPinned
-
-        if (isPinnedAndVisible) {
-            // Popup is already open and pinned — just update the text and retranslate.
-            _state.update { it.copy(inputText = intent.selectedText) }
+        if (_state.value.isQuickTranslateDialogVisible) {
+            // Already open, pinned or not: replace the text and count the trigger, so the popup
+            // refreshes in place and restarts its countdown. Hiding and re-showing it would
+            // flicker, move it, and throw away a pin the user had set.
+            _state.update {
+                it.copy(
+                    inputText = intent.selectedText,
+                    quickTranslateTriggerCount = it.quickTranslateTriggerCount + 1
+                )
+            }
         } else {
-            // Open a fresh popup — not pinned.
+            // Open a fresh popup — never pinned, whatever the last one was left as.
             _state.update {
                 it.copy(
                     inputText = intent.selectedText,
                     isQuickTranslateDialogPinned = false,
-                    isQuickTranslateDialogVisible = true
+                    isQuickTranslateDialogVisible = true,
+                    quickTranslateTriggerCount = it.quickTranslateTriggerCount + 1
                 )
             }
         }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/ConfigMigrator.kt
@@ -24,7 +24,11 @@ object ConfigMigrator {
      * would skip every migration it needs. A configuration this build creates from scratch is
      * stamped with this value instead.
      */
-    internal const val CURRENT_VERSION = 5
+    internal const val CURRENT_VERSION = 6
+
+    /** The old defaults, frozen: this is what "the user never changed it" looked like. */
+    private const val LEGACY_POPUP_IDLE_SECONDS = 3
+    private const val LEGACY_DICTIONARY_IDLE_SECONDS = 8
 
     /**
      * Applies all pending migrations to [config] in order and returns the result.
@@ -126,6 +130,28 @@ object ConfigMigrator {
                 config.copy(
                     configVersion = 5,
                     hotkeys = config.hotkeys + missingDefaults
+                )
+            }
+            5 -> {
+                // v5 → v6: the popup auto-hide defaults were too short to read the result before
+                // it vanished. Raised only for users still sitting on the old defaults — anyone
+                // who chose their own value keeps it, since a migration that overrode a deliberate
+                // choice would be worse than the short timeout ever was.
+                logger.info("ConfigMigrator: migrating v5 → v6 — raising untouched popup auto-hide timeouts")
+                config.copy(
+                    configVersion = 6,
+                    popupIdleTimeoutSeconds =
+                        if (config.popupIdleTimeoutSeconds == LEGACY_POPUP_IDLE_SECONDS) {
+                            Configuration.DEFAULT.popupIdleTimeoutSeconds
+                        } else {
+                            config.popupIdleTimeoutSeconds
+                        },
+                    quickDictionaryIdleTimeoutSeconds =
+                        if (config.quickDictionaryIdleTimeoutSeconds == LEGACY_DICTIONARY_IDLE_SECONDS) {
+                            Configuration.DEFAULT.quickDictionaryIdleTimeoutSeconds
+                        } else {
+                            config.quickDictionaryIdleTimeoutSeconds
+                        }
                 )
             }
             else -> {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -317,6 +317,17 @@ data class Configuration(
     val showDictionaryPanel: Boolean = false,
     val dictionaryAutoSource: DictionaryAutoSource = DictionaryAutoSource.TRANSLATED,
     val isDictionaryAutoPopupEnabled: Boolean = true,
+
+    /**
+     * Whether clicking away from a floating popup closes it.
+     *
+     * On by default: clicking elsewhere is how people dismiss a transient window, and a popup
+     * that ignores it has to be closed deliberately every time. Off suits anyone who translates
+     * a word and then works in the document beside it — for them, a click in the document
+     * throwing the translation away is the annoyance instead. Pinning still overrides it either
+     * way, which is what pinning is for.
+     */
+    val closePopupsOnClickOutside: Boolean = true,
     val mainWindowSize: Size? = null,
     val mainWindowPosition: Position? = null,
     val uiFontConfig: FontConfig = FontConfig(name = "Rubik", size = 13),

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -334,7 +334,14 @@ data class Configuration(
     val isPopupAutoSizeEnabled: Boolean = true,
     val isPopupAutoPositionEnabled: Boolean = true,
     val popupTransparencyPercentage: Int = 5,
-    val popupIdleTimeoutSeconds: Int = 3,
+    /**
+     * How long the translate popup waits before hiding itself.
+     *
+     * Three seconds was not enough to read a translated sentence, let alone a paragraph -- the
+     * popup was gone before most people finished. The countdown restarts on any activity, so a
+     * longer default costs nothing to someone who has already moved on.
+     */
+    val popupIdleTimeoutSeconds: Int = 12,
     val popupLastKnownSize: Size = Size(width = 450, height = 250),
     val popupLastKnownPosition: Position = Position(x = 0, y = 0),
 
@@ -346,7 +353,8 @@ data class Configuration(
     val imageSearchLastKnownPosition: Position = Position(x = 0, y = 0),
     val isQuickDictionaryPinned: Boolean = false,
     val isQuickDictionaryAutoPositionEnabled: Boolean = true,
-    val quickDictionaryIdleTimeoutSeconds: Int = 8,
+    /** Longer than the translate popup: definitions are read and compared, not glanced at. */
+    val quickDictionaryIdleTimeoutSeconds: Int = 20,
     val quickDictionaryTransparencyPercentage: Int = 5,
 
     // ---- Donation nudge ----

--- a/core/src/main/resources/localization/embedded_en.toml
+++ b/core/src/main/resources/localization/embedded_en.toml
@@ -460,6 +460,8 @@ auto_position = "Auto-position popup near the cursor"
 transparency = "Background Transparency:"
 popup_idle_timeout = "Hide after idle:"
 popup_idle_hint = "The popup fades out after this many seconds of inactivity. Move the mouse over it to reset the timer."
+close_popup_on_click_outside = "Close popups when clicking elsewhere"
+close_popup_on_click_outside_hint = "Clicking outside a floating popup dismisses it. Pinned popups always stay open."
 seconds_unit = "seconds"
 dict_popup_group = "Dictionary Popup"
 # Close button

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/InlineDefinitionBudgetTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/InlineDefinitionBudgetTest.kt
@@ -1,0 +1,152 @@
+package com.github.ahatem.qtranslate.core.main.domain.usecase
+
+import com.github.ahatem.qtranslate.api.dictionary.Definition
+import com.github.ahatem.qtranslate.api.dictionary.Dictionary
+import com.github.ahatem.qtranslate.api.dictionary.DictionaryEntry
+import com.github.ahatem.qtranslate.api.dictionary.DictionaryRequest
+import com.github.ahatem.qtranslate.api.dictionary.DictionaryResponse
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import com.github.ahatem.qtranslate.api.plugin.ServiceCapability
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.ahatem.qtranslate.api.plugin.SupportedLanguages
+import com.github.ahatem.qtranslate.core.main.mvi.MainState
+import com.github.ahatem.qtranslate.core.settings.data.ActiveServiceManager
+import com.github.ahatem.qtranslate.core.settings.data.Configuration
+import com.github.ahatem.qtranslate.core.shared.logging.LoggerFactory
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.ahatem.qtranslate.api.core.Logger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The rules that keep the inline definition a glance.
+ *
+ * These are the parts most likely to drift: the length budget decides whether the strip is one
+ * line or a paragraph, and the separator decides whether it reads as prose or as clutter. Both
+ * are pure string decisions, so they are worth pinning rather than eyeballing on screen.
+ */
+class InlineDefinitionBudgetTest {
+
+    private val longSense =
+        "the earth, together with all of its countries, peoples, and natural features, " +
+            "considered as a single place in which everybody lives"
+
+    @Test
+    fun `a long first sense is shortened and stands alone`() {
+        val definition = define(longSense, "a region or group of countries")
+
+        // Truncated rather than run on, and the second sense is dropped: after a sense this long
+        // a second one is a paragraph, not a glance.
+        assertTrue(definition.endsWith("…"), "expected an ellipsis, got: $definition")
+        assertFalse(definition.contains("a region or group"))
+        assertTrue(definition.length < longSense.length)
+    }
+
+    @Test
+    fun `two short senses are both kept`() {
+        val definition = define("a greeting", "an expression of surprise")
+
+        assertTrue(definition.contains("a greeting"))
+        assertTrue(definition.contains("an expression of surprise"))
+    }
+
+    @Test
+    fun `a sense ending in a full stop is not followed by a bullet`() {
+        val definition = define("a greeting.", "an expression of surprise")
+
+        // The full stop already separates them; a bullet on top of it reads as clutter.
+        assertFalse(definition.contains("·"), "unexpected bullet in: $definition")
+        assertTrue(definition.contains("a greeting. an expression of surprise"))
+    }
+
+    @Test
+    fun `a sense without punctuation is followed by a bullet`() {
+        val definition = define("a greeting", "an expression of surprise")
+
+        assertTrue(definition.contains("·"), "expected a separator in: $definition")
+    }
+
+    @Test
+    fun `the elision falls on a word boundary`() {
+        val definition = define(longSense)
+
+        val body = definition.substringAfter("— ").removeSuffix("…").trimEnd()
+        assertTrue(longSense.startsWith(body), "cut mid-phrase: $body")
+        assertFalse(body.endsWith(","), "left dangling punctuation: $body")
+    }
+
+    @Test
+    fun `the part of speech leads the line`() {
+        val definition = define("a greeting")
+
+        assertTrue(definition.startsWith("noun — "), "got: $definition")
+    }
+
+    // ── Harness ───────────────────────────────────────────────────────────────
+
+    /**
+     * Runs the fetch and waits for the definition to land.
+     *
+     * The use case launches its own coroutine, so the result is not available on return. Waited
+     * for rather than assumed, with a ceiling so a mistake fails the test instead of hanging it.
+     */
+    private fun define(vararg senses: String): String = runBlocking {
+        val state = MutableStateFlow(MainState())
+        val useCase = FetchInlineDefinitionUseCase(
+            scope = CoroutineScope(Dispatchers.Default),
+            activeServiceManager = managerWith(FakeDictionary(senses.toList())),
+            loggerFactory = SilentLoggerFactory
+        )
+
+        useCase(
+            word = "world",
+            language = LanguageCode.ENGLISH,
+            alternateWord = "",
+            alternateLanguage = LanguageCode.ENGLISH,
+            updateState = { transform -> state.value = state.value.transform() }
+        )
+
+        withTimeout(5_000) {
+            while (state.value.inlineDefinition.isBlank()) delay(5)
+        }
+        state.value.inlineDefinition
+    }
+
+    private fun managerWith(dictionary: Dictionary) = ActiveServiceManager(
+        activeServices = MutableStateFlow(mapOf("fake:default:dictionary" to dictionary)),
+        configuration = MutableStateFlow(Configuration.DEFAULT)
+    )
+
+    private class FakeDictionary(private val senses: List<String>) : Dictionary {
+        override val capabilities = setOf(ServiceCapability.DICTIONARY)
+        override val key = "dictionary"
+        override val name = "Fake"
+        override val version = "1.0.0"
+        override val supportedLanguages = SupportedLanguages.All
+
+        override suspend fun lookup(request: DictionaryRequest): Result<DictionaryResponse, ServiceError> =
+            Ok(
+                DictionaryResponse(
+                    listOf(DictionaryEntry(request.word, "noun", senses.map { Definition(it) }))
+                )
+            )
+    }
+
+    private object SilentLoggerFactory : LoggerFactory {
+        override fun getLogger(name: String): Logger = object : Logger {
+            override fun debug(message: String) = Unit
+            override fun info(message: String) = Unit
+            override fun warn(message: String) = Unit
+            override fun error(message: String, error: Throwable?) = Unit
+        }
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/about/InfoDialog.kt
@@ -35,6 +35,7 @@ class InfoDialog(owner: Frame) : JDialog(owner, true) {
     }
 
     init {
+        com.github.ahatem.qtranslate.ui.swing.shared.util.AppIcons.applyTo(this)
         defaultCloseOperation = HIDE_ON_CLOSE
         isResizable = false
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialog.kt
@@ -7,7 +7,7 @@ import java.awt.Dimension
 import java.awt.Frame
 import javax.swing.*
 
-class DictionaryDialog(owner: Frame) : JDialog(owner, false) {
+class DictionaryDialog(owner: Frame) : JDialog(null as Frame?, false) {
 
     private var state: DictionaryDialogState? = null
     private var updatingFromState = false
@@ -37,6 +37,7 @@ class DictionaryDialog(owner: Frame) : JDialog(owner, false) {
     }
 
     init {
+        com.github.ahatem.qtranslate.ui.swing.shared.util.AppIcons.applyTo(this)
         defaultCloseOperation = HIDE_ON_CLOSE
         isResizable = true
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -220,6 +220,10 @@ class QuickDictionaryDialog(
         mainPanel.add(contentArea, BorderLayout.CENTER)
 
         setupWindowBehavior()
+        popup.installClickOutsideToClose(
+            enabled = { currentState?.config?.closeOnClickOutside ?: true },
+            onClose = { currentState?.onClose?.invoke() }
+        )
         UIManager.addPropertyChangeListener(themeListener)
         updatePinButtonStyle(false)
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -31,9 +31,13 @@ import kotlin.math.abs
  * - Pin button to keep it visible
  */
 class QuickDictionaryDialog(
+    /**
+     * The main window, used only to position against. It is deliberately NOT this dialog's
+     * owner -- see FloatingPopupBehavior for why a tray application must not own these.
+     */
     private val owner: Frame,
     private val iconManager: IconManager
-) : JDialog(owner, ModalityType.MODELESS), Renderable<QuickDictionaryDialogState> {
+) : JDialog(null as Frame?, ModalityType.MODELESS), Renderable<QuickDictionaryDialogState> {
 
     private companion object {
         const val RESIZE_HANDLE_SIZE = 8

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -139,6 +139,7 @@ class QuickDictionaryDialog(
     // Timers
     private var fadeTimer: Timer? = null
     private var idleHideTimer: Timer? = null
+    private var idleCloseTimer: Timer? = null
     private var resizeSaveTimer: Timer? = null
     private var mouseExitDebounceTimer: Timer? = null
 
@@ -376,6 +377,13 @@ class QuickDictionaryDialog(
     private fun createSearchPanel(): JPanel {
         searchField.addActionListener { triggerLookup() }
         lookupButton.addActionListener { triggerLookup() }
+
+        // Typing is the clearest possible sign the popup is still wanted, and it used to count
+        // for nothing: with the pointer parked outside, a word typed slowly disappeared under the
+        // person typing it.
+        searchField.addKeyListener(object : KeyAdapter() {
+            override fun keyPressed(e: KeyEvent) = noteUserActivity()
+        })
         serviceCombo.addActionListener {
             if (!updatingFromState) {
                 val selected = serviceCombo.selectedItem as? ServiceInfo ?: return@addActionListener
@@ -463,8 +471,11 @@ class QuickDictionaryDialog(
         // set initial opacity from config before making visible (no animation on first show)
         val pct = currentState?.config?.transparencyPercentage ?: 0
         opacity = (100f - pct) / 100f
-        isVisible = true
+        // Set before showing. Changing focusableWindowState on a window already on screen makes
+        // AWT discard the native peer and build a new one, which flickers and can drop the focus
+        // the popup has just taken.
         focusableWindowState = true
+        isVisible = true
         installAwtMouseListener()
         if (!isPinned) startIdleHide()
     }
@@ -482,22 +493,38 @@ class QuickDictionaryDialog(
     }
 
     private fun startIdleHide() {
-        idleHideTimer?.stop()
+        stopIdleHide()
         val idleMs = (currentState?.config?.idleTimeoutSeconds ?: 8) * 1000
         idleHideTimer = Timer(idleMs) { event ->
-            if (!isPinned) {
-                fadeTo(0f, FADE_MS)
-                Timer(FADE_MS + 20) {
-                    if (!isPinned) currentState?.onClose?.invoke()
-                    (it.source as Timer).stop()
-                }.apply { isRepeats = false; start() }
-            }
             (event.source as Timer).stop()
+            if (isPinned) return@Timer
+            fadeTo(0f, FADE_MS)
+            // Held in a field rather than left to run on its own. The previous version armed an
+            // anonymous timer here that stopIdleHide could not reach, so a popup that had begun
+            // fading would still close itself a moment later even though the user had just moved
+            // the mouse back over it — or reopened it.
+            idleCloseTimer = Timer(FADE_MS + 20) { closeEvent ->
+                (closeEvent.source as Timer).stop()
+                if (!isPinned) currentState?.onClose?.invoke()
+            }.apply { isRepeats = false; start() }
         }.apply { isRepeats = false; start() }
     }
 
     private fun stopIdleHide() {
         idleHideTimer?.stop()
+        idleCloseTimer?.stop()
+        idleCloseTimer = null
+    }
+
+    /**
+     * Restarts the idle countdown because the user is doing something.
+     *
+     * Typing counted for nothing before this: the timer was reset by moving the mouse, dragging,
+     * resizing or focus changes, so typing a word with the pointer parked elsewhere let the popup
+     * vanish mid-word.
+     */
+    private fun noteUserActivity() {
+        if (isVisible && !isPinned) startIdleHide()
     }
 
     private fun headerBorder() = BorderFactory.createCompoundBorder(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -44,14 +44,26 @@ class QuickDictionaryDialog(
     }
 
     // Theme colors
-    private val borderColor = UIManager.getColor("Component.borderColor")
-    private val accentBorderColor = UIManager.getColor("Component.focusedBorderColor")
-        ?: UIManager.getColor("Component.accentColor")
-        ?: borderColor
-    private val toolbarSelectedBg = UIManager.getColor("Button.toolbar.selectedBackground")
-    private val toolbarSelectedFg = UIManager.getColor("Button.toolbar.selectedForeground")
-    private val labelFg = UIManager.getColor("Label.foreground")
-    private val disabledFg = UIManager.getColor("Label.disabledForeground")
+    // Accessors rather than fields. This dialog is built once and lives for the whole session, so
+    // a colour captured here would be the one the theme had at startup, and every border and
+    // dimmed label would keep it after a theme switch. See refreshTheme.
+    private val borderColor: Color? get() = UIManager.getColor("Component.borderColor")
+    private val accentBorderColor: Color?
+        get() = UIManager.getColor("Component.focusedBorderColor")
+            ?: UIManager.getColor("Component.accentColor")
+            ?: borderColor
+    private val toolbarSelectedBg: Color? get() = UIManager.getColor("Button.toolbar.selectedBackground")
+    private val toolbarSelectedFg: Color? get() = UIManager.getColor("Button.toolbar.selectedForeground")
+    private val labelFg: Color? get() = UIManager.getColor("Label.foreground")
+    private val disabledFg: Color? get() = UIManager.getColor("Label.disabledForeground")
+
+    /** Held so it can be detached; also the reason this is not an inline lambda. */
+    private val themeListener = java.beans.PropertyChangeListener { event ->
+        if (event.propertyName == "lookAndFeel") SwingUtilities.invokeLater { refreshTheme() }
+    }
+
+    /** The header, kept so its divider can be recoloured when the theme changes. */
+    private var headerPanel: JPanel? = null
 
     // Header widgets
     private val titleLabel = JLabel("").apply {
@@ -170,6 +182,7 @@ class QuickDictionaryDialog(
         mainPanel.add(contentArea, BorderLayout.CENTER)
 
         setupWindowBehavior()
+        UIManager.addPropertyChangeListener(themeListener)
         updatePinButtonStyle(false)
     }
 
@@ -353,12 +366,10 @@ class QuickDictionaryDialog(
 
         return JPanel(BorderLayout(8, 0)).apply {
             isOpaque = false
-            border = BorderFactory.createCompoundBorder(
-                BorderFactory.createMatteBorder(0, 0, 1, 0, borderColor),
-                EmptyBorder(6, 10, 6, 6)
-            )
+            border = headerBorder()
             add(titleLabel, BorderLayout.CENTER)
             add(rightPanel, BorderLayout.LINE_END)
+            headerPanel = this
         }
     }
 
@@ -487,6 +498,27 @@ class QuickDictionaryDialog(
 
     private fun stopIdleHide() {
         idleHideTimer?.stop()
+    }
+
+    private fun headerBorder() = BorderFactory.createCompoundBorder(
+        BorderFactory.createMatteBorder(0, 0, 1, 0, borderColor),
+        EmptyBorder(6, 10, 6, 6)
+    )
+
+    /**
+     * Re-applies every colour this dialog painted itself with.
+     *
+     * A border keeps whatever colour it was handed, and a new look and feel does not revisit it,
+     * so without this the popup goes on showing the previous theme's divider and dimmed text
+     * against the new background — the same fault the service selector had.
+     */
+    private fun refreshTheme() {
+        headerPanel?.border = headerBorder()
+        hintLabel.foreground = disabledFg
+        loadingLabel.foreground = disabledFg
+        updatePinButtonStyle(isPinned)
+        revalidate()
+        repaint()
     }
 
     private fun fadeTo(targetOpacity: Float, durationMs: Int) {
@@ -676,7 +708,10 @@ class QuickDictionaryDialog(
 
         addWindowListener(object : WindowAdapter() {
             override fun windowClosing(e: WindowEvent) { currentState?.onClose?.invoke() }
-            override fun windowClosed(e: WindowEvent) { uninstallAwtMouseListener() }
+            override fun windowClosed(e: WindowEvent) {
+                uninstallAwtMouseListener()
+                UIManager.removePropertyChangeListener(themeListener)
+            }
         })
 
         rootPane.registerKeyboardAction(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -240,10 +240,24 @@ class QuickDictionaryDialog(
         if (!isVisible) return
 
         val pinChanged = this.isPinned != state.isPinned
+        val retriggered = lastTriggerCount != state.triggerCount
+        lastTriggerCount = state.triggerCount
+
         currentState = state
         updateContent(state)
         if (pinChanged) handlePinState(state)
+
+        // The user asked for this popup again while it was already open. Refresh in place and
+        // give them the full countdown back — but only on a real trigger, since render runs for
+        // every unrelated state change and resetting on all of them would disable auto-hide.
+        if (retriggered) {
+            fadeTo(1f, FADE_MS)
+            noteUserActivity()
+        }
     }
+
+    /** The trigger this popup last reacted to; see [QuickDictionaryDialogState.triggerCount]. */
+    private var lastTriggerCount = 0
 
     private fun updateContent(state: QuickDictionaryDialogState) {
         isPinned = state.isPinned

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -220,10 +220,6 @@ class QuickDictionaryDialog(
         mainPanel.add(contentArea, BorderLayout.CENTER)
 
         setupWindowBehavior()
-        popup.installClickOutsideToClose(
-            enabled = { currentState?.config?.closeOnClickOutside ?: true },
-            onClose = { currentState?.onClose?.invoke() }
-        )
         UIManager.addPropertyChangeListener(themeListener)
         updatePinButtonStyle(false)
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -10,6 +10,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.*
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentMover
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentResizer
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.*
 import java.awt.event.*
@@ -129,31 +130,54 @@ class QuickDictionaryDialog(
         currentState?.onLookup?.invoke(word)
     }
 
+    /**
+     * Window flags, fading, idle-hide, pointer presence — shared with the other two popups.
+     *
+     * Declared ahead of [isPinned], whose setter writes into it: Kotlin initialises properties in
+     * declaration order, and the other way round leaves a window in which assigning isPinned
+     * would dereference null.
+     */
+    private val popup = FloatingPopupBehavior(
+        window = this,
+        owner = owner,
+        minimumSize = Dimension(UIScale.scale(320), UIScale.scale(200)),
+        pinnedBorderWidth = PINNED_BORDER_WIDTH,
+        resizeHandle = RESIZE_HANDLE_SIZE
+    ).apply {
+        configureIdleHide(
+            delayMs = { (currentState?.config?.idleTimeoutSeconds ?: 8) * 1000 },
+            fadeMs = FADE_MS,
+            restingOpacity = { (100f - (currentState?.config?.transparencyPercentage ?: 0)) / 100f },
+            // Dismissed through the store, so the application does not go on believing the popup
+            // is open after it has gone.
+            onExpired = { currentState?.onClose?.invoke() }
+        )
+    }
+
     // State
+    /**
+     * Mirrored into the popup helper on every change.
+     *
+     * The helper's idle-hide and pointer tracking both consult it, and two copies of "is this
+     * pinned" that drift apart mean a pinned popup that closes itself anyway.
+     */
     private var isPinned = false
+        set(value) {
+            field = value
+            popup.isPinned = value
+        }
     private var wasManuallyMoved = false
     private var isDragging = false
     private var isResizing = false
     private var currentState: QuickDictionaryDialogState? = null
 
     // Timers
-    private var fadeTimer: Timer? = null
-    private var idleHideTimer: Timer? = null
-    private var idleCloseTimer: Timer? = null
     private var resizeSaveTimer: Timer? = null
-    private var mouseExitDebounceTimer: Timer? = null
-
-    // Mouse over detection
-    private var awtMouseListener: AWTEventListener? = null
-    private var isMouseOver = false
 
     private val topPanel: JPanel
     private val mainPanel: JPanel
 
     init {
-        isUndecorated = true
-        isAlwaysOnTop = true
-        minimumSize = Dimension(UIScale.scale(320), UIScale.scale(200))
         focusableWindowState = false
 
         val wrapperPanel = JPanel(BorderLayout()).apply {
@@ -492,40 +516,12 @@ class QuickDictionaryDialog(
         currentState?.onSaveSize?.invoke(Size(sz.width, sz.height))
     }
 
-    private fun startIdleHide() {
-        stopIdleHide()
-        val idleMs = (currentState?.config?.idleTimeoutSeconds ?: 8) * 1000
-        idleHideTimer = Timer(idleMs) { event ->
-            (event.source as Timer).stop()
-            if (isPinned) return@Timer
-            fadeTo(0f, FADE_MS)
-            // Held in a field rather than left to run on its own. The previous version armed an
-            // anonymous timer here that stopIdleHide could not reach, so a popup that had begun
-            // fading would still close itself a moment later even though the user had just moved
-            // the mouse back over it — or reopened it.
-            idleCloseTimer = Timer(FADE_MS + 20) { closeEvent ->
-                (closeEvent.source as Timer).stop()
-                if (!isPinned) currentState?.onClose?.invoke()
-            }.apply { isRepeats = false; start() }
-        }.apply { isRepeats = false; start() }
-    }
+    private fun startIdleHide() = popup.startIdleHide()
 
-    private fun stopIdleHide() {
-        idleHideTimer?.stop()
-        idleCloseTimer?.stop()
-        idleCloseTimer = null
-    }
+    private fun stopIdleHide() = popup.stopIdleHide()
 
-    /**
-     * Restarts the idle countdown because the user is doing something.
-     *
-     * Typing counted for nothing before this: the timer was reset by moving the mouse, dragging,
-     * resizing or focus changes, so typing a word with the pointer parked elsewhere let the popup
-     * vanish mid-word.
-     */
-    private fun noteUserActivity() {
-        if (isVisible && !isPinned) startIdleHide()
-    }
+    /** Restarts the idle countdown because the user is doing something — typing counts. */
+    private fun noteUserActivity() = popup.noteActivity()
 
     private fun headerBorder() = BorderFactory.createCompoundBorder(
         BorderFactory.createMatteBorder(0, 0, 1, 0, borderColor),
@@ -548,81 +544,16 @@ class QuickDictionaryDialog(
         repaint()
     }
 
-    private fun fadeTo(targetOpacity: Float, durationMs: Int) {
-        // Always cancel any in-progress fade and restart — both callers run on EDT
-        // so there is no threading race to protect against. The old fadeLock guard
-        // was placed before fadeTimer?.stop(), which caused the fade-back-to-
-        // transparency to be silently dropped whenever a fade-to-opaque was still
-        // animating (e.g. quick mouse-in then mouse-out within 160 ms).
-        fadeTimer?.stop()
-        val start = opacity
-        val steps = FADE_STEPS.coerceAtLeast(1)
-        val stepDelay = (durationMs / steps).coerceAtLeast(10)
-        var step = 0
-        fadeTimer = Timer(stepDelay) {
-            step++
-            val t = step.toFloat() / steps
-            val value = start + (targetOpacity - start) * t
-            if (abs(opacity - value) > 0.01f) opacity = value
-            if (step >= steps) (it.source as Timer).stop()
-        }.apply { isRepeats = true; start() }
-    }
+    private fun fadeTo(targetOpacity: Float, durationMs: Int) = popup.fadeTo(targetOpacity, durationMs)
 
     // -----------------------------------------------------------------------
     // Mouse over detection
     // -----------------------------------------------------------------------
 
-    private fun installAwtMouseListener() {
-        if (awtMouseListener != null) return
-        awtMouseListener = AWTEventListener { ev ->
-            val me = ev as? MouseEvent ?: return@AWTEventListener
-            if (me.id != MouseEvent.MOUSE_MOVED &&
-                me.id != MouseEvent.MOUSE_ENTERED &&
-                me.id != MouseEvent.MOUSE_EXITED) return@AWTEventListener
-            SwingUtilities.invokeLater {
-                if (!isVisible) return@invokeLater
-                val p = MouseInfo.getPointerInfo()?.location ?: return@invokeLater
-                // Use dialog screen bounds directly — more reliable than coordinate conversion
-                // and avoids edge-case oscillation from rounding in convertPointFromScreen.
-                val over = bounds.contains(p)
-                if (over == isMouseOver) return@invokeLater  // no state change — do nothing
+    private fun installAwtMouseListener() = popup.installPointerTracking()
 
-                isMouseOver = over
-                if (over) {
-                    // Mouse entered: cancel any pending exit-debounce, stop idle, fade to full opacity.
-                    mouseExitDebounceTimer?.stop()
-                    stopIdleHide()
-                    fadeTo(1f, FADE_MS)
-                } else {
-                    // Mouse exited: debounce before fading so that brief exits at the window
-                    // border (mouse wiggle) don't cause flickering. If the mouse comes back
-                    // within the debounce window the timer is cancelled by the enter-branch above.
-                    mouseExitDebounceTimer?.stop()
-                    mouseExitDebounceTimer = Timer(120) {
-                        if (!isMouseOver && !isPinned) {
-                            applyTransparency()
-                            startIdleHide()
-                        }
-                        (it.source as Timer).stop()
-                    }.apply { isRepeats = false; start() }
-                }
-            }
-        }
-        Toolkit.getDefaultToolkit().addAWTEventListener(
-            awtMouseListener,
-            AWTEvent.MOUSE_MOTION_EVENT_MASK or AWTEvent.MOUSE_EVENT_MASK
-        )
-    }
+    private fun uninstallAwtMouseListener() = popup.uninstallPointerTracking()
 
-    private fun uninstallAwtMouseListener() {
-        mouseExitDebounceTimer?.stop()
-        mouseExitDebounceTimer = null
-        awtMouseListener?.let {
-            Toolkit.getDefaultToolkit().removeAWTEventListener(it)
-            awtMouseListener = null
-            isMouseOver = false
-        }
-    }
 
     // -----------------------------------------------------------------------
     // Size / position

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -536,7 +536,9 @@ class QuickDictionaryDialog(
         focusableWindowState = true
         isVisible = true
         installAwtMouseListener()
-        if (!isPinned) startIdleHide()
+        // Not if the pointer is already inside it -- the popup opens at the cursor, so it often
+        // is, and starting the countdown then hides the popup out from under the reader.
+        if (!isPinned && !popup.isPointerOver) startIdleHide()
     }
 
     private fun hideDialog() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -11,6 +11,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.util.*
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentMover
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentResizer
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.InlineLoadingBar
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.*
 import java.awt.event.*
@@ -125,6 +126,7 @@ class QuickDictionaryDialog(
     }
 
     // Results
+    private val loadingBar = InlineLoadingBar()
     private val resultView = DictionaryResultView()
     private val cardPanel = JPanel(CardLayout())
 
@@ -207,7 +209,14 @@ class QuickDictionaryDialog(
 
         // Restructure: top=header, center=body (search+chips+results)
         mainPanel.removeAll()
-        mainPanel.add(topPanel, BorderLayout.NORTH)
+        mainPanel.add(
+            JPanel(BorderLayout()).apply {
+                isOpaque = false
+                add(topPanel, BorderLayout.CENTER)
+                add(loadingBar, BorderLayout.SOUTH)
+            },
+            BorderLayout.NORTH
+        )
         mainPanel.add(contentArea, BorderLayout.CENTER)
 
         setupWindowBehavior()
@@ -320,9 +329,13 @@ class QuickDictionaryDialog(
             updatingFromState = false
         }
 
-        // Card
+        // Definitions already on screen stay there while the next lookup runs, with the hairline
+        // bar carrying the "working" signal instead. Swapping to the loading card would take away
+        // what the reader was in the middle of and give them a spinner in exchange.
+        loadingBar.isLoading = state.isLoading
+
         val card = when {
-            state.isLoading -> "loading"
+            state.isLoading && state.entries.isEmpty() -> "loading"
             state.entries.isNotEmpty() -> "results"
             else -> "hint"
         }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -146,7 +146,7 @@ class QuickDictionaryDialog(
     private val popup = FloatingPopupBehavior(
         window = this,
         owner = owner,
-        minimumSize = Dimension(UIScale.scale(320), UIScale.scale(200)),
+        minimumSize = Dimension(PopupSizing.minWidth(), UIScale.scale(240)),
         pinnedBorderWidth = PINNED_BORDER_WIDTH,
         resizeHandle = RESIZE_HANDLE_SIZE
     ).apply {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialogState.kt
@@ -20,6 +20,8 @@ data class QuickDictionaryDialogState(
     val lookedUpWord: String,
     val hasFailed: Boolean,
     val isPinned: Boolean,
+    /** Bumped when the user asks for this popup again; a change restarts the countdown. */
+    val triggerCount: Int,
     val availableDictionaries: List<ServiceInfo>,
     val selectedDictionaryId: String?,
     val config: QuickDictionaryConfig,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialogState.kt
@@ -48,6 +48,8 @@ data class QuickDictionaryConfig(
     /** When false, the dialog positions itself adjacent to the owner window instead of near the mouse cursor. */
     val positionNearMouse: Boolean = true,
     val idleTimeoutSeconds: Int = 8,
+    /** Whether pressing outside the popup dismisses it; pinning overrides this. */
+    val closeOnClickOutside: Boolean = true,
     val transparencyPercentage: Int = 5
 )
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/document/DocumentTranslationDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/document/DocumentTranslationDialog.kt
@@ -99,6 +99,7 @@ class DocumentTranslationDialog(
     private var progressVisible = false
 
     init {
+        com.github.ahatem.qtranslate.ui.swing.shared.util.AppIcons.applyTo(this)
         defaultCloseOperation = DO_NOTHING_ON_CLOSE
         isResizable = false
         contentPane = JPanel(BorderLayout()).apply {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/history/HistoryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/history/HistoryDialog.kt
@@ -10,7 +10,7 @@ import javax.swing.*
 import javax.swing.table.AbstractTableModel
 import javax.swing.table.DefaultTableCellRenderer
 
-class HistoryDialog(owner: Frame) : JDialog(owner, false) {
+class HistoryDialog(owner: Frame) : JDialog(null as Frame?, false) {
 
     private var state: HistoryDialogState? = null
 
@@ -36,6 +36,7 @@ class HistoryDialog(owner: Frame) : JDialog(owner, false) {
     private val closeButton = JButton()
 
     init {
+        com.github.ahatem.qtranslate.ui.swing.shared.util.AppIcons.applyTo(this)
         defaultCloseOperation = HIDE_ON_CLOSE
         isResizable = true
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -9,6 +9,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
 import com.github.ahatem.qtranslate.ui.swing.shared.util.toDimension
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.InlineLoadingBar
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.BorderLayout
 import java.awt.Color
@@ -118,6 +119,8 @@ class ImageSearchDialog(
         verticalScrollBar.unitIncrement = 16
     }
 
+    private val loadingBar = InlineLoadingBar()
+
     private val body = JPanel(BorderLayout())
 
     /** The enlarged view, or null when the grid is showing. */
@@ -158,7 +161,14 @@ class ImageSearchDialog(
 
         header = buildHeader()
         contentPane = JPanel(BorderLayout()).apply {
-            add(header, BorderLayout.NORTH)
+            add(
+                JPanel(BorderLayout()).apply {
+                    isOpaque = false
+                    add(header, BorderLayout.CENTER)
+                    add(loadingBar, BorderLayout.SOUTH)
+                },
+                BorderLayout.NORTH
+            )
             add(body.apply { add(scroll, BorderLayout.CENTER) }, BorderLayout.CENTER)
         }
 
@@ -289,6 +299,7 @@ class ImageSearchDialog(
 
     private fun applyText(state: ImageSearchDialogState) {
         isPinned = state.isPinned
+        loadingBar.isLoading = state.isLoading
         titleLabel.text = state.strings.title
         pinButton.toolTipText = if (state.isPinned) state.strings.unpinTooltip else state.strings.pinTooltip
         closeButton.toolTipText = state.strings.closeTooltip

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -16,10 +16,13 @@ import java.awt.Color
 import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Frame
+import java.awt.Graphics
+import java.awt.Graphics2D
 import java.awt.GridLayout
 import java.awt.Image
 import java.awt.Insets
 import java.awt.MouseInfo
+import java.awt.RenderingHints
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.ActionEvent
@@ -40,6 +43,7 @@ import javax.swing.JScrollPane
 import javax.swing.JTextField
 import javax.swing.KeyStroke
 import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.border.EmptyBorder
 
@@ -75,12 +79,21 @@ class ImageSearchDialog(
         const val GRID_GAP = 6
     }
 
-    private val borderColor: Color? = UIManager.getColor("Component.borderColor")
-    private val accentColor: Color? = UIManager.getColor("Component.focusedBorderColor")
-        ?: UIManager.getColor("Component.accentColor")
-        ?: borderColor
+    // Read on each use rather than captured once: a colour held in a field keeps the value the
+    // theme had when this dialog was built, and these popups are created once and live for the
+    // whole session, so after a theme switch they would go on painting the old theme's grey.
+    private val borderColor: Color get() = UIManager.getColor("Component.borderColor") ?: Color.GRAY
+    private val accentColor: Color
+        get() = UIManager.getColor("Component.focusedBorderColor")
+            ?: UIManager.getColor("Component.accentColor")
+            ?: borderColor
 
     private val thumbnails = ThumbnailLoader()
+
+    /** A field rather than an inline lambda, so [dispose] can detach it. */
+    private val themeListener = java.beans.PropertyChangeListener { event ->
+        if (event.propertyName == "lookAndFeel") SwingUtilities.invokeLater { refreshTheme() }
+    }
 
     private val titleLabel = JLabel("").apply { putClientProperty("FlatLaf.styleClass", "h4") }
     private val pinButton = createButtonWithIcon(iconManager, "icons/lucide/pin.svg", 14)
@@ -138,7 +151,7 @@ class ImageSearchDialog(
 
         header = buildHeader()
         contentPane = JPanel(BorderLayout()).apply {
-            border = BorderFactory.createLineBorder(borderColor ?: Color.GRAY, 1)
+            border = BorderFactory.createLineBorder(borderColor, 1)
             add(header, BorderLayout.NORTH)
             add(body.apply { add(scroll, BorderLayout.CENTER) }, BorderLayout.CENTER)
         }
@@ -146,6 +159,23 @@ class ImageSearchDialog(
         installEscapeToClose()
         installMoveAndResize()
         installResponsiveColumns()
+        UIManager.addPropertyChangeListener(themeListener)
+    }
+
+    /**
+     * Re-applies the colours already painted into borders and labels.
+     *
+     * The accessors above keep *new* components correct; this is for the ones already built, since
+     * a border holds the colour it was handed and a theme switch does not revisit it.
+     */
+    private fun refreshTheme() {
+        applyPinStyle(isPinned)
+        hintLabel.foreground = UIManager.getColor("Label.disabledForeground")
+        // Tiles carry a border and a dimmed credit line, and are cheapest to simply rebuild.
+        renderedResults = emptyList()
+        currentState?.let { rebuildGridIfChanged(it) }
+        revalidate()
+        repaint()
     }
 
     /**
@@ -265,6 +295,8 @@ class ImageSearchDialog(
         if (state.results == renderedResults) return
         renderedResults = state.results
 
+        // Whatever the previous grid was still fetching is now for a term nobody is looking at.
+        thumbnails.cancelPending()
         grid.removeAll()
         state.results.forEach { grid.add(tileFor(it, state)) }
 
@@ -280,9 +312,9 @@ class ImageSearchDialog(
      * carry require it to be visible, and a tooltip is not.
      */
     private fun tileFor(result: ImageResult, state: ImageSearchDialogState): JComponent {
-        val picture = JLabel("", SwingConstants.CENTER).apply {
+        val picture = ScaledImage().apply {
             preferredSize = Dimension(0, UIScale.scale(TILE_HEIGHT))
-            border = BorderFactory.createLineBorder(borderColor ?: Color.GRAY, 1)
+            border = BorderFactory.createLineBorder(borderColor, 1)
         }
 
         val caption = ElidingLabel(result.title.orEmpty()).apply {
@@ -302,7 +334,7 @@ class ImageSearchDialog(
         thumbnails.load(result.thumbnailUrl) { image ->
             // The grid may have been rebuilt by a newer search while this was in flight.
             if (picture.parent == null) return@load
-            picture.icon = ImageIcon(scaleToFit(image, picture.width, picture.height))
+            picture.image = image
         }
 
         return JPanel(BorderLayout(0, 2)).apply {
@@ -334,20 +366,9 @@ class ImageSearchDialog(
         val state = currentState ?: return
         preview = result
 
-        val picture = JLabel("", SwingConstants.CENTER)
-        // Shown at whatever size the popup happens to be, and rescaled when that changes.
-        var loaded: Image? = null
-        fun redraw() {
-            val image = loaded ?: return
-            picture.icon = ImageIcon(scaleToFit(image, picture.width, picture.height))
-        }
-        picture.addComponentListener(object : ComponentAdapter() {
-            override fun componentResized(e: ComponentEvent) = redraw()
-        })
-        thumbnails.load(result.thumbnailUrl) { image ->
-            loaded = image
-            redraw()
-        }
+        // Sizes itself to the popup as it changes, without rescaling work per resize event.
+        val picture = ScaledImage()
+        thumbnails.load(result.thumbnailUrl) { image -> picture.image = image }
 
         val caption = ElidingLabel(result.title.orEmpty()).apply {
             putClientProperty("FlatLaf.styleClass", "h4")
@@ -454,25 +475,58 @@ class ImageSearchDialog(
     }
 
     /**
-     * Scales to fit inside the tile without distorting it — a stretched diagram is harder to read
-     * than a small one.
+     * Draws an image scaled to fit, keeping its proportions.
+     *
+     * Scaling happens while painting rather than by producing a resized copy. `getScaledInstance`
+     * with `SCALE_SMOOTH` is the slow path in AWT, and the enlarged view rescaled on every resize
+     * event — so dragging the popup's edge ran it continuously on the event thread. Letting
+     * `drawImage` do it with a bilinear hint costs nothing per resize and looks the same.
+     *
+     * Never scaled above 1:1: a thumbnail stretched past its own resolution looks worse than a
+     * smaller sharp one.
      */
-    private fun scaleToFit(image: Image, boxWidth: Int, boxHeight: Int): Image {
-        val width = image.getWidth(null).takeIf { it > 0 } ?: return image
-        val height = image.getHeight(null).takeIf { it > 0 } ?: return image
-        val targetWidth = boxWidth.takeIf { it > 0 } ?: return image
-        val targetHeight = boxHeight.takeIf { it > 0 } ?: return image
+    private class ScaledImage : JComponent() {
 
-        val scale = minOf(targetWidth.toDouble() / width, targetHeight.toDouble() / height)
-        if (scale >= 1.0) return image
-        return image.getScaledInstance((width * scale).toInt(), (height * scale).toInt(), Image.SCALE_SMOOTH)
+        var image: Image? = null
+            set(value) {
+                field = value
+                repaint()
+            }
+
+        override fun paintComponent(g: Graphics) {
+            val source = image ?: return
+            val sourceWidth = source.getWidth(null)
+            val sourceHeight = source.getHeight(null)
+            if (sourceWidth <= 0 || sourceHeight <= 0) return
+
+            // Painted on a copy so the hints do not leak into whatever Swing draws next.
+            val g2 = g.create() as Graphics2D
+            try {
+                g2.setRenderingHint(
+                    RenderingHints.KEY_INTERPOLATION,
+                    RenderingHints.VALUE_INTERPOLATION_BILINEAR
+                )
+                g2.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+
+                val scale = minOf(
+                    width.toDouble() / sourceWidth,
+                    height.toDouble() / sourceHeight
+                ).coerceAtMost(1.0)
+                val drawWidth = (sourceWidth * scale).toInt().coerceAtLeast(1)
+                val drawHeight = (sourceHeight * scale).toInt().coerceAtLeast(1)
+
+                g2.drawImage(source, (width - drawWidth) / 2, (height - drawHeight) / 2, drawWidth, drawHeight, null)
+            } finally {
+                g2.dispose()
+            }
+        }
     }
 
     private fun applyPinStyle(pinned: Boolean) {
         (contentPane as JPanel).border = if (pinned) {
-            BorderFactory.createLineBorder(accentColor ?: Color.GRAY, PINNED_BORDER_WIDTH)
+            BorderFactory.createLineBorder(accentColor, PINNED_BORDER_WIDTH)
         } else {
-            BorderFactory.createLineBorder(borderColor ?: Color.GRAY, 1)
+            BorderFactory.createLineBorder(borderColor, 1)
         }
         contentPane.revalidate()
         contentPane.repaint()
@@ -542,9 +596,16 @@ class ImageSearchDialog(
         })
     }
 
-    /** Releases the thumbnail pool; the dialog is not usable afterwards. */
-    fun dispose(shutdownThumbnails: Boolean) {
-        if (shutdownThumbnails) thumbnails.shutdown()
+    /**
+     * Releases the thumbnail pool along with the window.
+     *
+     * Overrides the real `dispose` rather than adding a variant beside it: the previous
+     * `dispose(Boolean)` was never called from anywhere, so the pool it was meant to shut down
+     * never was.
+     */
+    override fun dispose() {
+        thumbnails.shutdown()
+        UIManager.removePropertyChangeListener(themeListener)
         super.dispose()
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -138,6 +138,9 @@ class ImageSearchDialog(
      */
     private var renderedResults: List<ImageResult> = emptyList()
 
+    /** The trigger this popup last reacted to; see [ImageSearchDialogState.triggerCount]. */
+    private var lastTriggerCount = 0
+
     /** Undecorated, always on top, draggable, resizable, Escape-dismissed — shared with the
      *  translate and dictionary popups so all three behave the same as windows. */
     private val popup = FloatingPopupBehavior(
@@ -272,10 +275,16 @@ class ImageSearchDialog(
         if (!isVisible) return
 
         val pinChanged = isPinned != state.isPinned
+        val retriggered = lastTriggerCount != state.triggerCount
+        lastTriggerCount = state.triggerCount
+
         currentState = state
         applyText(state)
         rebuildGridIfChanged(state)
         if (pinChanged) applyPinStyle(state.isPinned)
+        // Asked for again while open: bring it back to the front of the user's attention rather
+        // than closing and reopening it.
+        if (retriggered) toFront()
     }
 
     private fun applyText(state: ImageSearchDialogState) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -195,10 +195,6 @@ class ImageSearchDialog(
                 currentState?.onClose?.invoke(); true
             }
         }
-        popup.installClickOutsideToClose(
-            enabled = { currentState?.config?.closeOnClickOutside ?: true },
-            onClose = { currentState?.onClose?.invoke() }
-        )
         popup.installTheme(::refreshTheme)
         popup.applyPinBorder(false)
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -254,7 +254,10 @@ class ImageSearchDialog(
                 size = state.config.lastKnownSize.toDimension()
                 applyPosition(state.config)
                 isVisible = true
-                searchField.requestFocusInWindow()
+                // Queued rather than requested inline: focus cannot be taken until the window is
+                // actually on screen, so asking during the same event does nothing and the field
+                // silently fails to accept typing.
+                SwingUtilities.invokeLater { searchField.requestFocusInWindow() }
             } else {
                 saveGeometry()
                 isVisible = false

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -1,5 +1,7 @@
 package com.github.ahatem.qtranslate.ui.swing.imagesearch
 
+import com.formdev.flatlaf.FlatClientProperties
+import com.formdev.flatlaf.icons.FlatSearchIcon
 import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.api.imagesearch.ImageResult
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceInfo
@@ -99,7 +101,16 @@ class ImageSearchDialog(
     private val pinButton = createButtonWithIcon(iconManager, "icons/lucide/pin.svg", 14)
     private val closeButton = createButtonWithIcon(iconManager, "icons/lucide/close.svg", 16)
 
+    /**
+     * A search field in the look and feel's own idiom rather than a bare text box.
+     *
+     * FlatLaf draws the magnifier and the clear button itself from these properties, so they
+     * follow the theme and the scale factor without any icon handling here. The clear button only
+     * appears when there is something to clear.
+     */
     private val searchField = JTextField().apply {
+        putClientProperty(FlatClientProperties.TEXT_FIELD_LEADING_ICON, FlatSearchIcon())
+        putClientProperty(FlatClientProperties.TEXT_FIELD_SHOW_CLEAR_BUTTON, true)
         addActionListener { currentState?.onSearch?.invoke(text.trim()) }
     }
 
@@ -183,6 +194,10 @@ class ImageSearchDialog(
                 currentState?.onClose?.invoke(); true
             }
         }
+        popup.installClickOutsideToClose(
+            enabled = { currentState?.config?.closeOnClickOutside ?: true },
+            onClose = { currentState?.onClose?.invoke() }
+        )
         popup.installTheme(::refreshTheme)
         popup.applyPinBorder(false)
 
@@ -292,6 +307,11 @@ class ImageSearchDialog(
         applyText(state)
         rebuildGridIfChanged(state)
         if (pinChanged) applyPinStyle(state.isPinned)
+        // Re-triggered from a new selection: the field should show the word being searched, not
+        // the one from last time.
+        if (retriggered && state.searchedTerm.isNotBlank() && searchField.text != state.searchedTerm) {
+            searchField.text = state.searchedTerm
+        }
         // Asked for again while open: bring it back to the front of the user's attention rather
         // than closing and reopening it.
         if (retriggered) toFront()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -58,9 +58,13 @@ import javax.swing.border.EmptyBorder
  * vanishes mid-comparison would be worse than one the reader closes themselves.
  */
 class ImageSearchDialog(
+    /**
+     * The main window, used only to position against. It is deliberately NOT this dialog's
+     * owner -- see FloatingPopupBehavior for why a tray application must not own these.
+     */
     private val owner: Frame,
     private val iconManager: IconManager
-) : JDialog(owner, ModalityType.MODELESS), Renderable<ImageSearchDialogState> {
+) : JDialog(null as Frame?, ModalityType.MODELESS), Renderable<ImageSearchDialogState> {
 
     private companion object {
         const val RESIZE_HANDLE_SIZE = 8

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -8,8 +8,7 @@ import com.github.ahatem.qtranslate.core.settings.data.Size
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
 import com.github.ahatem.qtranslate.ui.swing.shared.util.toDimension
-import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentMover
-import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentResizer
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.BorderLayout
 import java.awt.Color
@@ -90,10 +89,6 @@ class ImageSearchDialog(
 
     private val thumbnails = ThumbnailLoader()
 
-    /** A field rather than an inline lambda, so [dispose] can detach it. */
-    private val themeListener = java.beans.PropertyChangeListener { event ->
-        if (event.propertyName == "lookAndFeel") SwingUtilities.invokeLater { refreshTheme() }
-    }
 
     private val titleLabel = JLabel("").apply { putClientProperty("FlatLaf.styleClass", "h4") }
     private val pinButton = createButtonWithIcon(iconManager, "icons/lucide/pin.svg", 14)
@@ -129,7 +124,6 @@ class ImageSearchDialog(
 
     private var currentState: ImageSearchDialogState? = null
     private var isPinned = false
-    private var wasManuallyMoved = false
 
     /**
      * The results the grid was last built from.
@@ -140,26 +134,42 @@ class ImageSearchDialog(
      */
     private var renderedResults: List<ImageResult> = emptyList()
 
+    /** Undecorated, always on top, draggable, resizable, Escape-dismissed — shared with the
+     *  translate and dictionary popups so all three behave the same as windows. */
+    private val popup = FloatingPopupBehavior(
+        window = this,
+        owner = owner,
+        minimumSize = Dimension(UIScale.scale(340), UIScale.scale(280)),
+        pinnedBorderWidth = PINNED_BORDER_WIDTH
+    )
+
     init {
-        isUndecorated = true
-        isAlwaysOnTop = true
         focusableWindowState = true
-        defaultCloseOperation = DO_NOTHING_ON_CLOSE
 
         pinButton.addActionListener { currentState?.onPinToggled?.invoke() }
         closeButton.addActionListener { currentState?.onClose?.invoke() }
 
         header = buildHeader()
         contentPane = JPanel(BorderLayout()).apply {
-            border = BorderFactory.createLineBorder(borderColor, 1)
             add(header, BorderLayout.NORTH)
             add(body.apply { add(scroll, BorderLayout.CENTER) }, BorderLayout.CENTER)
         }
 
-        installEscapeToClose()
-        installMoveAndResize()
+        popup.installDrag(header) { position -> currentState?.onSavePosition?.invoke(position) }
+        popup.installResize({ size -> currentState?.onSaveSize?.invoke(size) })
+        // Escape unwinds one step at a time: out of the enlarged image first, and only then out
+        // of the popup. Closing outright would throw away the search as well.
+        popup.installEscape {
+            if (preview != null) {
+                showGrid(); true
+            } else {
+                currentState?.onClose?.invoke(); true
+            }
+        }
+        popup.installTheme(::refreshTheme)
+        popup.applyPinBorder(false)
+
         installResponsiveColumns()
-        UIManager.addPropertyChangeListener(themeListener)
     }
 
     /**
@@ -235,7 +245,7 @@ class ImageSearchDialog(
         if (visibilityChanged) {
             if (state.isVisible) {
                 currentState = state
-                wasManuallyMoved = false
+                popup.resetManualMove()
                 applyText(state)
                 if (state.searchedTerm.isNotBlank() && searchField.text != state.searchedTerm) {
                     searchField.text = state.searchedTerm
@@ -522,78 +532,15 @@ class ImageSearchDialog(
         }
     }
 
-    private fun applyPinStyle(pinned: Boolean) {
-        (contentPane as JPanel).border = if (pinned) {
-            BorderFactory.createLineBorder(accentColor, PINNED_BORDER_WIDTH)
-        } else {
-            BorderFactory.createLineBorder(borderColor, 1)
-        }
-        contentPane.revalidate()
-        contentPane.repaint()
-    }
+    private fun applyPinStyle(pinned: Boolean) = popup.applyPinBorder(pinned)
 
     private fun applyPosition(config: ImageSearchConfig) {
-        if (wasManuallyMoved) return
-        val screen = graphicsConfiguration?.bounds ?: run {
-            setLocationRelativeTo(owner)
-            return
-        }
-        if (!config.positionNearMouse) {
-            setLocationRelativeTo(owner)
-            return
-        }
-        val mouse = MouseInfo.getPointerInfo()?.location ?: run {
-            setLocationRelativeTo(owner)
-            return
-        }
-        val x = (mouse.x + UIScale.scale(12))
-            .coerceIn(screen.x, (screen.x + screen.width - width).coerceAtLeast(screen.x))
-        val y = (mouse.y + UIScale.scale(12))
-            .coerceIn(screen.y, (screen.y + screen.height - height).coerceAtLeast(screen.y))
-        setLocation(x, y)
+        if (config.positionNearMouse) popup.positionNearMouse() else popup.positionBesideOwner()
     }
 
     private fun saveGeometry() {
         currentState?.onSavePosition?.invoke(Position(location.x.coerceAtLeast(0), location.y.coerceAtLeast(0)))
         currentState?.onSaveSize?.invoke(Size(size.width, size.height))
-    }
-
-    private fun installEscapeToClose() {
-        val root = rootPane
-        root.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-            .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "close-image-search")
-        root.actionMap.put("close-image-search", object : AbstractAction() {
-            override fun actionPerformed(e: ActionEvent) {
-                // Escape unwinds one step at a time: out of the enlarged image first, and only
-                // then out of the popup. Closing outright would throw away the search as well.
-                if (preview != null) showGrid() else currentState?.onClose?.invoke()
-            }
-        })
-    }
-
-    private fun installMoveAndResize() {
-        minimumSize = Dimension(UIScale.scale(340), UIScale.scale(280))
-
-        ComponentMover.builder()
-            .destinationComponent(this)
-            .build()
-            .register(header)
-
-        val handle = UIScale.scale(RESIZE_HANDLE_SIZE)
-        ComponentResizer.builder()
-            .dragInsets(Insets(handle, handle, handle, handle))
-            .minimumSize(minimumSize)
-            .onResizeEnd { currentState?.onSaveSize?.invoke(Size(size.width, size.height)) }
-            .build()
-            .register(this)
-
-        header.addMouseListener(object : MouseAdapter() {
-            override fun mouseReleased(e: MouseEvent) {
-                wasManuallyMoved = true
-                currentState?.onSavePosition
-                    ?.invoke(Position(location.x.coerceAtLeast(0), location.y.coerceAtLeast(0)))
-            }
-        })
     }
 
     /**
@@ -605,7 +552,7 @@ class ImageSearchDialog(
      */
     override fun dispose() {
         thumbnails.shutdown()
-        UIManager.removePropertyChangeListener(themeListener)
+        popup.uninstallTheme()
         super.dispose()
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -10,6 +10,7 @@ import com.github.ahatem.qtranslate.core.settings.data.Size
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
 import com.github.ahatem.qtranslate.ui.swing.shared.util.toDimension
+import com.github.ahatem.qtranslate.ui.swing.shared.util.PopupSizing
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.InlineLoadingBar
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
@@ -160,7 +161,7 @@ class ImageSearchDialog(
     private val popup = FloatingPopupBehavior(
         window = this,
         owner = owner,
-        minimumSize = Dimension(UIScale.scale(340), UIScale.scale(280)),
+        minimumSize = Dimension(PopupSizing.minWidth(), UIScale.scale(300)),
         pinnedBorderWidth = PINNED_BORDER_WIDTH
     )
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialogState.kt
@@ -20,6 +20,8 @@ data class ImageSearchDialogState(
     val searchedTerm: String,
     val hasFailed: Boolean,
     val isPinned: Boolean,
+    /** Bumped when the user asks for this popup again; a change restarts the countdown. */
+    val triggerCount: Int,
     val availableServices: List<ServiceInfo>,
     val selectedServiceId: String?,
     val config: ImageSearchConfig,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialogState.kt
@@ -38,7 +38,9 @@ data class ImageSearchDialogState(
 data class ImageSearchConfig(
     val lastKnownSize: Size,
     val lastKnownPosition: Position,
-    val positionNearMouse: Boolean = true
+    val positionNearMouse: Boolean = true,
+    /** Whether pressing outside the popup dismisses it; pinning overrides this. */
+    val closeOnClickOutside: Boolean = true
 )
 
 data class ImageSearchStrings(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ThumbnailLoader.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ThumbnailLoader.kt
@@ -37,6 +37,24 @@ class ThumbnailLoader(private val maxEntries: Int = 120) {
     )
 
     /**
+     * Everything queued belongs to this search. Bumped by [cancelPending] so work already in the
+     * queue can tell that its results are no longer wanted.
+     */
+    @Volatile
+    private var generation = 0
+
+    /**
+     * Abandons thumbnails still queued for an earlier search.
+     *
+     * Typing in the popup starts a search per pause, and without this every set of results
+     * downloads in full — four terms in quick succession fetched forty-odd images for the three
+     * grids nobody is looking at any more, ahead of the one they are.
+     */
+    fun cancelPending() {
+        generation++
+    }
+
+    /**
      * Loads [url], calling [onLoaded] on the event thread.
      *
      * [onLoaded] is not called if the image cannot be fetched or decoded: a tile that stays a
@@ -51,9 +69,14 @@ class ThumbnailLoader(private val maxEntries: Int = 120) {
             return
         }
 
+        val requested = generation
         pool.execute {
+            // Checked before the fetch, which is the expensive part and the point of cancelling.
+            if (requested != generation) return@execute
             val image = runCatching { fetch(url) }.getOrNull() ?: return@execute
+            // Cached regardless: it was paid for, and the same term searched again should be free.
             cache[url] = image
+            if (requested != generation) return@execute
             SwingUtilities.invokeLater { onLoaded(image) }
         }
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -754,13 +754,15 @@ class MainAppFrame(
                         else -> return@collect
                     }
 
-                    // Word is not a single valid word — dismiss any unpinned auto popup.
+                    // Not a single word, so no definition belongs under the result.
                     if (word.isBlank() || word.contains(Regex("\\s")) || word.length < 2) {
-                        if (key.isQuickDictionaryVisible && !key.isQuickDictionaryPinned) {
-                            mainStore.dispatch(MainIntent.HideQuickDictionary)
-                        }
+                        mainStore.dispatch(MainIntent.UpdateInlineDefinition(""))
                         return@collect
                     }
+
+                    // A single word: fetch the short definition that sits beneath the translation,
+                    // in the popup and in the main window alike. Nothing is opened for it.
+                    mainStore.dispatch(MainIntent.UpdateInlineDefinition(word, lang))
                     val current = mainStore.state.value.dictionaryWord
                     if (word.equals(current, ignoreCase = true)) return@collect
 
@@ -1350,6 +1352,7 @@ class MainAppFrame(
             translatedText = mainState.translatedText,
             isPinned = mainState.isQuickTranslateDialogPinned,
             triggerCount = mainState.quickTranslateTriggerCount,
+            definition = mainState.inlineDefinition,
 
             sourceLanguage = displaySourceLanguage,
             targetLanguage = mainState.targetLanguage,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -790,15 +790,21 @@ class MainAppFrame(
                         }
                         return@collect
                     }
-                    // Which word to define. SOURCE is a deliberate choice to define the word the
-                    // user typed; everything else defines the translation, which is what someone
-                    // reading a result is looking at.
+                    // Both sides of the translation are offered, in preference order. SOURCE means
+                    // the user asked for the word they typed; otherwise the translation comes
+                    // first, since that is what they are looking at.
+                    //
+                    // Both matter because dictionaries are lopsided. Translating English into
+                    // Arabic and defining only the Arabic would ask Google Dictionary for a
+                    // language it barely holds, and produce nothing every single time.
+                    val preferSource =
+                        key.autoSource == com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource.SOURCE
                     val (word, lang) =
-                        if (key.autoSource == com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource.SOURCE) {
-                            key.inputText to key.resolvedSourceLang
-                        } else {
-                            key.translatedText to key.targetLang
-                        }
+                        if (preferSource) key.inputText to key.resolvedSourceLang
+                        else key.translatedText to key.targetLang
+                    val (alternate, alternateLang) =
+                        if (preferSource) key.translatedText to key.targetLang
+                        else key.inputText to key.resolvedSourceLang
 
                     // Not a single word, so no definition belongs under the result.
                     if (word.isBlank() || word.contains(Regex("\\s")) || word.length < 2) {
@@ -808,7 +814,14 @@ class MainAppFrame(
 
                     // A single word: fetch the short definition that sits beneath the translation,
                     // in the popup and in the main window alike. Nothing is opened for it.
-                    mainStore.dispatch(MainIntent.UpdateInlineDefinition(word, lang))
+                    mainStore.dispatch(
+                        MainIntent.UpdateInlineDefinition(
+                            word = word,
+                            language = lang,
+                            alternateWord = alternate.takeIf { it.isNotBlank() && it.none(Char::isWhitespace) }.orEmpty(),
+                            alternateLanguage = alternateLang
+                        )
+                    )
                     val current = mainStore.state.value.dictionaryWord
                     if (word.equals(current, ignoreCase = true)) return@collect
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -314,9 +314,46 @@ class MainAppFrame(
             }
         },
         onPointerPressed = { location ->
-            runOnUi { selectionTranslateButton.dismissIfOutside(location) }
+            runOnUi {
+                selectionTranslateButton.dismissIfOutside(location)
+                dismissPopupsPressedOutside(location)
+            }
         }
     )
+
+    /**
+     * Closes any floating popup the user has just clicked away from.
+     *
+     * Driven by the native hook rather than by an AWT listener. The click that dismisses a popup
+     * almost always lands in another application — the document being read — and AWT never sees
+     * those: it only delivers events destined for this program's own windows. An AWT-based
+     * version of this appeared to work when clicking on QTranslate itself and did nothing at all
+     * in the case that matters.
+     *
+     * Pinned popups are left alone, which is the point of pinning.
+     */
+    private fun dismissPopupsPressedOutside(screenPoint: java.awt.Point) {
+        if (!settingsStore.state.value.workingConfiguration.closePopupsOnClickOutside) return
+        val state = mainStore.state.value
+
+        fun pressedOutside(dialog: java.awt.Window) = dialog.isVisible && !dialog.bounds.contains(screenPoint)
+
+        if (state.isQuickTranslateDialogVisible && !state.isQuickTranslateDialogPinned &&
+            pressedOutside(quickTranslateDialog)
+        ) {
+            mainStore.dispatch(MainIntent.HideQuickTranslate)
+        }
+        if (state.isQuickDictionaryVisible && !state.isQuickDictionaryPinned &&
+            pressedOutside(quickDictionaryDialog)
+        ) {
+            mainStore.dispatch(MainIntent.HideQuickDictionary)
+        }
+        if (state.isImageSearchVisible && !state.isImageSearchPinned &&
+            pressedOutside(imageSearchDialog)
+        ) {
+            mainStore.dispatch(MainIntent.HideImageSearch)
+        }
+    }
 
     private val statusBarController = StatusBarController(
         statusBar = mainContentView.statusBar,
@@ -506,14 +543,19 @@ class MainAppFrame(
             mainStore.state
                 .map { Triple(it.isLoading, it.isQuickTranslateDialogVisible, it.isReplacingSelection) }
                 .distinctUntilChanged()
-                .collect { (isLoading, _, isReplacing) ->
+                .collect { (isLoading, popupRequested, isReplacing) ->
                     withContext(Dispatchers.Swing) {
-                        // Keyed on whether the popup window is actually on screen, not on the
-                        // state flag. The popup now holds itself back until it has something to
-                        // show, so between the hotkey and the result the state says "visible"
-                        // while nothing is — which is exactly the stretch the indicator is for.
-                        val popupOnScreen = quickTranslateDialog.isVisible
-                        val shouldShow = isLoading && (isReplacing || (!isVisible && !popupOnScreen))
+                        // Two cases want the marker, and neither depends on whether the main
+                        // window happens to be open: a popup translation that has been asked for
+                        // but has nothing to show yet, and an inline replace, which has no window
+                        // of its own at all.
+                        //
+                        // It used to also require the main window to be hidden, on the reasoning
+                        // that a visible main window shows its own progress. But Ctrl+Q opens the
+                        // popup either way, and in that case the main window is not where the user
+                        // is looking.
+                        val popupPending = popupRequested && !quickTranslateDialog.isVisible
+                        val shouldShow = isLoading && (isReplacing || popupPending)
                         loadingIndicator.render(LoadingIndicatorState(isVisible = shouldShow))
                     }
                 }
@@ -718,8 +760,13 @@ class MainAppFrame(
                         curr.isLoading -> true
                         // Need a previous snapshot to detect transitions.
                         prev == null -> false
-                        // Auto-lookup is disabled — nothing to do.
-                        curr.autoSource == com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource.OFF -> false
+                        // The definition strip is switched off entirely.
+                        //
+                        // Gated on its own setting rather than on dictionaryAutoSource. That
+                        // setting used to mean "open the dictionary popup by itself", and anyone
+                        // who found that intrusive turned it off — which would now also cost them
+                        // the quiet one-line definition, a different thing they never refused.
+                        !curr.isDictionaryAutoPopupEnabled -> false
                         else -> {
                             // Primary trigger: translation just finished.
                             val justFinishedLoading = prev.isLoading && !curr.isLoading
@@ -743,16 +790,15 @@ class MainAppFrame(
                         }
                         return@collect
                     }
-                    val autoSource = key.autoSource
-                    if (autoSource == com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource.OFF) return@collect
-
-                    val (word, lang) = when (autoSource) {
-                        com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource.TRANSLATED ->
-                            key.translatedText to key.targetLang
-                        com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource.SOURCE ->
+                    // Which word to define. SOURCE is a deliberate choice to define the word the
+                    // user typed; everything else defines the translation, which is what someone
+                    // reading a result is looking at.
+                    val (word, lang) =
+                        if (key.autoSource == com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource.SOURCE) {
                             key.inputText to key.resolvedSourceLang
-                        else -> return@collect
-                    }
+                        } else {
+                            key.translatedText to key.targetLang
+                        }
 
                     // Not a single word, so no definition belongs under the result.
                     if (word.isBlank() || word.contains(Regex("\\s")) || word.length < 2) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -285,11 +285,9 @@ class MainAppFrame(
         },
         onShowDictionary = { selectedText ->
             appScope.launch {
-                // Toggle: Ctrl+D while popup is open → close it.
-                if (mainStore.state.value.isQuickDictionaryVisible) {
-                    mainStore.dispatch(MainIntent.HideQuickDictionary)
-                    return@launch
-                }
+                // No longer a toggle. Pressing the hotkey again with the popup open refreshes it
+                // in place and restarts its countdown — hiding it meant the popup vanished when
+                // the user was asking for more of it, and threw away a pin they had set.
                 val s = mainStore.state.value
                 val lang = when {
                     s.sourceLanguage != LanguageCode.AUTO -> s.sourceLanguage
@@ -301,12 +299,8 @@ class MainAppFrame(
             }
         },
         onShowImages = { selectedText ->
+            // Refreshes in place when already open, for the same reason as the dictionary.
             appScope.launch {
-                // Same toggle as the dictionary: the key that opened it closes it.
-                if (mainStore.state.value.isImageSearchVisible) {
-                    mainStore.dispatch(MainIntent.HideImageSearch)
-                    return@launch
-                }
                 mainStore.dispatch(MainIntent.ShowImageSearch(selectedText, resolvedLookupLanguage()))
             }
         },
@@ -512,9 +506,14 @@ class MainAppFrame(
             mainStore.state
                 .map { Triple(it.isLoading, it.isQuickTranslateDialogVisible, it.isReplacingSelection) }
                 .distinctUntilChanged()
-                .collect { (isLoading, isDialogVisible, isReplacing) ->
+                .collect { (isLoading, _, isReplacing) ->
                     withContext(Dispatchers.Swing) {
-                        val shouldShow = isLoading && (!isVisible && !isDialogVisible || isReplacing)
+                        // Keyed on whether the popup window is actually on screen, not on the
+                        // state flag. The popup now holds itself back until it has something to
+                        // show, so between the hotkey and the result the state says "visible"
+                        // while nothing is — which is exactly the stretch the indicator is for.
+                        val popupOnScreen = quickTranslateDialog.isVisible
+                        val shouldShow = isLoading && (isReplacing || (!isVisible && !popupOnScreen))
                         loadingIndicator.render(LoadingIndicatorState(isVisible = shouldShow))
                     }
                 }
@@ -1347,6 +1346,7 @@ class MainAppFrame(
             isLoading = mainState.isLoading,
             translatedText = mainState.translatedText,
             isPinned = mainState.isQuickTranslateDialogPinned,
+            triggerCount = mainState.quickTranslateTriggerCount,
 
             sourceLanguage = displaySourceLanguage,
             targetLanguage = mainState.targetLanguage,
@@ -1610,6 +1610,7 @@ class MainAppFrame(
             searchedTerm      = mainState.imageSearchTerm,
             hasFailed         = mainState.imageSearchFailed,
             isPinned          = mainState.isImageSearchPinned,
+            triggerCount      = mainState.imageSearchTriggerCount,
             availableServices = available,
             selectedServiceId = selectedId,
             config = ImageSearchConfig(
@@ -1682,6 +1683,7 @@ class MainAppFrame(
             lookedUpWord         = mainState.dictionaryWord,
             hasFailed            = mainState.dictionaryFailed,
             isPinned             = mainState.isQuickDictionaryPinned,
+            triggerCount         = mainState.quickDictionaryTriggerCount,
             availableDictionaries = availableDicts,
             selectedDictionaryId  = selectedDictId,
             autoSource               = config.dictionaryAutoSource,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -764,17 +764,20 @@ class MainAppFrame(
                     val current = mainStore.state.value.dictionaryWord
                     if (word.equals(current, ignoreCase = true)) return@collect
 
-                    if (key.panelVisible) {
-                        // Panel is open — update it directly.
+                    // Only ever fills in a dictionary the user already has open, and only in the
+                    // main window. It never summons one.
+                    //
+                    // Translating a single word used to make the dictionary popup appear on its
+                    // own. That was wrong twice over: it fired during Quick Translate with the
+                    // main window hidden, so a hotkey translation produced two windows when one
+                    // was asked for; and even in the main window it decided for the user that a
+                    // short word meant they wanted a definition. Looking a word up is now an
+                    // action they take — see the definition button on the output pane.
+                    if (key.panelVisible && key.mainVisible) {
                         withContext(Dispatchers.Swing) {
                             mainContentView.setDictionarySearchWord(word)
                         }
                         mainStore.dispatch(MainIntent.LookupWord(word, lang))
-                    } else if (key.mainVisible && key.isDictionaryAutoPopupEnabled) {
-                        // Panel closed but main window visible — show floating popup.
-                        // Position near the owner window, not the mouse cursor.
-                        quickDictionaryPositionNearMouse = false
-                        mainStore.dispatch(MainIntent.ShowQuickDictionary(word, lang))
                     }
                 }
         }
@@ -1366,6 +1369,7 @@ class MainAppFrame(
                 autoPositionEnabled = config.isPopupAutoPositionEnabled,
                 transparencyPercentage = config.popupTransparencyPercentage,
                 idleTimeoutSeconds = config.popupIdleTimeoutSeconds,
+                closeOnClickOutside = config.closePopupsOnClickOutside,
                 lastKnownSize = config.popupLastKnownSize,
                 lastKnownPosition = config.popupLastKnownPosition
             ),
@@ -1615,7 +1619,8 @@ class MainAppFrame(
             selectedServiceId = selectedId,
             config = ImageSearchConfig(
                 lastKnownSize     = config.imageSearchLastKnownSize,
-                lastKnownPosition = config.imageSearchLastKnownPosition
+                lastKnownPosition = config.imageSearchLastKnownPosition,
+                closeOnClickOutside = config.closePopupsOnClickOutside
             ),
             strings = ImageSearchStrings(
                 title             = localizer.getString("image_search_dialog.title"),
@@ -1696,6 +1701,7 @@ class MainAppFrame(
                 lastKnownPosition    = config.quickDictionaryLastKnownPosition,
                 positionNearMouse    = quickDictionaryPositionNearMouse,
                 idleTimeoutSeconds   = config.quickDictionaryIdleTimeoutSeconds,
+                closeOnClickOutside  = config.closePopupsOnClickOutside,
                 transparencyPercentage = config.quickDictionaryTransparencyPercentage
             ),
             strings = QuickDictionaryStrings(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -532,6 +532,11 @@ class MainContentView(
         )
 
         val hasOutputText = mainState.translatedText.isNotBlank()
+
+        // A one-word translation is the case where a definition is usually the next thing wanted.
+        // Anything longer is a sentence, and offering to "define" it would be noise.
+        val singleWordOutput = mainState.translatedText.trim()
+            .takeIf { it.isNotBlank() && it.none(Char::isWhitespace) && it.length >= 2 }
         val hasExtraText = mainState.extraOutputText.isNotBlank()
 
         // Nothing can be translated without a translator, and an empty window gives a new
@@ -571,6 +576,18 @@ class MainContentView(
                                 if (isTtsPlaying) dispatch(MainIntent.StopTTS)
                                 else dispatch(MainIntent.ListenToText(textSource = TextSource.Output))
                             }
+                        ),
+                        // Offered, not forced. A single-word result is the case where a definition
+                        // is usually wanted, so the button appears exactly then — but opening the
+                        // dictionary stays the reader's decision, which is what the popup that
+                        // used to appear on its own got wrong.
+                        Action(
+                            id = "define_output",
+                            iconPath = "icons/lucide/book-open.svg",
+                            tooltip = localizer.getString("main_window_editor_context_menu.find_in_dictionary"),
+                            isEnabled = !mainState.isLoading,
+                            isVisible = singleWordOutput != null,
+                            onClick = { singleWordOutput?.let { showDictionaryWithWord(it, currentTargetLanguage) } }
                         )
                     )
                 )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -532,11 +532,6 @@ class MainContentView(
         )
 
         val hasOutputText = mainState.translatedText.isNotBlank()
-
-        // A one-word translation is the case where a definition is usually the next thing wanted.
-        // Anything longer is a sentence, and offering to "define" it would be noise.
-        val singleWordOutput = mainState.translatedText.trim()
-            .takeIf { it.isNotBlank() && it.none(Char::isWhitespace) && it.length >= 2 }
         val hasExtraText = mainState.extraOutputText.isNotBlank()
 
         // Nothing can be translated without a translator, and an empty window gives a new
@@ -552,6 +547,9 @@ class MainContentView(
         outputTextPanel.render(
             OutputTextState(
                 text = mainState.translatedText,
+                // Shown automatically for a single word, empty otherwise, so a multi-word
+                // translation lays out exactly as it did before this existed.
+                definition = mainState.inlineDefinition,
                 noService = noService,
                 isLoading = mainState.isLoading,
                 fontConfig = config.scaledEditorFont,
@@ -576,18 +574,6 @@ class MainContentView(
                                 if (isTtsPlaying) dispatch(MainIntent.StopTTS)
                                 else dispatch(MainIntent.ListenToText(textSource = TextSource.Output))
                             }
-                        ),
-                        // Offered, not forced. A single-word result is the case where a definition
-                        // is usually wanted, so the button appears exactly then — but opening the
-                        // dictionary stays the reader's decision, which is what the popup that
-                        // used to appear on its own got wrong.
-                        Action(
-                            id = "define_output",
-                            iconPath = "icons/lucide/book-open.svg",
-                            tooltip = localizer.getString("main_window_editor_context_menu.find_in_dictionary"),
-                            isEnabled = !mainState.isLoading,
-                            isVisible = singleWordOutput != null,
-                            onClick = { singleWordOutput?.let { showDictionaryWithWord(it, currentTargetLanguage) } }
                         )
                     )
                 )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
@@ -310,10 +310,13 @@ class MainGlobalKeyListener(
         private var dragged = false
 
         override fun nativeMousePressed(event: NativeMouseEvent) {
-            if (!selectionIconEnabled.get()) return
-            // Any press dismisses a button left over from an earlier selection; the
-            // caller ignores presses that land on the button itself so clicks still work.
+            // Reported before the selection-icon check, not after. This is the only notice the
+            // application gets of a press that lands in another program, and the floating popups
+            // rely on it to close when the user clicks away. Tying it to the selection button
+            // meant turning that button off also stopped popups noticing clicks outside them.
             onPointerPressed(event.point)
+
+            if (!selectionIconEnabled.get()) return
             if (event.button != NativeMouseEvent.BUTTON1) return
             pressedAt = event.point
             dragged = false

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
@@ -249,9 +249,37 @@ class MainGlobalKeyListener(
         private var lastCtrlTime = 0L
         private val threshold = 400
 
+        /** True once a key other than Ctrl is pressed while Ctrl is held. */
+        private var ctrlWasPartOfCombination = false
+        private var ctrlIsDown = false
+
+        override fun nativeKeyPressed(e: NativeKeyEvent) {
+            if (e.keyCode == NativeKeyEvent.VC_CONTROL) {
+                ctrlIsDown = true
+                ctrlWasPartOfCombination = false
+            } else if (ctrlIsDown) {
+                ctrlWasPartOfCombination = true
+            }
+        }
+
         override fun nativeKeyReleased(e: NativeKeyEvent) {
-            if (!hotkeysEnabled.get()) return
             if (e.keyCode != NativeKeyEvent.VC_CONTROL) return
+            ctrlIsDown = false
+
+            // The Ctrl that ends a shortcut is not a tap. Every hotkey in this application is a
+            // Ctrl combination, so counting those releases meant two shortcuts pressed within the
+            // threshold — Ctrl+Q twice, or Ctrl+Q then Ctrl+D — read as a double-Ctrl and summoned
+            // the main window on top of the popup the user actually asked for.
+            //
+            // The time is cleared as well as ignored, so the release that ends a shortcut cannot
+            // pair with a genuine tap that follows it either.
+            if (ctrlWasPartOfCombination) {
+                ctrlWasPartOfCombination = false
+                lastCtrlTime = 0L
+                return
+            }
+
+            if (!hotkeysEnabled.get()) return
 
             // Only fire if the binding exists, is enabled, AND the user
             // has not opted out of the double-Ctrl mechanism specifically.
@@ -261,6 +289,8 @@ class MainGlobalKeyListener(
             val now = System.currentTimeMillis()
             if (now - lastCtrlTime < threshold) {
                 scope.launch { handleSelectedText(onShowApp) }
+                lastCtrlTime = 0L
+                return
             }
             lastCtrlTime = now
         }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -43,7 +43,8 @@ class OutputTextPanel(
     )
     private val actionsPanel = TextActionsPanel(iconManager)
     private val readOnlyPanel = ReadOnlyTextPanel(textPane, actionsPanel)
-    private val definitionStrip = DefinitionStrip()
+    // No rule of its own: the output pane above already draws a border.
+    private val definitionStrip = DefinitionStrip(showDivider = false)
 
     private val noServiceLabel = JLabel()
     private val noServiceAction = JButton().apply {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -6,6 +6,7 @@ import com.github.ahatem.qtranslate.ui.swing.main.widgets.ReadOnlyTextPanelState
 import com.github.ahatem.qtranslate.ui.swing.main.widgets.TextActionsPanel
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.AdvancedTextPane
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.DefinitionStrip
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.BorderLayout
 import java.awt.Color
@@ -42,6 +43,7 @@ class OutputTextPanel(
     )
     private val actionsPanel = TextActionsPanel(iconManager)
     private val readOnlyPanel = ReadOnlyTextPanel(textPane, actionsPanel)
+    private val definitionStrip = DefinitionStrip()
 
     private val noServiceLabel = JLabel()
     private val noServiceAction = JButton().apply {
@@ -72,6 +74,9 @@ class OutputTextPanel(
     init {
         add(noServiceBanner, BorderLayout.NORTH)
         add(readOnlyPanel, BorderLayout.CENTER)
+        // An aside beneath the translation. Kept out of readOnlyPanel so it never lands in the
+        // clipboard when the translation is copied.
+        add(definitionStrip, BorderLayout.SOUTH)
 
         textPane.hintText = localizationManager.getString("main_window_editor_context_menu.output_hint")
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextPanel.kt
@@ -99,6 +99,7 @@ class OutputTextPanel(
 
     override fun render(state: OutputTextState) {
         renderNoServiceBanner(state.noService)
+        definitionStrip.render(state.definition)
         readOnlyPanel.render(
             ReadOnlyTextPanelState(
                 text = state.text,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/output/OutputTextState.kt
@@ -21,6 +21,8 @@ data class NoServiceState(
 )
 
 data class OutputTextState(
+    /** Short definition for a single-word result; empty for anything longer. */
+    val definition: String = "",
     val text: String,
     val fontConfig: FontConfig,
     val fallbackFontConfig: FontConfig,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/LoadingIndicator.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/LoadingIndicator.kt
@@ -11,7 +11,15 @@ data class LoadingIndicatorState(
     val isVisible: Boolean
 ) : UiState
 
-class LoadingIndicator(owner: Frame) : JWindow(owner), Renderable<LoadingIndicatorState> {
+/**
+ * The small progress marker that follows the pointer while a popup translation is being fetched.
+ *
+ * Owned by Swing's shared hidden frame rather than by the main window. It exists precisely for the
+ * case where the main window is hidden in the tray, and an owned window is suppressed by the
+ * platform while its owner is hidden — so owning it by the main window meant it never appeared at
+ * the only time it was wanted.
+ */
+class LoadingIndicator(owner: Frame) : JWindow(), Renderable<LoadingIndicatorState> {
 
     private val positionUpdater = Timer(10) {
         val mouseLocation = MouseInfo.getPointerInfo().location

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/LoadingIndicator.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/LoadingIndicator.kt
@@ -41,16 +41,51 @@ class LoadingIndicator(owner: Frame) : JWindow(), Renderable<LoadingIndicatorSta
         pack()
     }
 
-    override fun render(state: LoadingIndicatorState) {
-        val shouldBeVisible = state.isVisible
+    /** When the marker went up, so a fast result cannot take it down before it was ever seen. */
+    private var shownAt = 0L
 
-        if (isVisible != shouldBeVisible) {
-            isVisible = shouldBeVisible
-            if (shouldBeVisible) {
+    private var pendingHide: Timer? = null
+
+    override fun render(state: LoadingIndicatorState) {
+        if (state.isVisible) {
+            pendingHide?.stop()
+            pendingHide = null
+            if (!isVisible) {
+                // Positioned before showing, or the first frame lands wherever the window was
+                // last left — usually the top-left corner of the screen.
+                MouseInfo.getPointerInfo()?.location?.let { setLocation(it.x, it.y + 20) }
+                shownAt = System.currentTimeMillis()
+                isVisible = true
                 positionUpdater.start()
-            } else {
-                positionUpdater.stop()
             }
+            return
         }
+
+        if (!isVisible) return
+
+        // A translation that returns in 80ms would otherwise show and hide the marker inside a
+        // single frame — the user sees a flicker, or nothing at all, and reports that the
+        // indicator "doesn't work". Held for a moment so that appearing means something.
+        val shownFor = System.currentTimeMillis() - shownAt
+        if (shownFor >= MINIMUM_VISIBLE_MS) {
+            hideNow()
+            return
+        }
+        if (pendingHide != null) return
+        pendingHide = Timer((MINIMUM_VISIBLE_MS - shownFor).toInt()) {
+            (it.source as Timer).stop()
+            pendingHide = null
+            hideNow()
+        }.apply { isRepeats = false; start() }
+    }
+
+    private fun hideNow() {
+        isVisible = false
+        positionUpdater.stop()
+    }
+
+    private companion object {
+        /** Long enough to register as "something is happening" rather than as a glitch. */
+        const val MINIMUM_VISIBLE_MS = 350L
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -12,6 +12,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.util.*
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.AdvancedTextPane
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentMover
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentResizer
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.*
 import java.awt.event.*
@@ -110,32 +111,52 @@ class QuickTranslateDialog(
     }
 
     // timers and state
-    private val fadeLock = AtomicBoolean(false)
-    private var fadeTimer: Timer? = null
     private var copyFeedbackTimer: Timer? = null
     private var resizeSaveTimer: Timer? = null
 
-    // idle/auto-hide manager (single timer)
-    private var idleHideTimer: Timer? = null
-    private var idleCloseTimer: Timer? = null
+    /**
+     * Window flags, fading, idle-hide, pointer presence — shared with the other two popups.
+     *
+     * Declared ahead of [isPinned], whose setter writes into it. Kotlin initialises properties in
+     * declaration order, so the other way round leaves a window in which assigning isPinned would
+     * dereference null.
+     */
+    private val popup = FloatingPopupBehavior(
+        window = this,
+        owner = owner,
+        minimumSize = Dimension(350, 120),
+        pinnedBorderWidth = PINNED_BORDER_WIDTH,
+        resizeHandle = RESIZE_HANDLE_SIZE
+    ).apply {
+        configureIdleHide(
+            delayMs = { (currentConfig?.idleTimeoutSeconds ?: 3) * 1000 },
+            fadeMs = FADE_MS,
+            restingOpacity = { (100f - (currentConfig?.transparencyPercentage ?: 0)) / 100f },
+            // Dismissed through the store. Hiding the window directly left the application still
+            // believing the popup was open.
+            onExpired = { onDismiss() }
+        )
+    }
 
     // flags
     private var isDragging = false
     private var isResizing = false
+
+    /**
+     * Mirrored into the popup helper, whose idle-hide and pointer tracking both consult it.
+     * Two copies of "is this pinned" drifting apart means a pinned popup closing itself anyway.
+     */
     private var isPinned = false
+        set(value) {
+            field = value
+            popup.isPinned = value
+        }
     private var wasManuallyMoved = false
     private var currentConfig: DialogConfig? = null
 
     private var lastRenderedText: String? = null
 
-    // mouse presence detection via AWT
-    private var awtMouseListener: AWTEventListener? = null
-    private var isMouseOver = false
-
     init {
-        isUndecorated = true
-        isAlwaysOnTop = true
-        minimumSize = Dimension(350, 120)
         focusableWindowState = false
 
         val wrapperPanel = JPanel(BorderLayout()).apply {
@@ -292,31 +313,13 @@ class QuickTranslateDialog(
         fadeTo(target, FADE_MS)
     }
 
-    private fun fadeTo(targetOpacity: Float, durationMs: Int) {
-        if (fadeLock.get()) return
-        fadeLock.set(true)
-        fadeTimer?.stop()
-
-        val start = opacity
-        val steps = max(1, FADE_STEPS)
-        val stepDelay = max(10, durationMs / steps)
-        var step = 0
-
-        fadeTimer = Timer(stepDelay) {
-            step++
-            val t = step.toFloat() / steps
-            val value = start + (targetOpacity - start) * t
-            setOpacityIfDifferent(value)
-
-            if (step >= steps) {
-                (it.source as Timer).stop()
-                fadeLock.set(false)
-            }
-        }.apply {
-            isRepeats = true
-            start()
-        }
-    }
+    /**
+     * Delegated to the shared helper, which also drops a bug that lived only here: the old guard
+     * returned early while a fade was still running, so a fade back to transparency was silently
+     * discarded whenever the mouse entered and left within one animation. The dictionary popup
+     * had this fixed; this one never did.
+     */
+    private fun fadeTo(targetOpacity: Float, durationMs: Int) = popup.fadeTo(targetOpacity, durationMs)
 
     private fun setOpacityIfDifferent(value: Float) {
         if (abs(opacity - value) > 0.01f) opacity = value
@@ -345,82 +348,15 @@ class QuickTranslateDialog(
         onSaveSize(size.toSize())
     }
 
-    private fun startIdleHide() {
-        // restart single idle timer — reads live config each call so changes take effect immediately
-        val idleHideDelayMs = (currentConfig?.idleTimeoutSeconds ?: 3) * 1000
-        stopIdleHide()
-        idleHideTimer = Timer(idleHideDelayMs) { event ->
-            (event.source as Timer).stop()
-            if (isPinned) return@Timer
-            fadeTo(0f, FADE_MS)
-            // Kept in a field so stopIdleHide can reach it. Previously this was an anonymous
-            // timer nobody held, so a popup that had started fading still closed a moment later
-            // even if the user had moved back onto it or reopened it in the meantime.
-            idleCloseTimer = Timer(FADE_MS + 20) { closeEvent ->
-                (closeEvent.source as Timer).stop()
-                // Dismissed through the store rather than hidden directly. Hiding the window here
-                // left the application still believing the popup was open, so anything keyed on
-                // that — the loading indicator among them — went on behaving as if it were.
-                if (!isPinned) onDismiss()
-            }.apply { isRepeats = false; start() }
-        }.apply {
-            isRepeats = false
-            start()
-        }
-    }
+    private fun startIdleHide() = popup.startIdleHide()
 
-    private fun stopIdleHide() {
-        idleHideTimer?.stop()
-        idleCloseTimer?.stop()
-        idleCloseTimer = null
-    }
+    private fun stopIdleHide() = popup.stopIdleHide()
 
-    private fun installAwtMouseListener() {
-        if (awtMouseListener != null) return
-        awtMouseListener = AWTEventListener { ev ->
-            val me = ev as? MouseEvent ?: return@AWTEventListener
-            if (me.id == MouseEvent.MOUSE_PRESSED) {
-                if (!isPinned && isVisible) {
-                    val clickPoint = Point(me.locationOnScreen)
-                    SwingUtilities.convertPointFromScreen(clickPoint, contentPane)
-                    if (!contentPane.contains(clickPoint)) onDismiss()
-                }
-                return@AWTEventListener
-            }
-            if (me.id != MouseEvent.MOUSE_MOVED && me.id != MouseEvent.MOUSE_ENTERED && me.id != MouseEvent.MOUSE_EXITED) return@AWTEventListener
-            SwingUtilities.invokeLater {
-                val p = MouseInfo.getPointerInfo()?.location ?: return@invokeLater
-                val cp = Point(p)
-                SwingUtilities.convertPointFromScreen(cp, contentPane)
-                val over = contentPane.contains(cp)
-                if (over != isMouseOver) {
-                    isMouseOver = over
-                    if (isMouseOver) {
-                        stopIdleHide()
-                        fadeTo(1f, FADE_MS)
-                    } else {
-                        if (!isPinned) {
-                            applyTransparency()
-                            startIdleHide()
-                        }
-                    }
-                } else {
-                    // mouse moved inside window: reset idle timer
-                    if (isMouseOver && !isPinned) startIdleHide()
-                }
-            }
-        }
-        Toolkit.getDefaultToolkit()
-            .addAWTEventListener(awtMouseListener, AWTEvent.MOUSE_MOTION_EVENT_MASK or AWTEvent.MOUSE_EVENT_MASK)
-    }
 
-    private fun uninstallAwtMouseListener() {
-        awtMouseListener?.let {
-            Toolkit.getDefaultToolkit().removeAWTEventListener(it)
-            awtMouseListener = null
-            isMouseOver = false
-        }
-    }
+    private fun installAwtMouseListener() = popup.installPointerTracking()
+
+    private fun uninstallAwtMouseListener() = popup.uninstallPointerTracking()
+
 
     // sizing (reuse measurePane; skip heavy ops during resize)
     private fun applySize(text: String) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -46,14 +46,38 @@ class QuickTranslateDialog(
         const val RESIZE_SAVE_DEBOUNCE_MS = 180
     }
 
-    // theme colors cached
-    private val borderColor = UIManager.getColor("Component.borderColor")
-    private val accentBorderColor = UIManager.getColor("Component.focusedBorderColor")
-        ?: UIManager.getColor("Component.accentColor")
-        ?: borderColor
-    private val toolbarSelectedBg = UIManager.getColor("Button.toolbar.selectedBackground")
-    private val toolbarSelectedFg = UIManager.getColor("Button.toolbar.selectedForeground")
-    private val labelFg = UIManager.getColor("Label.foreground")
+    // Read on use, not cached. This dialog is created once and outlives any number of theme
+    // switches; a captured colour would pin the borders and button styling to whichever theme
+    // happened to be active at startup. See refreshTheme.
+    private val borderColor: Color? get() = UIManager.getColor("Component.borderColor")
+    private val accentBorderColor: Color?
+        get() = UIManager.getColor("Component.focusedBorderColor")
+            ?: UIManager.getColor("Component.accentColor")
+            ?: borderColor
+    private val toolbarSelectedBg: Color? get() = UIManager.getColor("Button.toolbar.selectedBackground")
+    private val toolbarSelectedFg: Color? get() = UIManager.getColor("Button.toolbar.selectedForeground")
+    private val labelFg: Color? get() = UIManager.getColor("Label.foreground")
+
+    /** A field, not an inline lambda, so it can be detached when the window goes away. */
+    private val themeListener = java.beans.PropertyChangeListener { event ->
+        if (event.propertyName == "lookAndFeel") SwingUtilities.invokeLater { refreshTheme() }
+    }
+
+    /** Panels carrying a themed divider, kept so it can be redrawn in the new theme's colour. */
+    private val dividedPanels = mutableListOf<Pair<JPanel, () -> javax.swing.border.Border>>()
+
+    /**
+     * Re-applies the colours this dialog painted itself with.
+     *
+     * Borders keep the colour they were given, and switching look and feel does not revisit them,
+     * so without this the popup keeps the old theme's edges against the new background.
+     */
+    private fun refreshTheme() {
+        dividedPanels.forEach { (panel, borderOf) -> panel.border = borderOf() }
+        updatePinButtonStyle(isPinned)
+        revalidate()
+        repaint()
+    }
 
     // title + controls
     private val languagePairLabel = JLabel().apply { putClientProperty("FlatLaf.styleClass", "h4") }
@@ -142,6 +166,7 @@ class QuickTranslateDialog(
         mainPanel.add(textScrollPane, BorderLayout.CENTER)
 
         setupWindowBehavior(topPanel)
+        UIManager.addPropertyChangeListener(themeListener)
         updatePinButtonStyle(isPinned)
     }
 
@@ -535,6 +560,7 @@ class QuickTranslateDialog(
 
         val separator = JPanel().apply {
             border = BorderFactory.createMatteBorder(0, 0, 0, 1, borderColor)
+            dividedPanels += this to { BorderFactory.createMatteBorder(0, 0, 0, 1, borderColor) }
             preferredSize = Dimension(1, 24)
             maximumSize = Dimension(1, Int.MAX_VALUE)
             isOpaque = false
@@ -564,6 +590,7 @@ class QuickTranslateDialog(
         val finalPanel = JPanel().apply {
             isOpaque = false
             border = BorderFactory.createMatteBorder(0, 0, 1, 0, borderColor)
+            dividedPanels += this to { BorderFactory.createMatteBorder(0, 0, 1, 0, borderColor) }
         }
 
         val grid = GridBag(finalPanel)
@@ -667,6 +694,7 @@ class QuickTranslateDialog(
             override fun windowClosing(e: WindowEvent) = onDismiss()
             override fun windowClosed(e: WindowEvent) {
                 uninstallAwtMouseListener()
+                UIManager.removePropertyChangeListener(themeListener)
             }
         })
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -13,6 +13,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.widgets.AdvancedTextPane
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentMover
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentResizer
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.InlineLoadingBar
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.*
 import java.awt.event.*
@@ -102,6 +103,8 @@ class QuickTranslateDialog(
         isEditable = false
         border = EmptyBorder(6, 6, 6, 6)
     }
+
+    private val loadingBar = InlineLoadingBar()
 
     private val topPanel = createTopPanel()
 
@@ -194,7 +197,16 @@ class QuickTranslateDialog(
             horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
         }
 
-        mainPanel.add(topPanel, BorderLayout.NORTH)
+        // Header, then the hairline loading bar, then the text. The bar reserves its height even
+        // when idle, so a reload does not nudge the translation down and back up again.
+        mainPanel.add(
+            JPanel(BorderLayout()).apply {
+                isOpaque = false
+                add(topPanel, BorderLayout.CENTER)
+                add(loadingBar, BorderLayout.SOUTH)
+            },
+            BorderLayout.NORTH
+        )
         mainPanel.add(textScrollPane, BorderLayout.CENTER)
 
         setupWindowBehavior(topPanel)
@@ -286,6 +298,9 @@ class QuickTranslateDialog(
     // Full content sync
     private fun updateContent(state: QuickTranslateDialogState) {
         this.isPinned = state.isPinned
+        // Only while something is already on screen: before that the popup is withheld and the
+        // standalone loading indicator covers the wait.
+        loadingBar.isLoading = state.isLoading && isVisible
 
         val source = state.sourceLanguage.tag.uppercase()
         val target = state.targetLanguage.tag.uppercase()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -210,6 +210,10 @@ class QuickTranslateDialog(
         mainPanel.add(textScrollPane, BorderLayout.CENTER)
 
         setupWindowBehavior(topPanel)
+        popup.installClickOutsideToClose(
+            enabled = { currentConfig?.closeOnClickOutside ?: true },
+            onClose = { onDismiss() }
+        )
         UIManager.addPropertyChangeListener(themeListener)
         updatePinButtonStyle(isPinned)
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -24,6 +24,10 @@ import kotlin.math.max
 
 
 class QuickTranslateDialog(
+    /**
+     * The main window, used only to position against. It is deliberately NOT this dialog's
+     * owner -- see FloatingPopupBehavior for why a tray application must not own these.
+     */
     private val owner: Frame,
     private val iconManager: IconManager,
     private val onDismiss: () -> Unit,
@@ -33,7 +37,7 @@ class QuickTranslateDialog(
     private val onSavePosition: (Position) -> Unit,
     private val onSaveSize: (Size) -> Unit,
     private val onPinToggled: () -> Unit
-) : JDialog(owner, ModalityType.MODELESS), Renderable<QuickTranslateDialogState> {
+) : JDialog(null as Frame?, ModalityType.MODELESS), Renderable<QuickTranslateDialogState> {
 
     private companion object {
         const val MAX_WIDTH_SCALE = 0.40

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -14,6 +14,7 @@ import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentMover
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ComponentResizer
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.FloatingPopupBehavior
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.InlineLoadingBar
+import com.github.ahatem.qtranslate.ui.swing.shared.widgets.DefinitionStrip
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.Renderable
 import java.awt.*
 import java.awt.event.*
@@ -105,6 +106,7 @@ class QuickTranslateDialog(
     }
 
     private val loadingBar = InlineLoadingBar()
+    private val definitionStrip = DefinitionStrip()
 
     private val topPanel = createTopPanel()
 
@@ -208,6 +210,8 @@ class QuickTranslateDialog(
             BorderLayout.NORTH
         )
         mainPanel.add(textScrollPane, BorderLayout.CENTER)
+        // Below the translation, above nothing: an aside, not part of the result.
+        mainPanel.add(definitionStrip, BorderLayout.SOUTH)
 
         setupWindowBehavior(topPanel)
         popup.installClickOutsideToClose(
@@ -305,6 +309,8 @@ class QuickTranslateDialog(
         // Only while something is already on screen: before that the popup is withheld and the
         // standalone loading indicator covers the wait.
         loadingBar.isLoading = state.isLoading && isVisible
+        // Only for single words; the state carries it empty otherwise, so the strip hides itself.
+        definitionStrip.render(state.definition)
 
         val source = state.sourceLanguage.tag.uppercase()
         val target = state.targetLanguage.tag.uppercase()
@@ -402,7 +408,9 @@ class QuickTranslateDialog(
         focusableWindowState = true
         isVisible = true
         installAwtMouseListener()
-        if (!isPinned) startIdleHide()
+        // Not if the pointer is already inside it -- the popup opens at the cursor, so it often
+        // is, and starting the countdown then hides the popup out from under the reader.
+        if (!isPinned && !popup.isPointerOver) startIdleHide()
     }
 
     private fun hideDialog() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -117,6 +117,7 @@ class QuickTranslateDialog(
 
     // idle/auto-hide manager (single timer)
     private var idleHideTimer: Timer? = null
+    private var idleCloseTimer: Timer? = null
 
     // flags
     private var isDragging = false
@@ -326,8 +327,10 @@ class QuickTranslateDialog(
         val transparency = currentConfig?.transparencyPercentage ?: 0
         opacity = (100f - transparency) / 100f
 
-        isVisible = true
+        // Set before showing: changing focusableWindowState on a window already on screen makes
+        // AWT discard and rebuild the native peer, which flickers and can drop focus.
         focusableWindowState = true
+        isVisible = true
         installAwtMouseListener()
         if (!isPinned) startIdleHide()
     }
@@ -345,17 +348,21 @@ class QuickTranslateDialog(
     private fun startIdleHide() {
         // restart single idle timer — reads live config each call so changes take effect immediately
         val idleHideDelayMs = (currentConfig?.idleTimeoutSeconds ?: 3) * 1000
-        idleHideTimer?.stop()
+        stopIdleHide()
         idleHideTimer = Timer(idleHideDelayMs) { event ->
-            if (!isPinned) fadeTo(0f, FADE_MS) // fade out visually
-            // after fade complete, actually hide
-            Timer(FADE_MS + 20) {
-                if (!isPinned) {
-                    hideDialog()
-                }
-                (it.source as Timer).stop()
-            }.apply { isRepeats = false; start() }
             (event.source as Timer).stop()
+            if (isPinned) return@Timer
+            fadeTo(0f, FADE_MS)
+            // Kept in a field so stopIdleHide can reach it. Previously this was an anonymous
+            // timer nobody held, so a popup that had started fading still closed a moment later
+            // even if the user had moved back onto it or reopened it in the meantime.
+            idleCloseTimer = Timer(FADE_MS + 20) { closeEvent ->
+                (closeEvent.source as Timer).stop()
+                // Dismissed through the store rather than hidden directly. Hiding the window here
+                // left the application still believing the popup was open, so anything keyed on
+                // that — the loading indicator among them — went on behaving as if it were.
+                if (!isPinned) onDismiss()
+            }.apply { isRepeats = false; start() }
         }.apply {
             isRepeats = false
             start()
@@ -364,6 +371,8 @@ class QuickTranslateDialog(
 
     private fun stopIdleHide() {
         idleHideTimer?.stop()
+        idleCloseTimer?.stop()
+        idleCloseTimer = null
     }
 
     private fun installAwtMouseListener() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -214,10 +214,6 @@ class QuickTranslateDialog(
         mainPanel.add(definitionStrip, BorderLayout.SOUTH)
 
         setupWindowBehavior(topPanel)
-        popup.installClickOutsideToClose(
-            enabled = { currentConfig?.closeOnClickOutside ?: true },
-            onClose = { onDismiss() }
-        )
         UIManager.addPropertyChangeListener(themeListener)
         updatePinButtonStyle(isPinned)
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -160,6 +160,12 @@ class QuickTranslateDialog(
 
     private var lastRenderedText: String? = null
 
+    /** True while the popup has been asked for but is waiting for something worth showing. */
+    private var pendingShow = false
+
+    /** The trigger this popup last reacted to; see [QuickTranslateDialogState.triggerCount]. */
+    private var lastTriggerCount = 0
+
     init {
         focusableWindowState = false
 
@@ -213,22 +219,50 @@ class QuickTranslateDialog(
                 )
 
                 updateContent(state)
-                applySize(state.translatedText)
-                applyPosition()
-                showDialog()
+
+                // Nothing to show yet, so nothing is shown. Opening now would put a popup on
+                // screen sized to an empty string — a sliver that then jumps to full size when
+                // the translation lands. The loading indicator covers the wait instead, and the
+                // popup appears once, already the right size.
+                if (state.isLoading && state.translatedText.isBlank()) {
+                    pendingShow = true
+                    return
+                }
+                showNow(state)
             } else {
+                pendingShow = false
                 hideDialog()
             }
             return
         }
 
-        if (!isVisible) return
+        if (!isVisible) {
+            // A deferred open, now that the result has arrived — or failed, which also deserves
+            // to be shown rather than left waiting forever.
+            if (pendingShow && state.isVisible && (!state.isLoading || state.translatedText.isNotBlank())) {
+                currentConfig = state.config
+                updateContent(state)
+                showNow(state)
+            }
+            return
+        }
 
         val pinStateChanged = this.isPinned != state.isPinned
+        val retriggered = lastTriggerCount != state.triggerCount
+        lastTriggerCount = state.triggerCount
 
         updateContent(state)
 
         if (pinStateChanged) handlePinState(state)
+
+        // Asked for again while already open: refresh in place, come back to full opacity, and
+        // restart the countdown. Re-sized for the new text, since it is a different translation.
+        if (retriggered) {
+            fadeTo(1f, FADE_MS)
+            if (!isResizing && !isDragging) applySize(state.translatedText)
+            popup.noteActivity()
+            toFront()
+        }
 
         // only refresh font when user changed it
         if (!isResizing && !isDragging) {
@@ -237,6 +271,16 @@ class QuickTranslateDialog(
                 newFallback = state.config.fallbackFont.toFont()
             )
         }
+    }
+
+    /** Sizes the popup for the text it is about to show, then puts it on screen. */
+    private fun showNow(state: QuickTranslateDialogState) {
+        pendingShow = false
+        wasManuallyMoved = false
+        lastTriggerCount = state.triggerCount
+        applySize(state.translatedText)
+        applyPosition()
+        showDialog()
     }
 
     // Full content sync

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -131,7 +131,7 @@ class QuickTranslateDialog(
     private val popup = FloatingPopupBehavior(
         window = this,
         owner = owner,
-        minimumSize = Dimension(350, 120),
+        minimumSize = Dimension(PopupSizing.minWidth(), PopupSizing.minHeight()),
         pinnedBorderWidth = PINNED_BORDER_WIDTH,
         resizeHandle = RESIZE_HANDLE_SIZE
     ).apply {
@@ -442,8 +442,14 @@ class QuickTranslateDialog(
         // happens to be placed — prevents wrong-monitor bounds on multi-monitor setups.
         val gc = MouseInfo.getPointerInfo()?.device?.defaultConfiguration ?: graphicsConfiguration
         val screenBounds = gc.bounds
-        val maxWidth = (screenBounds.width * MAX_WIDTH_SCALE).toInt()
-        val maxHeight = (screenBounds.height * MAX_HEIGHT_SCALE).toInt()
+        // Bounded by a readable line length first and the screen second. A share of the screen
+        // alone stretches one sentence across half a wide monitor, which is hard to read for the
+        // same reason a book is not printed edge to edge.
+        val maxWidth = PopupSizing.maxTextWidth(
+            measurePane.getFontMetrics(outputTextArea.font),
+            screenBounds
+        )
+        val maxHeight = PopupSizing.maxHeight(screenBounds)
 
         measurePane.font = outputTextArea.font
         if (measurePane.text != text) measurePane.text = text

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
@@ -17,6 +17,8 @@ data class QuickTranslateDialogState(
     val isPinned: Boolean,
     /** Bumped when the user asks for this popup again; a change restarts the countdown. */
     val triggerCount: Int,
+    /** Short definition for a single-word result; empty for anything longer. */
+    val definition: String,
 
     // --- The Data is now a first-class citizen ---
     val sourceLanguage: LanguageCode,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
@@ -38,6 +38,8 @@ data class DialogConfig(
     val autoPositionEnabled: Boolean,
     val transparencyPercentage: Int,
     val idleTimeoutSeconds: Int = 3,
+    /** Whether pressing outside the popup dismisses it; pinning overrides this. */
+    val closeOnClickOutside: Boolean = true,
     val lastKnownSize: Size,
     val lastKnownPosition: Position
 )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
@@ -15,6 +15,8 @@ data class QuickTranslateDialogState(
     val isLoading: Boolean,
     val translatedText: String,
     val isPinned: Boolean,
+    /** Bumped when the user asks for this popup again; a change restarts the countdown. */
+    val triggerCount: Int,
 
     // --- The Data is now a first-class citizen ---
     val sourceLanguage: LanguageCode,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
@@ -119,6 +119,7 @@ class SettingsDialog(
     // ─────────────────────────────────────────────────────────────────────────
 
     init {
+        com.github.ahatem.qtranslate.ui.swing.shared.util.AppIcons.applyTo(this)
         title = localizationManager.getString("settings_dialog.title")
         layout = BorderLayout()
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
@@ -49,6 +49,11 @@ class SettingsDialog(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    /** Held as a field so it can be removed again — a lambda passed inline never can be. */
+    private val themeListener = java.beans.PropertyChangeListener { event ->
+        if (event.propertyName == "lookAndFeel") SwingUtilities.invokeLater { updateBorders() }
+    }
+
     // ── Nav items (ordered) ───────────────────────────────────────────────────
     private val navItems = listOf(
         localizationManager.getString("settings_dialog_sidebar.general"),
@@ -139,9 +144,7 @@ class SettingsDialog(
 
         // Apply borders based on current theme, then keep them fresh on theme changes
         updateBorders()
-        UIManager.addPropertyChangeListener { evt ->
-            if (evt.propertyName == "lookAndFeel") SwingUtilities.invokeLater { updateBorders() }
-        }
+        UIManager.addPropertyChangeListener(themeListener)
 
         rootPane.registerKeyboardAction(
             { cancelAndClose() },
@@ -152,6 +155,18 @@ class SettingsDialog(
         defaultCloseOperation = DO_NOTHING_ON_CLOSE
         addWindowListener(object : WindowAdapter() {
             override fun windowClosing(e: WindowEvent) = cancelAndClose()
+
+            /**
+             * Detaches from [UIManager] on the way out.
+             *
+             * A fresh dialog is built every time settings are opened, and `UIManager` holds its
+             * listeners for the life of the process. Without this, each open pins an entire
+             * dialog — every panel and everything they reference — in memory for good, and every
+             * later theme change runs the handlers of all the dead ones.
+             */
+            override fun windowClosed(e: WindowEvent) {
+                UIManager.removePropertyChangeListener(themeListener)
+            }
         })
 
         observeState()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
@@ -74,6 +74,11 @@ class DynamicPluginSettingsDialog(
     )
 
     private val components = mutableMapOf<String, SettingComponent>()
+
+    /** A field rather than an inline lambda, so [dispose] can detach it again. */
+    private val themeListener = java.beans.PropertyChangeListener { event ->
+        if (event.propertyName == "lookAndFeel") SwingUtilities.invokeLater { updateButtonBarBorder() }
+    }
     private val saveButton = JButton(localizationManager.getString("common.save"))
     private val testButton = JButton(localizationManager.getString("plugin_config.test_connection")).apply {
         addActionListener { onTestClicked() }
@@ -120,9 +125,7 @@ class DynamicPluginSettingsDialog(
         add(buttonBar, BorderLayout.SOUTH)
 
         // Keep button-bar top-border in sync with the active theme
-        UIManager.addPropertyChangeListener { evt ->
-            if (evt.propertyName == "lookAndFeel") SwingUtilities.invokeLater { updateButtonBarBorder() }
-        }
+        UIManager.addPropertyChangeListener(themeListener)
 
         // Keyboard shortcuts
         rootPane.defaultButton = saveButton
@@ -772,6 +775,9 @@ class DynamicPluginSettingsDialog(
     override fun dispose() {
         // A check can still be in flight; without this it would come back to a disposed window.
         dialogScope.cancel()
+        // One of these dialogs is built per plugin configured, and UIManager keeps its listeners
+        // for the life of the process — so leaving this attached pins the whole dialog forever.
+        UIManager.removePropertyChangeListener(themeListener)
         super.dispose()
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/WindowPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/WindowPanel.kt
@@ -18,6 +18,7 @@ class WindowPanel(
     }
 
     private lateinit var layoutCombo: JComboBox<LayoutInfo>
+    private lateinit var closeOnClickOutsideCheck: JCheckBox
     private lateinit var historyCheck: JCheckBox
     private lateinit var languageCheck: JCheckBox
     private lateinit var servicesCheck: JCheckBox
@@ -173,6 +174,14 @@ class WindowPanel(
         )
         addHint(localizationManager.getString("settings_window.popup_idle_hint"))
 
+        closeOnClickOutsideCheck = addCheckbox(
+            localizationManager.getString("settings_window.close_popup_on_click_outside"),
+            true
+        ) { enabled ->
+            applyDraft(store) { it.copy(closePopupsOnClickOutside = enabled) }
+        }
+        addHint(localizationManager.getString("settings_window.close_popup_on_click_outside_hint"))
+
         // Dictionary Popup sub-section
         addSubSeparator(localizationManager.getString("settings_window.dict_popup_sub"))
 
@@ -257,6 +266,7 @@ class WindowPanel(
             autoPositionCheck.isSelected = c.isPopupAutoPositionEnabled
             transparencySpinner.value = c.popupTransparencyPercentage.coerceIn(5, 50)
             popupIdleSpinner.value = c.popupIdleTimeoutSeconds
+            closeOnClickOutsideCheck.isSelected = c.closePopupsOnClickOutside
             dictTransparencySpinner.value = c.quickDictionaryTransparencyPercentage.coerceIn(5, 50)
             dictIdleSpinner.value = c.quickDictionaryIdleTimeoutSeconds
             closeButtonCombo.selectedItem = (0 until closeButtonCombo.itemCount)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/AppIcons.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/AppIcons.kt
@@ -1,0 +1,33 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.util
+
+import java.awt.Image
+import java.awt.Window
+import javax.imageio.ImageIO
+
+/**
+ * The application's window icons, loaded once.
+ *
+ * Every window needs these applied explicitly. A window inherits nothing from its owner, and the
+ * floating popups are deliberately owned by Swing's shared hidden frame — so without this they
+ * show Java's default coffee cup wherever the platform surfaces a window icon.
+ *
+ * Several sizes are supplied and the platform picks: a title bar wants 16px, the task switcher
+ * wants 32 or 48, and letting it downscale 128 for a 16px slot looks like mud.
+ */
+object AppIcons {
+
+    private val images: List<Image> by lazy {
+        listOf(16, 32, 64, 128).mapNotNull { size ->
+            runCatching {
+                AppIcons::class.java.classLoader
+                    .getResourceAsStream("icons/app/$size.png")
+                    ?.use(ImageIO::read)
+            }.getOrNull()
+        }
+    }
+
+    /** Applies the application icons to [window]. Does nothing if the resources are missing. */
+    fun applyTo(window: Window) {
+        if (images.isNotEmpty()) window.iconImages = images
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/PopupSizing.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/PopupSizing.kt
@@ -1,0 +1,68 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.util
+
+import com.formdev.flatlaf.util.UIScale
+import java.awt.Font
+import java.awt.FontMetrics
+import java.awt.Rectangle
+
+/**
+ * How wide a floating popup should be allowed to get.
+ *
+ * A popup sized purely as a fraction of the screen is wrong at both ends: on a wide monitor it
+ * becomes a single line of text stretched across half a metre, which is genuinely hard to read
+ * because the eye loses its place on the return sweep — the reason books and well-set web pages
+ * cap their measure. And a popup sized purely to its content is a sliver when the content is one
+ * word.
+ *
+ * So the width is bounded by a comfortable line length, measured in characters of the font
+ * actually in use, and then by the screen as a safety net for very large text or very small
+ * displays.
+ */
+object PopupSizing {
+
+    /**
+     * Characters per line the width aims not to exceed.
+     *
+     * Typographic advice for a comfortable measure runs from about 45 to 75 characters. The upper
+     * end suits a popup, which is read in a glance rather than for minutes at a time.
+     */
+    private const val IDEAL_LINE_CHARACTERS = 72
+
+    /** Never wider than this share of the screen, whatever the font says. */
+    private const val MAX_SCREEN_FRACTION = 0.42
+
+    /** Never taller than this share, so a long translation scrolls instead of filling the screen. */
+    private const val MAX_HEIGHT_FRACTION = 0.45
+
+    /**
+     * Wide enough that a one-word translation still looks like a considered answer rather than a
+     * tooltip that ran out of room.
+     */
+    private const val MIN_WIDTH = 380
+
+    private const val MIN_HEIGHT = 140
+
+    /**
+     * The widest the text area should be drawn, in pixels.
+     *
+     * Uses the average character width of [font] rather than a fixed pixel count, so the measure
+     * holds when the user picks a larger font or a different family.
+     */
+    fun maxTextWidth(metrics: FontMetrics, screen: Rectangle): Int {
+        val averageCharacter = metrics.charWidth('n').coerceAtLeast(1)
+        val comfortable = averageCharacter * IDEAL_LINE_CHARACTERS
+        val screenCap = (screen.width * MAX_SCREEN_FRACTION).toInt()
+        return minOf(comfortable, screenCap).coerceAtLeast(minWidth())
+    }
+
+    fun maxHeight(screen: Rectangle): Int = (screen.height * MAX_HEIGHT_FRACTION).toInt()
+
+    /** Scaled, because a fixed pixel floor is a different size on every display. */
+    fun minWidth(): Int = UIScale.scale(MIN_WIDTH)
+
+    fun minHeight(): Int = UIScale.scale(MIN_HEIGHT)
+
+    /** Convenience for callers that have a font rather than metrics to hand. */
+    fun maxTextWidth(font: Font, metricsProvider: (Font) -> FontMetrics, screen: Rectangle): Int =
+        maxTextWidth(metricsProvider(font), screen)
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -221,35 +221,41 @@ class FontFallbackDocumentListener(
     private fun applyFontFallback(doc: StyledDocument, offset: Int, length: Int, primary: Font, fallback: Font) {
         if (length <= 0) return
         val text = doc.getText(offset, length)
-        var pos  = 0
-        while (pos < text.length) {
-            val remaining        = text.substring(pos)
-            val primaryFailIndex = primary.canDisplayUpTo(remaining)
+        // Copied once, then scanned in place. The previous version called text.substring(pos)
+        // once per run, copying everything still to be scanned each time, which made a run-heavy
+        // document quadratic in allocation — while this method's own documentation claimed it
+        // allocated nothing per character. canDisplayUpTo takes an offset only for char arrays,
+        // which is why this is an array rather than the string.
+        val chars = text.toCharArray()
+        val end = chars.size
+        var pos = 0
 
-            if (primaryFailIndex == -1) {
-                applyRunAttributes(doc, offset + pos, remaining.length, primary)
+        while (pos < end) {
+            val primaryFail = primary.canDisplayUpTo(chars, pos, end)
+
+            if (primaryFail == -1) {
+                applyRunAttributes(doc, offset + pos, end - pos, primary)
                 break
             }
-            if (primaryFailIndex > 0) {
-                applyRunAttributes(doc, offset + pos, primaryFailIndex, primary)
-                pos += primaryFailIndex
+            if (primaryFail > pos) {
+                applyRunAttributes(doc, offset + pos, primaryFail - pos, primary)
+                pos = primaryFail
                 continue
             }
 
-            val fallbackFailIndex = fallback.canDisplayUpTo(remaining)
-            if (fallbackFailIndex == -1) {
-                applyRunAttributes(doc, offset + pos, remaining.length, fallback)
+            val fallbackFail = fallback.canDisplayUpTo(chars, pos, end)
+            if (fallbackFail == -1) {
+                applyRunAttributes(doc, offset + pos, end - pos, fallback)
                 break
             }
-            if (fallbackFailIndex > 0) {
-                applyRunAttributes(doc, offset + pos, fallbackFailIndex, fallback)
-                pos += fallbackFailIndex
+            if (fallbackFail > pos) {
+                applyRunAttributes(doc, offset + pos, fallbackFail - pos, fallback)
+                pos = fallbackFail
                 continue
             }
 
             // Neither font can display this code point — skip it and let the system handle it.
-            val cpLen = Character.charCount(remaining.codePointAt(0))
-            pos += cpLen
+            pos += Character.charCount(Character.codePointAt(chars, pos))
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -271,6 +271,9 @@ class FontFallbackDocumentListener(
     }
 }
 
+/** Shared because it is only ever read; a fresh one per paint was pure garbage. */
+private val EMPTY_INSETS = Insets(0, 0, 0, 0)
+
 private fun toBufferedImage(image: Image): BufferedImage {
     if (image is BufferedImage) return image
     val buffered = BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB)
@@ -316,6 +319,14 @@ class AdvancedTextPane(
      */
     var showCharCount: Boolean = false
         set(value) { field = value; repaint() }
+
+    // Paint-path caches. This component repaints on every caret blink, so anything allocated in
+    // paintComponent is allocated roughly twice a second per pane, forever.
+    private var cachedCounterFont: Font? = null
+    private var cachedCounterBase: Font? = null
+    private var cachedCounterValue: Int = -1
+    private var cachedCounterText: String = ""
+    private var cachedDisabledFg: Color? = null
 
     private val contextMenu: JPopupMenu by lazy { createContextMenu() }
     private val fallbackListener: FontFallbackDocumentListener
@@ -457,38 +468,68 @@ class AdvancedTextPane(
     // -----------------------------------------------------------------------
 
     override fun paintComponent(g: Graphics) {
-        val g2 = g as Graphics2D
-        g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
-        g2.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON)
-        super.paintComponent(g)
+        // Painted on a copy. Rendering hints set on the Graphics Swing handed us outlive this
+        // method and change how sibling components are drawn afterwards; AdvancedCaret already
+        // saves and restores for the same reason, and this half of the file did not.
+        val g2 = g.create() as Graphics2D
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+            g2.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON)
+            super.paintComponent(g2)
 
-        // Use document.length (O(1)) instead of text.length (O(n) serialisation).
-        val docLen     = document.length
-        val insets     = margin ?: Insets(0, 0, 0, 0)
-        val disabledFg = UIManager.getColor("Label.disabledForeground") ?: Color.GRAY
-        val ltr        = componentOrientation.isLeftToRight
+            // Use document.length (O(1)) instead of text.length (O(n) serialisation).
+            val docLen = document.length
+            val hasHint = docLen == 0 && hintText.isNotBlank()
+            val hasCounter = showCharCount && docLen > 0
+            if (!hasHint && !hasCounter) return
 
-        // Placeholder / hint text — drawn only when the pane is empty.
-        if (docLen == 0 && hintText.isNotBlank()) {
-            g2.font  = font
-            g2.color = disabledFg
-            val fm = g2.fontMetrics
-            val x  = if (ltr) insets.left + 2 else width - insets.right - 2 - fm.stringWidth(hintText)
-            val y  = insets.top + fm.ascent
-            g2.drawString(hintText, x, y)
+            // Only touched when something is actually drawn — paint runs on every caret blink.
+            val insets = margin ?: EMPTY_INSETS
+            val disabledFg = cachedDisabledFg
+                ?: (UIManager.getColor("Label.disabledForeground") ?: Color.GRAY).also { cachedDisabledFg = it }
+            val ltr = componentOrientation.isLeftToRight
+
+            if (hasHint) {
+                g2.font = font
+                g2.color = disabledFg
+                val fm = g2.fontMetrics
+                val x = if (ltr) insets.left + 2 else width - insets.right - 2 - fm.stringWidth(hintText)
+                val y = insets.top + fm.ascent
+                g2.drawString(hintText, x, y)
+            }
+
+            if (hasCounter) {
+                val counterFont = counterFont()
+                val counterStr = counterText(docLen)
+                g2.font = counterFont
+                g2.color = disabledFg
+                val fm = g2.getFontMetrics(counterFont)
+                val x = if (ltr) width - insets.right - fm.stringWidth(counterStr) - 2 else insets.left + 2
+                val y = height - insets.bottom - 2
+                g2.drawString(counterStr, x, y)
+            }
+        } finally {
+            g2.dispose()
         }
+    }
 
-        // Character count — drawn in the bottom corner when enabled and there is text.
-        if (showCharCount && docLen > 0) {
-            val counterFont = font.deriveFont(font.size2D - 1f)
-            val counterStr  = docLen.toString()
-            g2.font  = counterFont
-            g2.color = disabledFg
-            val fm = g2.getFontMetrics(counterFont)
-            val x  = if (ltr) width - insets.right - fm.stringWidth(counterStr) - 2 else insets.left + 2
-            val y  = height - insets.bottom - 2
-            g2.drawString(counterStr, x, y)
+    /** Derived once per font rather than on every paint — `deriveFont` is not free. */
+    private fun counterFont(): Font {
+        val base = font
+        if (cachedCounterBase !== base || cachedCounterFont == null) {
+            cachedCounterBase = base
+            cachedCounterFont = base.deriveFont(base.size2D - 1f)
         }
+        return cachedCounterFont!!
+    }
+
+    /** The count changes far less often than the pane repaints, so the string is kept. */
+    private fun counterText(length: Int): String {
+        if (cachedCounterValue != length) {
+            cachedCounterValue = length
+            cachedCounterText = length.toString()
+        }
+        return cachedCounterText
     }
 
     // -----------------------------------------------------------------------
@@ -735,6 +776,11 @@ class AdvancedTextPane(
     override fun updateUI() {
         super.updateUI()
         putClientProperty(HONOR_DISPLAY_PROPERTIES, true)
+        // A theme switch invalidates the cached colour and the font derived from the old one.
+        // Swing calls this for us then, which is why the caches need no listener of their own.
+        cachedCounterFont = null
+        cachedCounterBase = null
+        cachedDisabledFg = null
     }
 
     override fun getScrollableTracksViewportWidth(): Boolean =

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
@@ -3,6 +3,7 @@ package com.github.ahatem.qtranslate.ui.swing.shared.widgets
 import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.ui.swing.shared.util.isRTL
 import java.awt.BorderLayout
+import java.awt.Color
 import java.awt.ComponentOrientation
 import java.awt.Dimension
 import javax.swing.BorderFactory
@@ -18,11 +19,22 @@ import javax.swing.UIManager
  * word would hand you the word *and* a dictionary entry, which is almost never what was wanted.
  * Keeping it out of the output pane keeps copy honest.
  *
- * Styled as an aside — smaller, dimmer, indented to the same measure as the text above — because
- * it is a detail attached to the answer and not the answer. It hides itself entirely when there is
- * nothing to say, so a multi-word translation is laid out exactly as it was before this existed.
+ * Styled as an aside — smaller, dimmer, set apart from the answer — because it is a detail
+ * attached to the answer and not the answer. It hides itself entirely when there is nothing to
+ * say, so a multi-word translation is laid out exactly as it was before this existed.
+ *
+ * @param showDivider whether to draw a hairline above the definition.
+ *
+ * True where the strip is the only thing marking the boundary — the popup, whose content pane
+ * draws nothing of its own, and where the rule is exactly right. False beneath the main window's
+ * output pane, which already has a border of its own: a second line immediately below it reads as
+ * a doubled rule and cuts the definition off into a band rather than attaching it to the
+ * translation. The two placements genuinely differ, so this is a parameter rather than a single
+ * choice imposed on both.
  */
-class DefinitionStrip : JPanel(BorderLayout()) {
+class DefinitionStrip(private val showDivider: Boolean = true) : JPanel(BorderLayout()) {
+
+    private val borderColor: Color get() = UIManager.getColor("Component.borderColor") ?: Color.GRAY
 
     private val text = JTextArea().apply {
         isEditable = false
@@ -89,20 +101,26 @@ class DefinitionStrip : JPanel(BorderLayout()) {
         repaint()
     }
 
-    /**
-     * Spacing only — no rule of its own.
-     *
-     * The output pane it sits beneath already draws a border, and a second hairline immediately
-     * below that read as a doubled line and made the definition look like a separate band rather
-     * than a note about the translation. Indented to the same measure as the text above so the
-     * two line up instead of the definition running to the panel edge.
-     */
     private fun applyBorder() {
-        border = BorderFactory.createEmptyBorder(
-            UIScale.scale(4),
-            UIScale.scale(10),
-            UIScale.scale(6),
-            UIScale.scale(10)
-        )
+        border = if (showDivider) {
+            BorderFactory.createCompoundBorder(
+                BorderFactory.createMatteBorder(1, 0, 0, 0, borderColor),
+                BorderFactory.createEmptyBorder(
+                    UIScale.scale(6),
+                    UIScale.scale(8),
+                    UIScale.scale(6),
+                    UIScale.scale(8)
+                )
+            )
+        } else {
+            // Spacing alone. Indented to the same measure as the text above, so the definition
+            // lines up with the translation instead of running wider than the box it belongs to.
+            BorderFactory.createEmptyBorder(
+                UIScale.scale(4),
+                UIScale.scale(10),
+                UIScale.scale(6),
+                UIScale.scale(10)
+            )
+        }
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
@@ -3,6 +3,7 @@ package com.github.ahatem.qtranslate.ui.swing.shared.widgets
 import com.formdev.flatlaf.util.UIScale
 import java.awt.BorderLayout
 import java.awt.Color
+import java.awt.Dimension
 import javax.swing.BorderFactory
 import javax.swing.JPanel
 import javax.swing.JTextArea
@@ -41,6 +42,22 @@ class DefinitionStrip : JPanel(BorderLayout()) {
         isVisible = false
         applyBorder()
         add(text, BorderLayout.CENTER)
+    }
+
+    /**
+     * Height measured against the width this strip has actually been given.
+     *
+     * A wrapping `JTextArea` reports a preferred size based on its own current width, which in
+     * `BorderLayout.SOUTH` is whatever it was last set to rather than what it is about to get.
+     * Left alone it asks for one line and gets one line, clipping a two-line definition — or asks
+     * for its full unwrapped width and is squeezed flat. Measuring at the real width avoids both.
+     */
+    override fun getPreferredSize(): Dimension {
+        val insets = insets
+        val available = (width - insets.left - insets.right).coerceAtLeast(1)
+        text.setSize(available, Int.MAX_VALUE)
+        val textHeight = text.preferredSize.height
+        return Dimension(0, textHeight + insets.top + insets.bottom)
     }
 
     /** Blank hides the strip; anything else shows it. */

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
@@ -1,8 +1,9 @@
 package com.github.ahatem.qtranslate.ui.swing.shared.widgets
 
 import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.ui.swing.shared.util.isRTL
 import java.awt.BorderLayout
-import java.awt.Color
+import java.awt.ComponentOrientation
 import java.awt.Dimension
 import javax.swing.BorderFactory
 import javax.swing.JPanel
@@ -17,13 +18,11 @@ import javax.swing.UIManager
  * word would hand you the word *and* a dictionary entry, which is almost never what was wanted.
  * Keeping it out of the output pane keeps copy honest.
  *
- * Styled as an aside — smaller, dimmer, above a hairline — because it is a detail attached to the
- * answer and not the answer. It hides itself entirely when there is nothing to say, so a
- * multi-word translation is laid out exactly as it was before this existed.
+ * Styled as an aside — smaller, dimmer, indented to the same measure as the text above — because
+ * it is a detail attached to the answer and not the answer. It hides itself entirely when there is
+ * nothing to say, so a multi-word translation is laid out exactly as it was before this existed.
  */
 class DefinitionStrip : JPanel(BorderLayout()) {
-
-    private val borderColor: Color get() = UIManager.getColor("Component.borderColor") ?: Color.GRAY
 
     private val text = JTextArea().apply {
         isEditable = false
@@ -63,7 +62,19 @@ class DefinitionStrip : JPanel(BorderLayout()) {
     /** Blank hides the strip; anything else shows it. */
     fun render(definition: String) {
         val wanted = definition.isNotBlank()
-        if (wanted && text.text != definition) text.text = definition
+        if (wanted && text.text != definition) {
+            text.text = definition
+            // Follows the definition's own script, not the interface language. A definition of an
+            // Arabic word is Arabic, and left-aligning it under a right-aligned translation reads
+            // as a stray line of text rather than a note about the word above it.
+            val orientation =
+                if (definition.isRTL()) ComponentOrientation.RIGHT_TO_LEFT
+                else ComponentOrientation.LEFT_TO_RIGHT
+            if (text.componentOrientation != orientation) {
+                text.componentOrientation = orientation
+                componentOrientation = orientation
+            }
+        }
         if (isVisible != wanted) {
             isVisible = wanted
             revalidate()
@@ -78,15 +89,20 @@ class DefinitionStrip : JPanel(BorderLayout()) {
         repaint()
     }
 
+    /**
+     * Spacing only — no rule of its own.
+     *
+     * The output pane it sits beneath already draws a border, and a second hairline immediately
+     * below that read as a doubled line and made the definition look like a separate band rather
+     * than a note about the translation. Indented to the same measure as the text above so the
+     * two line up instead of the definition running to the panel edge.
+     */
     private fun applyBorder() {
-        border = BorderFactory.createCompoundBorder(
-            BorderFactory.createMatteBorder(1, 0, 0, 0, borderColor),
-            BorderFactory.createEmptyBorder(
-                UIScale.scale(6),
-                UIScale.scale(8),
-                UIScale.scale(6),
-                UIScale.scale(8)
-            )
+        border = BorderFactory.createEmptyBorder(
+            UIScale.scale(4),
+            UIScale.scale(10),
+            UIScale.scale(6),
+            UIScale.scale(10)
         )
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/DefinitionStrip.kt
@@ -1,0 +1,75 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.widgets
+
+import com.formdev.flatlaf.util.UIScale
+import java.awt.BorderLayout
+import java.awt.Color
+import javax.swing.BorderFactory
+import javax.swing.JPanel
+import javax.swing.JTextArea
+import javax.swing.UIManager
+
+/**
+ * A short definition shown under a translation, for single words.
+ *
+ * Deliberately a separate strip rather than text appended to the translation itself, which is how
+ * this used to be done elsewhere. Appended text ends up in the clipboard: copying a translated
+ * word would hand you the word *and* a dictionary entry, which is almost never what was wanted.
+ * Keeping it out of the output pane keeps copy honest.
+ *
+ * Styled as an aside — smaller, dimmer, above a hairline — because it is a detail attached to the
+ * answer and not the answer. It hides itself entirely when there is nothing to say, so a
+ * multi-word translation is laid out exactly as it was before this existed.
+ */
+class DefinitionStrip : JPanel(BorderLayout()) {
+
+    private val borderColor: Color get() = UIManager.getColor("Component.borderColor") ?: Color.GRAY
+
+    private val text = JTextArea().apply {
+        isEditable = false
+        isOpaque = false
+        lineWrap = true
+        wrapStyleWord = true
+        // Not focusable and not in the tab order: it is something to glance at, and stopping on
+        // it while tabbing between the real controls would be a nuisance.
+        isFocusable = false
+        putClientProperty("FlatLaf.styleClass", "small")
+        foreground = UIManager.getColor("Label.disabledForeground")
+    }
+
+    init {
+        isOpaque = false
+        isVisible = false
+        applyBorder()
+        add(text, BorderLayout.CENTER)
+    }
+
+    /** Blank hides the strip; anything else shows it. */
+    fun render(definition: String) {
+        val wanted = definition.isNotBlank()
+        if (wanted && text.text != definition) text.text = definition
+        if (isVisible != wanted) {
+            isVisible = wanted
+            revalidate()
+            repaint()
+        }
+    }
+
+    /** Re-reads the theme's colours, which borders and foregrounds do not do by themselves. */
+    fun refreshTheme() {
+        text.foreground = UIManager.getColor("Label.disabledForeground")
+        applyBorder()
+        repaint()
+    }
+
+    private fun applyBorder() {
+        border = BorderFactory.createCompoundBorder(
+            BorderFactory.createMatteBorder(1, 0, 0, 0, borderColor),
+            BorderFactory.createEmptyBorder(
+                UIScale.scale(6),
+                UIScale.scale(8),
+                UIScale.scale(6),
+                UIScale.scale(8)
+            )
+        )
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
@@ -383,6 +383,37 @@ class FloatingPopupBehavior(
         isPointerOver = false
     }
 
+    /**
+     * Closes the popup when the user presses somewhere outside it.
+     *
+     * Watched globally, because the click that dismisses a popup lands in another application
+     * entirely — the document being read, usually. A press rather than a release, so the popup is
+     * gone by the time the click takes effect where it landed.
+     *
+     * Pinned popups ignore it: staying put regardless is what a pin means. [enabled] is read on
+     * each press so the setting takes effect without reinstalling anything.
+     */
+    fun installClickOutsideToClose(enabled: () -> Boolean, onClose: () -> Unit) {
+        if (outsideClickListener != null) return
+        val listener = AWTEventListener { event ->
+            val mouse = event as? MouseEvent ?: return@AWTEventListener
+            if (mouse.id != MouseEvent.MOUSE_PRESSED) return@AWTEventListener
+            if (!window.isVisible || isPinned || !enabled()) return@AWTEventListener
+
+            val screenPoint = mouse.locationOnScreen ?: return@AWTEventListener
+            if (!window.bounds.contains(screenPoint)) SwingUtilities.invokeLater(onClose)
+        }
+        outsideClickListener = listener
+        Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.MOUSE_EVENT_MASK)
+    }
+
+    fun uninstallClickOutsideToClose() {
+        outsideClickListener?.let { Toolkit.getDefaultToolkit().removeAWTEventListener(it) }
+        outsideClickListener = null
+    }
+
+    private var outsideClickListener: AWTEventListener? = null
+
     /** Everything a popup must let go of when it is hidden. */
     fun onHidden() {
         stopIdleHide()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
@@ -373,6 +373,21 @@ class FloatingPopupBehavior(
         pointerListener = listener
         Toolkit.getDefaultToolkit()
             .addAWTEventListener(listener, AWTEvent.MOUSE_MOTION_EVENT_MASK or AWTEvent.MOUSE_EVENT_MASK)
+        samplePointer()
+    }
+
+    /**
+     * Reads where the pointer is right now, rather than waiting to be told it moved.
+     *
+     * These popups open at the cursor, so the pointer is frequently inside one the instant it
+     * appears — and then never generates an enter event, because it never crossed the boundary.
+     * The popup therefore believed the pointer was elsewhere and counted down to hiding itself
+     * while the user was sitting over it, reading.
+     */
+    fun samplePointer() {
+        val pointer = MouseInfo.getPointerInfo()?.location ?: return
+        isPointerOver = window.isVisible && window.bounds.contains(pointer)
+        if (isPointerOver) stopIdleHide()
     }
 
     fun uninstallPointerTracking() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
@@ -1,0 +1,223 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.widgets
+
+import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.core.settings.data.Position
+import com.github.ahatem.qtranslate.core.settings.data.Size
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Frame
+import java.awt.Insets
+import java.awt.MouseInfo
+import java.awt.event.ActionEvent
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.beans.PropertyChangeListener
+import javax.swing.AbstractAction
+import javax.swing.BorderFactory
+import javax.swing.JComponent
+import javax.swing.JDialog
+import javax.swing.KeyStroke
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+
+/**
+ * The window behaviour shared by the floating popups — translate, dictionary, images.
+ *
+ * ### Why a helper rather than a base class
+ * The three popups agree about how their *window* behaves and disagree about everything inside
+ * it, including deliberately: the image popup has no idle-hide, because a grid of pictures is
+ * compared and clicked through while a definition is read in a couple of seconds. A base class
+ * would have to expose each of those differences as a hook, and the fade and idle-hide logic in
+ * the two older dialogs carries edge cases that were found the hard way — a mouse leaving during
+ * a fade, a drag that must suspend the hide timer. Those stay where they were debugged. What
+ * moves here is the part that was three identical copies.
+ *
+ * ### What it does not own
+ * Fade animation, idle-hide, and mouse-over tracking. Two of the three popups have them; moving
+ * them would mean rewriting working code for symmetry's sake.
+ */
+class FloatingPopupBehavior(
+    private val window: JDialog,
+    private val owner: Frame,
+    minimumSize: Dimension,
+    private val pinnedBorderWidth: Int = 4,
+    private val resizeHandle: Int = 8
+) {
+
+    /**
+     * True once the user has dragged the window, after which it stops repositioning itself.
+     *
+     * A popup that jumped back to the pointer after being deliberately moved would be fighting
+     * the person using it.
+     */
+    var wasManuallyMoved: Boolean = false
+        private set
+
+    private var themeListener: PropertyChangeListener? = null
+
+    private val borderColor: Color get() = UIManager.getColor("Component.borderColor") ?: Color.GRAY
+    private val accentColor: Color
+        get() = UIManager.getColor("Component.focusedBorderColor")
+            ?: UIManager.getColor("Component.accentColor")
+            ?: borderColor
+
+    init {
+        window.isUndecorated = true
+        window.isAlwaysOnTop = true
+        window.defaultCloseOperation = JDialog.DO_NOTHING_ON_CLOSE
+        window.minimumSize = minimumSize
+    }
+
+    /**
+     * Makes [handle] the part of the window that can be dragged, and records that it was.
+     *
+     * [onMoved] is called with the resting position so the caller can persist it.
+     */
+    fun installDrag(handle: JComponent, onMoved: (Position) -> Unit) {
+        ComponentMover.builder()
+            .destinationComponent(window)
+            .build()
+            .register(handle)
+
+        handle.addMouseListener(object : MouseAdapter() {
+            override fun mouseReleased(e: MouseEvent) {
+                wasManuallyMoved = true
+                onMoved(Position(window.x.coerceAtLeast(0), window.y.coerceAtLeast(0)))
+            }
+        })
+    }
+
+    /** Border-edge resizing, reporting the final size so the caller can persist it. */
+    fun installResize(onResized: (Size) -> Unit, onStart: () -> Unit = {}, onEnd: () -> Unit = {}) {
+        val inset = UIScale.scale(resizeHandle)
+        ComponentResizer.builder()
+            .dragInsets(Insets(inset, inset, inset, inset))
+            .minimumSize(window.minimumSize)
+            .onResizeStart { onStart() }
+            .onResizeEnd {
+                onResized(Size(window.width, window.height))
+                onEnd()
+            }
+            .build()
+            .register(window)
+    }
+
+    /**
+     * Escape handling.
+     *
+     * [onEscape] returns true when it consumed the key — a popup showing a drilled-in view uses
+     * that to step back out rather than closing and discarding what the user was looking at.
+     */
+    fun installEscape(onEscape: () -> Boolean) {
+        window.rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+            .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), ESCAPE_ACTION)
+        window.rootPane.actionMap.put(ESCAPE_ACTION, object : AbstractAction() {
+            override fun actionPerformed(e: ActionEvent) {
+                onEscape()
+            }
+        })
+    }
+
+    /**
+     * The border that marks a pinned popup.
+     *
+     * Rebuilt on each call rather than stored, because a border keeps the colour it was handed and
+     * a look-and-feel change does not revisit it.
+     */
+    fun applyPinBorder(pinned: Boolean, target: JComponent = window.rootPane) {
+        target.border = if (pinned) {
+            BorderFactory.createLineBorder(accentColor, pinnedBorderWidth)
+        } else {
+            val coloured = 2
+            val padding = (pinnedBorderWidth - coloured).coerceAtLeast(0)
+            BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(borderColor, coloured),
+                BorderFactory.createEmptyBorder(padding, padding, padding, padding)
+            )
+        }
+        target.revalidate()
+        target.repaint()
+    }
+
+    /**
+     * Places the window near the pointer, kept fully on the screen it appears on.
+     *
+     * Does nothing once the user has moved it themselves.
+     */
+    fun positionNearMouse(offset: Int = 12) {
+        if (wasManuallyMoved) return
+        val screen = window.graphicsConfiguration?.bounds ?: return centreOnOwner()
+        val pointer = MouseInfo.getPointerInfo()?.location ?: return centreOnOwner()
+        val scaled = UIScale.scale(offset)
+
+        // Flipped to the other side of the pointer when it will not fit, rather than clamped to
+        // the screen edge: clamping slides the popup back under the cursor, which then sits on
+        // top of the first thing the reader wants to look at. Taken from the dictionary popup,
+        // which had the better of the two behaviours.
+        var x = pointer.x + scaled
+        var y = pointer.y + scaled
+        if (x + window.width > screen.x + screen.width) x = pointer.x - window.width - scaled
+        if (y + window.height > screen.y + screen.height) y = pointer.y - window.height - scaled
+
+        window.setLocation(x.coerceAtLeast(screen.x), y.coerceAtLeast(screen.y))
+    }
+
+    /**
+     * Places the window beside the owner, falling back to its other side when there is no room.
+     *
+     * Used when the popup was opened by the application rather than by a gesture, where appearing
+     * at the pointer would put it wherever the mouse happened to be resting.
+     */
+    fun positionBesideOwner(gap: Int = 8) {
+        if (wasManuallyMoved) return
+        val screen = window.graphicsConfiguration?.bounds ?: return centreOnOwner()
+        val bounds = owner.bounds
+        val scaled = UIScale.scale(gap)
+
+        var x = bounds.x + bounds.width + scaled
+        if (x + window.width > screen.x + screen.width) x = bounds.x - window.width - scaled
+        val y = bounds.y + (bounds.height - window.height) / 2
+
+        window.setLocation(
+            x.coerceIn(screen.x, (screen.x + screen.width - window.width).coerceAtLeast(screen.x)),
+            y.coerceIn(screen.y, (screen.y + screen.height - window.height).coerceAtLeast(screen.y))
+        )
+    }
+
+    fun applyStoredPosition(position: Position) {
+        if (wasManuallyMoved) return
+        window.setLocation(position.x, position.y)
+    }
+
+    fun centreOnOwner() = window.setLocationRelativeTo(owner)
+
+    /** Forgets that the window was dragged, so the next open positions itself again. */
+    fun resetManualMove() {
+        wasManuallyMoved = false
+    }
+
+    /**
+     * Re-runs [onThemeChanged] whenever the look and feel changes.
+     *
+     * Held in a field so [uninstallTheme] can detach it: `UIManager` keeps its listeners for the
+     * life of the process, and an inline lambda could never be removed at all.
+     */
+    fun installTheme(onThemeChanged: () -> Unit) {
+        uninstallTheme()
+        val listener = PropertyChangeListener { event ->
+            if (event.propertyName == "lookAndFeel") SwingUtilities.invokeLater(onThemeChanged)
+        }
+        themeListener = listener
+        UIManager.addPropertyChangeListener(listener)
+    }
+
+    fun uninstallTheme() {
+        themeListener?.let { UIManager.removePropertyChangeListener(it) }
+        themeListener = null
+    }
+
+    private companion object {
+        const val ESCAPE_ACTION = "floating-popup-escape"
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
@@ -3,6 +3,7 @@ package com.github.ahatem.qtranslate.ui.swing.shared.widgets
 import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.core.settings.data.Position
 import com.github.ahatem.qtranslate.core.settings.data.Size
+import com.github.ahatem.qtranslate.ui.swing.shared.util.AppIcons
 import java.awt.AWTEvent
 import java.awt.Color
 import java.awt.Dimension
@@ -81,6 +82,9 @@ class FloatingPopupBehavior(
             ?: borderColor
 
     init {
+        // Applied here so every floating popup gets it: they are owned by the shared hidden
+        // frame, which carries Java's default icon and passes it on.
+        AppIcons.applyTo(window)
         window.isUndecorated = true
         window.isAlwaysOnTop = true
         window.defaultCloseOperation = JDialog.DO_NOTHING_ON_CLOSE

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
@@ -398,37 +398,6 @@ class FloatingPopupBehavior(
         isPointerOver = false
     }
 
-    /**
-     * Closes the popup when the user presses somewhere outside it.
-     *
-     * Watched globally, because the click that dismisses a popup lands in another application
-     * entirely — the document being read, usually. A press rather than a release, so the popup is
-     * gone by the time the click takes effect where it landed.
-     *
-     * Pinned popups ignore it: staying put regardless is what a pin means. [enabled] is read on
-     * each press so the setting takes effect without reinstalling anything.
-     */
-    fun installClickOutsideToClose(enabled: () -> Boolean, onClose: () -> Unit) {
-        if (outsideClickListener != null) return
-        val listener = AWTEventListener { event ->
-            val mouse = event as? MouseEvent ?: return@AWTEventListener
-            if (mouse.id != MouseEvent.MOUSE_PRESSED) return@AWTEventListener
-            if (!window.isVisible || isPinned || !enabled()) return@AWTEventListener
-
-            val screenPoint = mouse.locationOnScreen ?: return@AWTEventListener
-            if (!window.bounds.contains(screenPoint)) SwingUtilities.invokeLater(onClose)
-        }
-        outsideClickListener = listener
-        Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.MOUSE_EVENT_MASK)
-    }
-
-    fun uninstallClickOutsideToClose() {
-        outsideClickListener?.let { Toolkit.getDefaultToolkit().removeAWTEventListener(it) }
-        outsideClickListener = null
-    }
-
-    private var outsideClickListener: AWTEventListener? = null
-
     /** Everything a popup must let go of when it is hidden. */
     fun onHidden() {
         stopIdleHide()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
@@ -44,6 +44,16 @@ import kotlin.math.abs
  *
  * ### What it does not own
  * Anything to do with content. What a popup shows, and when it asks for more of it, is its own.
+ *
+ * ### Ownership
+ * These popups must be constructed with a **null owner**, not with the main window, and [owner]
+ * here is a positioning reference only. AWT ties an owned window's fate to its owner: while the
+ * owner is hidden or iconified the platform suppresses windows it owns, and showing one can pull
+ * the owner back into view. This application lives in the tray, so its main window is hidden or
+ * iconified most of the time — which made a hotkey sometimes summon the main window, sometimes
+ * dismiss it, and sometimes produce no popup at all, depending on the state the window was last
+ * left in. A null owner gives Swing's shared hidden frame, which is never shown and never
+ * iconified, so none of that applies.
  */
 class FloatingPopupBehavior(
     private val window: JDialog,

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/FloatingPopupBehavior.kt
@@ -3,12 +3,15 @@ package com.github.ahatem.qtranslate.ui.swing.shared.widgets
 import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.core.settings.data.Position
 import com.github.ahatem.qtranslate.core.settings.data.Size
+import java.awt.AWTEvent
 import java.awt.Color
 import java.awt.Dimension
 import java.awt.Frame
 import java.awt.Insets
 import java.awt.MouseInfo
+import java.awt.Toolkit
 import java.awt.event.ActionEvent
+import java.awt.event.AWTEventListener
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -19,7 +22,9 @@ import javax.swing.JComponent
 import javax.swing.JDialog
 import javax.swing.KeyStroke
 import javax.swing.SwingUtilities
+import javax.swing.Timer
 import javax.swing.UIManager
+import kotlin.math.abs
 
 /**
  * The window behaviour shared by the floating popups — translate, dictionary, images.
@@ -27,15 +32,18 @@ import javax.swing.UIManager
  * ### Why a helper rather than a base class
  * The three popups agree about how their *window* behaves and disagree about everything inside
  * it, including deliberately: the image popup has no idle-hide, because a grid of pictures is
- * compared and clicked through while a definition is read in a couple of seconds. A base class
- * would have to expose each of those differences as a hook, and the fade and idle-hide logic in
- * the two older dialogs carries edge cases that were found the hard way — a mouse leaving during
- * a fade, a drag that must suspend the hide timer. Those stay where they were debugged. What
- * moves here is the part that was three identical copies.
+ * compared and clicked through while a definition is read in a couple of seconds. Composition
+ * lets that be a decision each popup makes — it simply never calls [configureIdleHide] — rather
+ * than a hook a base class has to invent.
+ *
+ * ### What it owns
+ * Window flags, the pinned border, Escape, dragging, resizing, geometry, positioning, the theme
+ * listener, fading, idle-hide and pointer presence. All of it existed two or three times over
+ * before, closely enough that the copies shared their bugs: an idle-close timer nothing held a
+ * reference to, and a countdown no amount of typing would reset.
  *
  * ### What it does not own
- * Fade animation, idle-hide, and mouse-over tracking. Two of the three popups have them; moving
- * them would mean rewriting working code for symmetry's sake.
+ * Anything to do with content. What a popup shows, and when it asks for more of it, is its own.
  */
 class FloatingPopupBehavior(
     private val window: JDialog,
@@ -217,7 +225,159 @@ class FloatingPopupBehavior(
         themeListener = null
     }
 
+    // ── Fading, idle-hide, and pointer presence ───────────────────────────────
+    //
+    // These were written twice, identically enough that both copies carried the same two bugs:
+    // an idle-close timer nothing held a reference to, and a countdown that no amount of typing
+    // would reset. One implementation, fixed once.
+
+    private var fadeTimer: Timer? = null
+    private var idleTimer: Timer? = null
+    private var idleCloseTimer: Timer? = null
+    private var exitDebounceTimer: Timer? = null
+    private var pointerListener: AWTEventListener? = null
+
+    private var idleDelayMs: () -> Int = { 8_000 }
+    private var idleFadeMs: Int = 160
+    private var restingOpacity: () -> Float = { 1f }
+    private var onIdleExpired: () -> Unit = {}
+
+    /** Set by the owner whenever the user pins or unpins; nothing auto-hides while pinned. */
+    var isPinned: Boolean = false
+
+    /** True while the pointer is inside the window. */
+    var isPointerOver: Boolean = false
+        private set
+
+    /**
+     * @param delayMs read fresh on each start so a settings change takes effect immediately.
+     * @param restingOpacity the opacity to return to once the pointer leaves.
+     * @param onExpired how the owner dismisses itself. Route this through the application's
+     *   state rather than hiding the window directly, or the rest of the app goes on believing
+     *   the popup is open.
+     */
+    fun configureIdleHide(
+        delayMs: () -> Int,
+        fadeMs: Int = 160,
+        restingOpacity: () -> Float,
+        onExpired: () -> Unit
+    ) {
+        this.idleDelayMs = delayMs
+        this.idleFadeMs = fadeMs
+        this.restingOpacity = restingOpacity
+        this.onIdleExpired = onExpired
+    }
+
+    fun startIdleHide() {
+        stopIdleHide()
+        if (isPinned) return
+        idleTimer = Timer(idleDelayMs().coerceAtLeast(500)) { event ->
+            (event.source as Timer).stop()
+            if (isPinned) return@Timer
+            fadeTo(0f, idleFadeMs)
+            // Held, so stopIdleHide can cancel it. Left anonymous, a popup that had begun fading
+            // closed itself regardless of the user moving back onto it or reopening it.
+            idleCloseTimer = Timer(idleFadeMs + 20) { closeEvent ->
+                (closeEvent.source as Timer).stop()
+                if (!isPinned) onIdleExpired()
+            }.apply { isRepeats = false; start() }
+        }.apply { isRepeats = false; start() }
+    }
+
+    fun stopIdleHide() {
+        idleTimer?.stop()
+        idleCloseTimer?.stop()
+        idleCloseTimer = null
+    }
+
+    /** Restarts the countdown because the user did something — typing counts. */
+    fun noteActivity() {
+        if (window.isVisible && !isPinned) startIdleHide()
+    }
+
+    /**
+     * Animates opacity, cancelling any fade already running.
+     *
+     * Restarting rather than refusing while one is in flight: an earlier version guarded against
+     * re-entry and so dropped the fade back to transparency whenever the mouse entered and left
+     * within a single animation.
+     */
+    fun fadeTo(target: Float, durationMs: Int = idleFadeMs) {
+        fadeTimer?.stop()
+        val start = window.opacity
+        val steps = FADE_STEPS
+        val delay = (durationMs / steps).coerceAtLeast(10)
+        var step = 0
+        fadeTimer = Timer(delay) { event ->
+            step++
+            val value = start + (target - start) * (step.toFloat() / steps)
+            if (abs(window.opacity - value) > 0.01f) window.opacity = value.coerceIn(0f, 1f)
+            if (step >= steps) (event.source as Timer).stop()
+        }.apply { isRepeats = true; start() }
+    }
+
+    /**
+     * Watches the pointer globally so the popup can wake when it is hovered.
+     *
+     * Global because the popup must react to a pointer that never enters any of its components —
+     * crossing the window edge is enough. Screen bounds are compared directly rather than
+     * converting coordinates, which rounds and makes the state oscillate at the border.
+     */
+    fun installPointerTracking(exitDebounceMs: Int = 120) {
+        if (pointerListener != null) return
+        val listener = AWTEventListener { event ->
+            val mouse = event as? MouseEvent ?: return@AWTEventListener
+            if (mouse.id != MouseEvent.MOUSE_MOVED &&
+                mouse.id != MouseEvent.MOUSE_ENTERED &&
+                mouse.id != MouseEvent.MOUSE_EXITED
+            ) return@AWTEventListener
+
+            SwingUtilities.invokeLater {
+                if (!window.isVisible) return@invokeLater
+                val pointer = MouseInfo.getPointerInfo()?.location ?: return@invokeLater
+                val over = window.bounds.contains(pointer)
+                if (over == isPointerOver) return@invokeLater
+                isPointerOver = over
+
+                if (over) {
+                    exitDebounceTimer?.stop()
+                    stopIdleHide()
+                    fadeTo(1f)
+                } else {
+                    // Debounced, so a wiggle across the border does not flicker the window.
+                    exitDebounceTimer?.stop()
+                    exitDebounceTimer = Timer(exitDebounceMs) { timerEvent ->
+                        (timerEvent.source as Timer).stop()
+                        if (!isPointerOver && !isPinned) {
+                            fadeTo(restingOpacity())
+                            startIdleHide()
+                        }
+                    }.apply { isRepeats = false; start() }
+                }
+            }
+        }
+        pointerListener = listener
+        Toolkit.getDefaultToolkit()
+            .addAWTEventListener(listener, AWTEvent.MOUSE_MOTION_EVENT_MASK or AWTEvent.MOUSE_EVENT_MASK)
+    }
+
+    fun uninstallPointerTracking() {
+        exitDebounceTimer?.stop()
+        exitDebounceTimer = null
+        pointerListener?.let { Toolkit.getDefaultToolkit().removeAWTEventListener(it) }
+        pointerListener = null
+        isPointerOver = false
+    }
+
+    /** Everything a popup must let go of when it is hidden. */
+    fun onHidden() {
+        stopIdleHide()
+        fadeTimer?.stop()
+        uninstallPointerTracking()
+    }
+
     private companion object {
         const val ESCAPE_ACTION = "floating-popup-escape"
+        const val FADE_STEPS = 8
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/InlineLoadingBar.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/InlineLoadingBar.kt
@@ -1,0 +1,50 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.widgets
+
+import com.formdev.flatlaf.util.UIScale
+import java.awt.BorderLayout
+import java.awt.Dimension
+import javax.swing.JPanel
+import javax.swing.JProgressBar
+
+/**
+ * A hairline progress bar for work happening inside a popup that already has something on screen.
+ *
+ * The popups used to blank their content while reloading, which threw away the very thing the
+ * reader was in the middle of — the previous translation or definition, still perfectly useful
+ * while the next one arrives. This says "working" without taking anything away.
+ *
+ * The bar occupies a fixed height whether or not it is showing, so appearing and disappearing
+ * never moves the content beneath it. A progress bar that shoves the text down by three pixels
+ * every time it runs is worse than no progress bar.
+ */
+class InlineLoadingBar : JPanel(BorderLayout()) {
+
+    private val bar = JProgressBar().apply {
+        isIndeterminate = true
+        // Hidden rather than absent, so this panel keeps its height either way.
+        isVisible = false
+        preferredSize = Dimension(0, UIScale.scale(BAR_HEIGHT))
+        border = null
+    }
+
+    var isLoading: Boolean = false
+        set(value) {
+            if (field == value) return
+            field = value
+            // Animating an indeterminate bar costs a repaint timer, so it only runs while shown.
+            bar.isIndeterminate = value
+            bar.isVisible = value
+        }
+
+    init {
+        isOpaque = false
+        preferredSize = Dimension(0, UIScale.scale(BAR_HEIGHT))
+        minimumSize = Dimension(0, UIScale.scale(BAR_HEIGHT))
+        add(bar, BorderLayout.CENTER)
+    }
+
+    private companion object {
+        /** Thin enough to read as a hint rather than a component. */
+        const val BAR_HEIGHT = 3
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/update/UpdateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/update/UpdateDialog.kt
@@ -27,7 +27,7 @@ import javax.swing.JScrollPane
 import javax.swing.UIManager
 import javax.swing.event.HyperlinkEvent
 
-class UpdateDialog(owner: Frame) : JDialog(owner, false) {
+class UpdateDialog(owner: Frame) : JDialog(null as Frame?, false) {
 
     // ------------------------------------------------------------------ UI
     private val versionBanner = JLabel().apply {
@@ -90,6 +90,7 @@ class UpdateDialog(owner: Frame) : JDialog(owner, false) {
 
     // ------------------------------------------------------------------ init
     init {
+        com.github.ahatem.qtranslate.ui.swing.shared.util.AppIcons.applyTo(this)
         defaultCloseOperation = HIDE_ON_CLOSE
         isResizable = true
 


### PR DESCRIPTION
Replaces #170, which had to be closed to unblock the merge of #169 — GitHub will not merge a pull request that has another stacked on it, and once #169 merged its branch was deleted, leaving #170 with no base to reopen against. Same 16 commits, rebased onto `develop`.

Unrelated to the plugin API work; it accumulated on the same branch and was split out at review time.

---

An audit of the three floating popups and `AdvancedTextPane`, then the defects it found, then the ones found by using the result.

### Leaks and correctness

**A listener leak that grows with use.** `SettingsDialog` and `DynamicPluginSettingsDialog` registered a `UIManager` listener as an inline lambda and never removed it — and a fresh settings dialog is built on every open. Each open pinned an entire dialog tree in memory permanently and added another stale handler to every later theme change. Passing a lambda made it unremovable even in principle.

**None of the three popups survived a theme change.** All captured colours into fields at construction and none listened for the switch; they live for the whole session, so this was permanent.

**Owned windows.** Every popup, plus `DictionaryDialog`, `HistoryDialog`, `UpdateDialog` and the loading marker, was owned by the main window. AWT ties an owned window's fate to its owner, and this application lives in the tray — so a hotkey would sometimes summon the main window, sometimes push it away, and sometimes produce no popup at all, depending on the state the window was left in. They now use the shared hidden frame. The loading marker had never been visible at all for exactly this reason: it exists for the case where the main window is hidden.

**Double-Ctrl misfiring.** The "show main window" detector counted every Ctrl release, including the one ending a shortcut — so two hotkeys inside 400ms were indistinguishable from a deliberate double tap.

**Click-outside-to-close never worked.** It listened through AWT, which only sees events destined for this program's windows, while the dismissing click almost always lands in another application. Now on the native hook, and a setting.

### Show and hide

The idle-hide sequence armed a second timer nothing held, so a popup that began fading closed itself regardless — including after the user moved back onto it or reopened it. Quick Translate hid itself without telling the store, leaving the app believing it was open. Typing did not reset the dictionary's countdown. Pointer presence was only updated by a crossing event, so a popup opening *at* the cursor never noticed the pointer was already inside and hid itself while being read.

Re-triggering an open popup used to hide it. It now refreshes in place and restarts its countdown, driven by a trigger counter in the state — a dialog cannot otherwise distinguish "the user asked again" from the many unrelated renders it sees, and resetting on all of them would disable auto-hide entirely.

### Performance

`applyFontFallback` called `substring` once per font run — quadratic in allocation, while its own documentation promised no per-character allocation. `paintComponent` allocated a derived font, a string and an `Insets` on every caret blink, and mutated the shared `Graphics` hints without restoring them.

### Features

`FloatingPopupBehavior` collects the window behaviour all three popups had each written for themselves. Composition, not inheritance: the image popup has no idle-hide on purpose, and with a helper that is simply a call it does not make. Consolidating found that the copies had already drifted — the dictionary's fade carried a fix the translate popup never received.

A **definition strip** shows a short definition under single-word translations, in the popup and main window, with no click, replacing a dictionary popup that used to appear uninvited. It is a separate strip rather than text appended to the output — appended text ends up in the clipboard, and copying a translated word should not hand back a dictionary entry. Length is budgeted so it stays a glance, and it takes its direction from the definition's own script. Both sides of a translation are offered to the dictionary in turn, because the common dictionaries cover English thoroughly and most other languages barely at all.

Popup width is bounded by a comfortable line length measured in characters of the font in use, not by a fraction of the screen.

### Verification

`./gradlew build` green after rebasing onto `develop`; 6 tests on the definition budget rules. The window-level behaviour was exercised by hand throughout — most of these defects were found that way rather than by reading.