### PR TITLE
fix(ui): let the popup's Listen button stop playback

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -168,6 +168,7 @@ class MainAppFrame(
             // Reads the source text, not the translation — the popup is most often used
             // to check how the original word is pronounced.
             onListen = { mainStore.dispatch(MainIntent.ListenToText(TextSource.Input)) },
+            onStopListening = { mainStore.dispatch(MainIntent.StopTTS) },
             onCopy = { mainStore.state.value.translatedText.copyToClipboard() },
             onSavePosition = { pos ->
                 settingsStore.dispatch(
@@ -1411,6 +1412,7 @@ class MainAppFrame(
             translatedText = mainState.translatedText,
             isPinned = mainState.isQuickTranslateDialogPinned,
             triggerCount = mainState.quickTranslateTriggerCount,
+            isTtsPlaying = mainState.isTtsPlaying,
             definition = mainState.inlineDefinition,
 
             sourceLanguage = displaySourceLanguage,
@@ -1439,6 +1441,7 @@ class MainAppFrame(
                 copyTooltip = localizer.getString("common.copy"),
                 closeTooltip = localizer.getString("common.close"),
                 listenTooltip = localizer.getString("common.listen"),
+                stopListeningTooltip = localizer.getString("common.stop"),
                 pinTooltip = localizer.getString("common.pin"),
                 unpinTooltip = localizer.getString("common.unpin"),
                 loadingText = localizer.getString("common.loading")

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialog.kt
@@ -35,6 +35,7 @@ class QuickTranslateDialog(
     private val onDismiss: () -> Unit,
     onTranslatorSelected: (String) -> Unit,
     private val onListen: () -> Unit,
+    private val onStopListening: () -> Unit,
     private val onCopy: () -> Unit,
     private val onSavePosition: (Position) -> Unit,
     private val onSaveSize: (Size) -> Unit,
@@ -170,6 +171,14 @@ class QuickTranslateDialog(
 
     /** The trigger this popup last reacted to; see [QuickTranslateDialogState.triggerCount]. */
     private var lastTriggerCount = 0
+
+    /**
+     * Whether speech is playing, as of the last render.
+     *
+     * The click handler is installed once and cannot see the current state, so it reads this to
+     * decide whether a press means play or stop.
+     */
+    private var currentIsTtsPlaying = false
 
     init {
         focusableWindowState = false
@@ -321,11 +330,23 @@ class QuickTranslateDialog(
         )
 
         pinButton.toolTipText = if (state.isPinned) state.strings.unpinTooltip else state.strings.pinTooltip
-        listenButton.toolTipText = state.strings.listenTooltip
         copyButton.toolTipText = state.strings.copyTooltip
         closeButton.toolTipText = state.strings.closeTooltip
 
-        listenButton.isEnabled = state.actionsState.canListen && !state.isLoading
+        // Becomes a stop button while speech is playing, as it does in the main window. Pressing
+        // Listen a second time used to start another playback over the first, with no way to stop
+        // either of them.
+        val playing = state.isTtsPlaying
+        currentIsTtsPlaying = playing
+        listenButton.icon = iconManager.getIcon(
+            if (playing) "icons/lucide/close.svg" else "icons/lucide/volume.svg",
+            14,
+            14
+        )
+        listenButton.toolTipText =
+            if (playing) state.strings.stopListeningTooltip else state.strings.listenTooltip
+
+        listenButton.isEnabled = playing || (state.actionsState.canListen && !state.isLoading)
         copyButton.isEnabled = state.actionsState.canCopy && !state.isLoading
 
         val textToRender = if (state.isLoading) state.strings.loadingText else state.translatedText
@@ -538,7 +559,9 @@ class QuickTranslateDialog(
 
     private fun createTopPanel(): JPanel {
         pinButton.addActionListener { onPinToggled() }
-        listenButton.addActionListener { onListen() }
+        listenButton.addActionListener {
+            if (currentIsTtsPlaying) onStopListening() else onListen()
+        }
         copyButton.addActionListener {
             onCopy()
             showCopyFeedback()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quciktranslate/QuickTranslateDialogState.kt
@@ -17,6 +17,13 @@ data class QuickTranslateDialogState(
     val isPinned: Boolean,
     /** Bumped when the user asks for this popup again; a change restarts the countdown. */
     val triggerCount: Int,
+    /**
+     * Whether speech is playing right now.
+     *
+     * The Listen button turns into a stop button while it is, the same as in the main window.
+     * Without it, pressing Listen again started a second playback on top of the first.
+     */
+    val isTtsPlaying: Boolean = false,
     /** Short definition for a single-word result; empty for anything longer. */
     val definition: String,
 
@@ -63,6 +70,7 @@ data class DialogStrings(
     val copyTooltip: String,
     val closeTooltip: String,
     val listenTooltip: String,
+    val stopListeningTooltip: String,
     val pinTooltip: String,
     val unpinTooltip: String,
     val loadingText: String


### PR DESCRIPTION
## What does this PR do?

Pressing **Listen** in the Quick Translate popup while speech was already playing started a second playback on top of the first, with no way to stop either one.

The main window has handled this for a while. Its button turns into a stop button while audio is playing, and pressing it stops playback. The popup never got the same treatment, so its button always meant "play".

The popup now shows the same close icon while audio is playing and stops instead. It reads `isTtsPlaying` from the store rather than keeping a flag of its own, so the two windows can't end up disagreeing about whether sound is coming out. Stopping in one place flips the other's button back.

One small detail: the button stays enabled while playing even when the text would otherwise make it unavailable, because stopping has to remain possible.

## Related issues

None filed. Found while testing the popup work from #172.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

Notes against the checklist: the playing state comes from `MainState` and the button dispatches `MainIntent.StopTTS`, so the decision stays in the store and the dialog only renders it. No I/O was added. The new `isTtsPlaying` and `stopListeningTooltip` fields on the dialog state carry KDoc explaining why they exist.

## Screenshots (if UI changes)

The button swaps between the existing volume and close icons already used by the main window for this exact purpose, so there is nothing new to show. Verified by hand: play from the popup, confirm the icon flips, press again to stop, and confirm stopping from the main window flips the popup's button back.