### PR TITLE
feat(dictionary): read the headword aloud

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/HandleTextToSpeechUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/HandleTextToSpeechUseCase.kt
@@ -49,10 +49,14 @@ class HandleTextToSpeechUseCase(
         currentState: MainState,
         textSource: TextSource,
         textOverride: String?,
+        languageOverride: LanguageCode? = null,
         onStatusUpdate: suspend (code: StatusCode, type: NotificationType, isTemporary: Boolean) -> Unit
     ) {
         val textToSynthesize = textOverride ?: getTextFromSource(currentState, textSource)
-        val language = determineLanguage(currentState, textSource)
+        // AUTO is not a language a TTS service can speak, so it falls through to the panel's
+        // language rather than being handed over as-is.
+        val language = languageOverride?.takeIf { it != LanguageCode.AUTO }
+            ?: determineLanguage(currentState, textSource)
 
         if (textToSynthesize.isBlank()) {
             logger.debug("TTS skipped: text is blank")

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/LookupWordUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/LookupWordUseCase.kt
@@ -64,6 +64,7 @@ class LookupWordUseCase(
                     copy(
                         isDictionaryLoading = true,
                         dictionaryWord = word,
+                        dictionaryLanguage = language,
                         dictionaryFailed = false
                     )
                 }

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
@@ -69,10 +69,13 @@ sealed interface MainIntent : UiIntent {
      * User requested text-to-speech for a specific text panel.
      * @property textSource Which panel to read aloud.
      * @property text Optional text override. If `null`, uses the text from [textSource].
+     * @property language Optional language override. If `null`, it is derived from [textSource].
+     *   Set by callers whose text belongs to neither panel, such as a dictionary headword.
      */
     data class ListenToText(
         val textSource: TextSource,
-        val text: String? = null
+        val text: String? = null,
+        val language: LanguageCode? = null
     ) : MainIntent
 
     /** User manually triggered a spell check (or it was triggered automatically). */

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainState.kt
@@ -61,6 +61,14 @@ data class MainState(
     val dictionaryEntries: List<DictionaryEntry> = emptyList(),
     val isDictionaryLoading: Boolean = false,
     val dictionaryWord: String = "",
+    /**
+     * The language [dictionaryWord] was looked up in.
+     *
+     * Kept so the Listen control beside a headword can speak it in the right language. A lookup
+     * can come from either side of a translation, so neither the source nor the target language
+     * is a reliable stand-in.
+     */
+    val dictionaryLanguage: LanguageCode = LanguageCode("en"),
     val dictionaryFailed: Boolean = false,
     val isDictionaryPanelVisible: Boolean = false,
     val spellCheckCorrections: List<Correction> = emptyList(),

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -281,7 +281,7 @@ class MainStore(
             }
 
             is MainIntent.ListenToText -> scope.launch {
-                handleListen(intent.textSource, intent.text)
+                handleListen(intent.textSource, intent.text, intent.language)
             }
 
             is MainIntent.OcrAndTranslateImage -> scope.launch {
@@ -524,12 +524,17 @@ class MainStore(
         )
     }
 
-    private suspend fun handleListen(textSource: TextSource, textOverride: String?) {
+    private suspend fun handleListen(
+        textSource: TextSource,
+        textOverride: String?,
+        languageOverride: LanguageCode?
+    ) {
         handleTextToSpeechUseCase(
-            currentState   = _state.value,
-            textSource     = textSource,
-            textOverride   = textOverride,
-            onStatusUpdate = ::updateStatusBar
+            currentState     = _state.value,
+            textSource       = textSource,
+            textOverride     = textOverride,
+            languageOverride = languageOverride,
+            onStatusUpdate   = ::updateStatusBar
         )
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialog.kt
@@ -2,12 +2,13 @@ package com.github.ahatem.qtranslate.ui.swing.dictionary
 
 import com.formdev.flatlaf.util.UIScale
 import com.github.ahatem.qtranslate.core.main.domain.model.ServiceInfo
+import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.Frame
 import javax.swing.*
 
-class DictionaryDialog(owner: Frame) : JDialog(null as Frame?, false) {
+class DictionaryDialog(owner: Frame, iconManager: IconManager) : JDialog(null as Frame?, false) {
 
     private var state: DictionaryDialogState? = null
     private var updatingFromState = false
@@ -22,7 +23,7 @@ class DictionaryDialog(owner: Frame) : JDialog(null as Frame?, false) {
     private val loadingLabel = JLabel("", SwingConstants.CENTER).apply {
         foreground = UIManager.getColor("Label.disabledForeground")
     }
-    private val resultView = DictionaryResultView()
+    private val resultView = DictionaryResultView(iconManager)
     private val cardPanel = JPanel(java.awt.CardLayout())
 
     private val serviceCombo = JComboBox<ServiceInfo>().apply {
@@ -136,9 +137,14 @@ class DictionaryDialog(owner: Frame) : JDialog(null as Frame?, false) {
                 onSynonymClicked = { word ->
                     searchField.text = word
                     state?.onLookup?.invoke(word)
-                }
+                },
+                listenTooltip = newState.listenTooltip,
+                stopTooltip = newState.stopListeningTooltip,
+                onListen = newState.onListen,
+                onStopListening = newState.onStopListening
             )
         }
+        resultView.setSpeaking(newState.isTtsPlaying)
 
         if (!isVisible) {
             pack()

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryDialogState.kt
@@ -12,12 +12,18 @@ data class DictionaryDialogState(
     val loadingMessage: String,
     val errorMessage: String,
     val synonymsLabel: String,
+    val listenTooltip: String = "",
+    val stopListeningTooltip: String = "",
     val isLoading: Boolean,
+    /** Whether speech is playing right now; the headword's Listen control becomes a stop button. */
+    val isTtsPlaying: Boolean = false,
     val entries: List<DictionaryEntry>,
     val lookedUpWord: String,
     val hasFailed: Boolean,
     val availableDictionaries: List<ServiceInfo> = emptyList(),
     val selectedDictionaryId: String? = null,
     val onLookup: (word: String) -> Unit,
+    val onListen: (word: String) -> Unit = {},
+    val onStopListening: () -> Unit = {},
     val onDictionarySelected: (serviceId: String) -> Unit = {},
 )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanel.kt
@@ -24,7 +24,7 @@ class DictionaryPanel(
 
     private val hintLabel = JLabel("", SwingConstants.CENTER)
     private val loadingLabel = JLabel("", SwingConstants.CENTER)
-    private val resultView = DictionaryResultView()
+    private val resultView = DictionaryResultView(iconManager)
     private val cardPanel = JPanel(CardLayout())
 
     private val serviceCombo = JComboBox<ServiceInfo>().apply {
@@ -287,9 +287,14 @@ class DictionaryPanel(
                     chips.clear()
                     searchField.text = word
                     onLookup(word)
-                }
+                },
+                listenTooltip = state.listenTooltip,
+                stopTooltip = state.stopListeningTooltip,
+                onListen = state.onListen,
+                onStopListening = state.onStopListening
             )
         }
+        resultView.setSpeaking(state.isTtsPlaying)
     }
 
     fun setSearchWord(word: String) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanelState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryPanelState.kt
@@ -13,7 +13,11 @@ data class DictionaryPanelState(
     val loadingMessage: String,
     val errorMessage: String,
     val synonymsLabel: String,
+    val listenTooltip: String = "",
+    val stopListeningTooltip: String = "",
     val isLoading: Boolean,
+    /** Whether speech is playing right now; the headword's Listen control becomes a stop button. */
+    val isTtsPlaying: Boolean = false,
     val entries: List<DictionaryEntry>,
     val lookedUpWord: String,
     val hasFailed: Boolean,
@@ -25,4 +29,6 @@ data class DictionaryPanelState(
     val autoSourceTranslatedLabel: String = "",
     val autoSourceSourceLabel: String = "",
     val onAutoSourceChanged: (DictionaryAutoSource) -> Unit = {},
+    val onListen: (word: String) -> Unit = {},
+    val onStopListening: () -> Unit = {},
 )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/DictionaryResultView.kt
@@ -1,7 +1,11 @@
 package com.github.ahatem.qtranslate.ui.swing.dictionary
 
+import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.ui.swing.shared.icon.IconManager
+import com.github.ahatem.qtranslate.ui.swing.shared.util.applyForegroundColorFilter
 import com.github.ahatem.qtranslate.ui.swing.shared.util.clearBorder
+import com.github.ahatem.qtranslate.ui.swing.shared.util.createButtonWithIcon
 import com.github.ahatem.qtranslate.api.dictionary.DictionaryEntry
 import java.awt.*
 import javax.swing.*
@@ -11,7 +15,22 @@ import javax.swing.*
  * Implements [Scrollable] so that the content tracks the viewport width, enabling
  * JTextArea line-wrapping without a fixed pixel width.
  */
-class DictionaryResultView : JScrollPane() {
+class DictionaryResultView(private val iconManager: IconManager) : JScrollPane() {
+
+    /**
+     * The speaker beside the headword, kept so playback state can be reflected without rebuilding.
+     *
+     * A rebuild would clear the panel for a frame and reset the scroll position, which is a poor
+     * trade for swapping one icon — and it would happen every time audio started or stopped.
+     */
+    private var listenButton: JButton? = null
+
+    private var headword: String = ""
+    private var isSpeaking = false
+    private var listenTooltip = ""
+    private var stopTooltip = ""
+    private var onListen: ((String) -> Unit)? = null
+    private var onStopListening: (() -> Unit)? = null
 
     private val content = object : JPanel(), Scrollable {
         override fun getPreferredScrollableViewportSize(): Dimension = preferredSize
@@ -43,12 +62,24 @@ class DictionaryResultView : JScrollPane() {
     fun render(
         entries: List<DictionaryEntry>,
         synonymsLabel: String,
-        onSynonymClicked: ((String) -> Unit)? = null
+        onSynonymClicked: ((String) -> Unit)? = null,
+        listenTooltip: String = "",
+        stopTooltip: String = "",
+        onListen: ((String) -> Unit)? = null,
+        onStopListening: (() -> Unit)? = null
     ) {
+        // Assigned before the early return, so a caller that re-renders with the same entries but
+        // fresh callbacks does not leave the speaker wired to the previous ones.
+        this.listenTooltip = listenTooltip
+        this.stopTooltip = stopTooltip
+        this.onListen = onListen
+        this.onStopListening = onStopListening
+
         if (entries == lastEntries && synonymsLabel == lastSynonymsLabel) return
         lastEntries = entries
         lastSynonymsLabel = synonymsLabel
         content.removeAll()
+        listenButton = null
 
         if (entries.isEmpty()) {
             content.revalidate()
@@ -57,8 +88,9 @@ class DictionaryResultView : JScrollPane() {
         }
 
         val first = entries.first()
+        headword = first.word
 
-        addRow(wordLabel(first.word))
+        addRow(headwordRow(first.word))
         addGap(4)
 
         first.phonetic?.let {
@@ -100,6 +132,55 @@ class DictionaryResultView : JScrollPane() {
 
     private fun wordLabel(text: String): JLabel = JLabel(text).apply {
         font = font.deriveFont(Font.BOLD, font.size + 9f)
+    }
+
+    /**
+     * The headword, followed by a speaker when the caller supplied a listen callback.
+     *
+     * The button sits on the baseline row rather than in the toolbar because it belongs to the
+     * word, not to the window: the standalone dictionary dialog has no toolbar of its own.
+     */
+    private fun headwordRow(word: String): JComponent {
+        val label = wordLabel(word)
+        val listen = onListen ?: return label
+
+        val button = createButtonWithIcon(iconManager, LISTEN_ICON, LISTEN_ICON_SIZE).apply {
+            putClientProperty("JButton.buttonType", "toolBarButton")
+            isFocusable = false
+            addActionListener {
+                if (isSpeaking) onStopListening?.invoke() else listen(headword)
+            }
+        }
+        listenButton = button
+        applySpeakingState()
+
+        return JPanel(FlowLayout(FlowLayout.LEADING, UIScale.scale(6), 0)).apply {
+            isOpaque = false
+            // BoxLayout hands a row its maximum height, which would stretch a FlowLayout panel
+            // and float the word away from the definitions below it.
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+            add(label)
+            add(button)
+        }
+    }
+
+    /**
+     * Reflects playback in the speaker without rebuilding the entry list.
+     *
+     * Safe to call before anything is rendered; it does nothing until a headword exists.
+     */
+    fun setSpeaking(speaking: Boolean) {
+        if (speaking == isSpeaking) return
+        isSpeaking = speaking
+        applySpeakingState()
+    }
+
+    private fun applySpeakingState() {
+        val button = listenButton ?: return
+        val iconPath = if (isSpeaking) STOP_ICON else LISTEN_ICON
+        button.icon = (iconManager.getIcon(iconPath, LISTEN_ICON_SIZE, LISTEN_ICON_SIZE)
+            as FlatSVGIcon).applyForegroundColorFilter()
+        button.toolTipText = if (isSpeaking) stopTooltip else listenTooltip
     }
 
     private fun muteLabel(text: String): JLabel = JLabel(text).apply {
@@ -184,5 +265,11 @@ class DictionaryResultView : JScrollPane() {
             if (muted) foreground = UIManager.getColor("Label.disabledForeground")
             if (italic) font = font.deriveFont(Font.ITALIC)
         }
+    }
+
+    private companion object {
+        const val LISTEN_ICON = "icons/lucide/volume.svg"
+        const val STOP_ICON = "icons/lucide/close.svg"
+        const val LISTEN_ICON_SIZE = 14
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -127,7 +127,7 @@ class QuickDictionaryDialog(
 
     // Results
     private val loadingBar = InlineLoadingBar()
-    private val resultView = DictionaryResultView()
+    private val resultView = DictionaryResultView(iconManager)
     private val cardPanel = JPanel(CardLayout())
 
     // Word chips
@@ -349,9 +349,14 @@ class QuickDictionaryDialog(
                     chips.clear()
                     searchField.text = word
                     state.onLookup(word)
-                }
+                },
+                listenTooltip = state.strings.listenTooltip,
+                stopTooltip = state.strings.stopListeningTooltip,
+                onListen = state.onListen,
+                onStopListening = state.onStopListening
             )
         }
+        resultView.setSpeaking(state.isTtsPlaying)
     }
 
     fun setSearchWord(word: String) {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialogState.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialogState.kt
@@ -31,8 +31,12 @@ data class QuickDictionaryDialogState(
     val autoSourceOffLabel: String = "",
     val autoSourceTranslatedLabel: String = "",
     val autoSourceSourceLabel: String = "",
+    /** Whether speech is playing right now; the headword's Listen control becomes a stop button. */
+    val isTtsPlaying: Boolean = false,
     // callbacks
     val onLookup: (word: String) -> Unit,
+    val onListen: (word: String) -> Unit = {},
+    val onStopListening: () -> Unit = {},
     val onDictionarySelected: (serviceId: String) -> Unit,
     val onAutoSourceChanged: (DictionaryAutoSource) -> Unit = {},
     val onPinToggled: () -> Unit,
@@ -63,5 +67,7 @@ data class QuickDictionaryStrings(
     val synonymsLabel: String,
     val pinTooltip: String,
     val unpinTooltip: String,
-    val closeTooltip: String
+    val closeTooltip: String,
+    val listenTooltip: String = "",
+    val stopListeningTooltip: String = ""
 )

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -88,7 +88,7 @@ class MainAppFrame(
     private val aboutDialog by lazy { InfoDialog(this) }
     private val updateDialog by lazy { UpdateDialog(this) }
     private val historyDialog by lazy { HistoryDialog(this) }
-    private val dictionaryDialog by lazy { DictionaryDialog(this) }
+    private val dictionaryDialog by lazy { DictionaryDialog(this, iconManager) }
     private val loadingIndicator by lazy { LoadingIndicator(this) }
 
     private val documentTranslationDialog by lazy {
@@ -1632,13 +1632,18 @@ class MainAppFrame(
             loadingMessage        = localizer.getString("dictionary_dialog.loading_message"),
             errorMessage          = localizer.getString("dictionary_dialog.error_message"),
             synonymsLabel         = localizer.getString("dictionary_dialog.synonyms_label"),
+            listenTooltip         = localizer.getString("common.listen"),
+            stopListeningTooltip  = localizer.getString("common.stop"),
             isLoading             = s.isDictionaryLoading,
+            isTtsPlaying          = s.isTtsPlaying,
             entries               = s.dictionaryEntries,
             lookedUpWord          = s.dictionaryWord,
             hasFailed             = s.dictionaryFailed,
             availableDictionaries = availableDicts,
             selectedDictionaryId  = selectedDictId,
             onLookup = { word -> mainStore.dispatch(MainIntent.LookupWord(word, resolvedLang)) },
+            onListen = { word -> listenToLookedUpWord(word) },
+            onStopListening = { mainStore.dispatch(MainIntent.StopTTS) },
             onDictionarySelected = { serviceId ->
                 settingsStore.dispatch(
                     SettingsIntent.UpdateServiceInActivePreset(
@@ -1648,6 +1653,22 @@ class MainAppFrame(
                 val currentWord = mainStore.state.value.dictionaryWord
                 if (currentWord.isNotBlank()) mainStore.dispatch(MainIntent.LookupWord(currentWord, resolvedLang))
             }
+        )
+    }
+
+    /**
+     * Speaks a dictionary headword in the language it was looked up in.
+     *
+     * A lookup can be triggered from either side of a translation, so the word does not reliably
+     * belong to the input panel; [MainState.dictionaryLanguage] is what the lookup actually used.
+     */
+    private fun listenToLookedUpWord(word: String) {
+        mainStore.dispatch(
+            MainIntent.ListenToText(
+                textSource = TextSource.Input,
+                text = word,
+                language = mainStore.state.value.dictionaryLanguage
+            )
         )
     }
 
@@ -1779,9 +1800,14 @@ class MainAppFrame(
                 synonymsLabel    = localizer.getString("dictionary_dialog.synonyms_label"),
                 pinTooltip       = localizer.getString("common.pin"),
                 unpinTooltip     = localizer.getString("common.unpin"),
-                closeTooltip     = localizer.getString("common.close")
+                closeTooltip     = localizer.getString("common.close"),
+                listenTooltip    = localizer.getString("common.listen"),
+                stopListeningTooltip = localizer.getString("common.stop")
             ),
+            isTtsPlaying = mainState.isTtsPlaying,
             onLookup = { word -> mainStore.dispatch(MainIntent.LookupWord(word, resolvedLang)) },
+            onListen = { word -> listenToLookedUpWord(word) },
+            onStopListening = { mainStore.dispatch(MainIntent.StopTTS) },
             onDictionarySelected = { serviceId ->
                 settingsStore.dispatch(
                     SettingsIntent.UpdateServiceInActivePreset(

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -226,6 +226,8 @@ class MainContentView(
         val selectedDictionaryId: String?,
         val dictionaryCount: Int,
         val autoSource: com.github.ahatem.qtranslate.core.settings.data.DictionaryAutoSource,
+        /** Part of the key so the headword's Listen control flips when playback starts or stops. */
+        val isTtsPlaying: Boolean,
     )
 
     init {
@@ -359,6 +361,7 @@ class MainContentView(
             selectedDictionaryId = selectedDictId,
             dictionaryCount   = availableDicts.size,
             autoSource        = config.dictionaryAutoSource,
+            isTtsPlaying      = mainState.isTtsPlaying,
         )
         if (key == lastDictionaryKey) return
         lastDictionaryKey = key
@@ -400,7 +403,10 @@ class MainContentView(
                     loadingMessage        = localizer.getString("dictionary_dialog.loading_message"),
                     errorMessage          = localizer.getString("dictionary_dialog.error_message"),
                     synonymsLabel         = localizer.getString("dictionary_dialog.synonyms_label"),
+                    listenTooltip         = localizer.getString("common.listen"),
+                    stopListeningTooltip  = localizer.getString("common.stop"),
                     isLoading             = key.isLoading,
+                    isTtsPlaying          = key.isTtsPlaying,
                     entries               = key.entries,
                     lookedUpWord          = key.word,
                     hasFailed             = key.hasFailed,
@@ -415,6 +421,18 @@ class MainContentView(
                             SettingsIntent.ToggleSetting { it.copy(dictionaryAutoSource = newSource) }
                         )
                     },
+                    // The headword belongs to the lookup, not to a panel, so it carries the
+                    // language the lookup was made in rather than the input panel's.
+                    onListen = { word ->
+                        dispatch(
+                            MainIntent.ListenToText(
+                                textSource = TextSource.Input,
+                                text = word,
+                                language = key.lookupLanguage
+                            )
+                        )
+                    },
+                    onStopListening = { dispatch(MainIntent.StopTTS) },
                 )
             )
         }


### PR DESCRIPTION
## What does this PR do?

The dictionary had no way to hear a word. That is a gap for the people the dictionary is most useful to, and it sits oddly next to the translation popup, which has had a Listen control for a while (#173).

Adds a speaker beside the headword in `DictionaryResultView`, so all three dictionary surfaces get it at once: the quick popup, the standalone dialog, and the panel docked in the main window. It turns into a stop button while audio is playing, matching the main window and the translate popup.

**Language.** A looked-up word can come from either side of a translation, so neither the source nor the target language is a safe guess for how to pronounce it. `MainState.dictionaryLanguage` now records what the lookup actually used, and `ListenToText` gains a `language` override alongside the `text` override it already had. `AUTO` falls back to the panel's language rather than being handed to a TTS service that cannot speak it.

**Updated in place, not re-rendered.** The button swaps through `setSpeaking` rather than a re-render. Rebuilding the entry list on every play and stop would blank the panel for a frame and throw away the reader's scroll position, which is a poor trade for swapping one icon.

One thing left deliberately open: the button is always enabled, where the main window's Listen greys out when no TTS service is active. The dictionary states carry no `canListen` flag, and pressing it without a TTS service shows the usual status-bar warning. Worth adding the flag if that reads wrong in use.

## Related issues

None filed. Found while checking whether the dictionary had the same defect as #173. It did not, because it had no Listen control at all.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

Notes against the checklist: playback state comes from `MainState.isTtsPlaying` and the button dispatches `MainIntent.ListenToText` or `MainIntent.StopTTS`, so the decision stays in the store and the view only renders it. No I/O was added. The new state fields and the reason the button updates outside the render path both carry KDoc.

## Screenshots (if UI changes)

The control reuses the volume and close icons the main window already uses for exactly this, so there is nothing new to look at in isolation. The build and the test suite are green; the layout of the speaker beside the headword has not been checked on screen yet, since the automation here cannot see a Gradle-spawned JVM.
