### PR TITLE
fix(ui): stop the interface growing every time the font is reapplied

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ConfigurationExtensions.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ConfigurationExtensions.kt
@@ -1,23 +1,29 @@
 package com.github.ahatem.qtranslate.ui.swing.shared.util
 
-import com.formdev.flatlaf.util.UIScale
+import kotlin.math.roundToInt
 import com.github.ahatem.qtranslate.core.settings.data.Configuration
 import com.github.ahatem.qtranslate.core.settings.data.FontConfig
 
 /**
- * The point size actually used for [size], given the user's zoom and the display's density.
+ * The point size actually used for [size], given the user's zoom.
  *
- * Two independent factors: `uiScale` is the app's own zoom setting, and [UIScale] is how many
- * device pixels the display puts behind one logical pixel. The configured size is authored against
- * a 100% display, so without the second factor the fonts stay physically small on a 150% or 200%
- * screen while every icon, inset and border around them is scaled up — text ends up looking like
- * it belongs to a different window than its own chrome.
+ * Only the app's own zoom is applied here, deliberately. The result is installed as `defaultFont`,
+ * and FlatLaf derives its user scale factor *from* that font — so everything else in the interface
+ * that goes through [UIScale] already follows the user's zoom without being told about it.
  *
- * These sizes are installed directly as `defaultFont` and on the editors, which is why the scaling
- * has to happen here: a font handed to Swing verbatim is used verbatim.
+ * Scaling by [UIScale] as well used to look like the thorough thing to do, and it fed the output
+ * back into its own input: a larger `defaultFont` raised the scale factor, which enlarged the next
+ * font, which raised the factor again. The interface grew by the zoom percentage every time the
+ * font was reapplied, which is on every theme, title-bar or font change.
+ *
+ * The display's own density is not this function's job. On Java 9 and later the runtime scales the
+ * whole window for a HiDPI display, and FlatLaf's system scale factor covers what it does not.
  */
 private fun FontConfig.scaledTo(uiScale: Int): FontConfig =
-    copy(size = UIScale.scale((size * (uiScale / 100f)).toInt()))
+    copy(size = ((size * (uiScale / 100f)).roundToInt()).coerceAtLeast(MIN_FONT_SIZE))
+
+/** Below this a label stops being readable, and a bad zoom value should not make the app unusable. */
+private const val MIN_FONT_SIZE = 6
 
 val Configuration.scaledUiFont: FontConfig
     get() = uiFontConfig.scaledTo(uiScale)

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ConfigurationExtensionsTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ConfigurationExtensionsTest.kt
@@ -1,0 +1,78 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.util
+
+import com.formdev.flatlaf.FlatLaf
+import com.formdev.flatlaf.FlatLightLaf
+import com.formdev.flatlaf.util.UIScale
+import com.github.ahatem.qtranslate.core.settings.data.Configuration
+import com.github.ahatem.qtranslate.core.settings.data.FontConfig
+import java.awt.Font
+import javax.swing.UIManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the font scaling to the user's zoom and nothing else.
+ *
+ * The size produced here is installed as `defaultFont`, and FlatLaf derives its user scale factor
+ * from that font. Anything in this calculation that reads the current scale factor therefore feeds
+ * its own output back into its input, and the interface grows by the zoom percentage every time
+ * the font is reapplied. That shipped once; these tests are here so it cannot ship twice.
+ */
+class ConfigurationExtensionsTest {
+
+    private fun configWith(size: Int, scale: Int) = Configuration.DEFAULT.copy(
+        uiFontConfig = FontConfig(name = "Dialog", size = size),
+        uiScale = scale
+    )
+
+    @Test
+    fun `zoom is applied exactly once`() {
+        assertEquals(15, configWith(size = 12, scale = 125).scaledUiFont.size)
+        assertEquals(12, configWith(size = 12, scale = 100).scaledUiFont.size)
+        assertEquals(24, configWith(size = 12, scale = 200).scaledUiFont.size)
+    }
+
+    /**
+     * The same configuration gives the same size however large the current default font is.
+     *
+     * This is the regression itself: enlarging `defaultFont` raises FlatLaf's user scale factor,
+     * and the old calculation multiplied by that factor, so asking a second time gave a bigger
+     * answer than asking the first time.
+     *
+     * The look and feel has to be installed and the font actually pushed through `updateUI` for
+     * this to mean anything. Without that, `UIScale` reports a factor of 1 and the test passes
+     * against the very bug it exists to catch.
+     */
+    @Test
+    fun `size does not depend on the font currently installed`() {
+        val config = configWith(size = 13, scale = 125)
+
+        FlatLightLaf.setup()
+        val first = config.scaledUiFont.size
+
+        UIManager.put("defaultFont", Font("Dialog", Font.PLAIN, 48))
+        FlatLaf.updateUI()
+        // Guards the guard: if this ever stops holding, the assertion below proves nothing.
+        assertTrue(
+            UIScale.scale(10) > 10,
+            "UIScale is not reporting a raised factor, so this test cannot detect the regression"
+        )
+
+        val second = config.scaledUiFont.size
+        assertEquals(first, second, "Scaling must not read the font it is about to replace")
+    }
+
+    @Test
+    fun `all three fonts scale the same way`() {
+        val config = Configuration.DEFAULT.copy(
+            uiFontConfig = FontConfig(name = "Dialog", size = 10),
+            editorFontConfig = FontConfig(name = "Dialog", size = 10),
+            editorFallbackFontConfig = FontConfig(name = "Dialog", size = 10),
+            uiScale = 150
+        )
+        assertEquals(15, config.scaledUiFont.size)
+        assertEquals(15, config.scaledEditorFont.size)
+        assertEquals(15, config.scaledEditorFallbackFont.size)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

With the UI scale set to anything above 100%, changing the theme, the unified title bar, or a font made the whole interface a further 25% larger — and again on the next change, and again after that.

The scaled font size is installed as `defaultFont`, and **FlatLaf derives its user scale factor from that font**. The calculation in `ConfigurationExtensions` also multiplied by that same factor, so it fed its own output back into its input: a bigger font raised the factor, and the raised factor produced a bigger font. At 100% the multiplier is 1 and nothing moves, which is why it survived a release.

Only the app's own zoom is applied now. Everything else in the interface already goes through `UIScale` and therefore follows the user's zoom by way of the default font, which is how FlatLaf intends this to work — the second multiplication was not thoroughness, it was the loop.

The display's density is not this function's job either. Java scales the whole window for a HiDPI display and FlatLaf's system scale factor covers the rest.

### A note on the tests

Three of them, two of which fail against the old calculation — verified by putting it back.

Getting there took a correction worth recording. The first version of these tests **passed against the bug**, because `UIScale` reports a factor of 1 when no look and feel is installed, so the multiplication they existed to catch was by one. They now install FlatLaf, push a 48pt font through `updateUI`, and assert that `UIScale` is actually reporting a raised factor *before* asserting anything about the result. A test that cannot fail is worse than no test, because it reads as cover.

## Related issues

None filed. Reported during hands-on testing at 125%.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

Notes against the checklist: this is a pure function over `Configuration`, so there is no state handling and no I/O. The reasoning for applying one factor rather than two is in KDoc on the function, since the mistake is an easy one to make again.

## Screenshots (if UI changes)

Nothing to show in a still. To reproduce on `develop`: set Settings → Appearance → Scale to 125%, apply, then change the theme two or three times and watch the interface grow each time.

**Worth knowing after merge:** because the double-scaling is gone, the interface at a given zoom is now smaller than the last build rendered it. That is the bug's absence rather than a regression, but it is a visible change for anyone who had grown used to the inflated size.
