### PR TITLE
Settings dialog: lay it out correctly right to left

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,8 +101,33 @@ val prepareManualQaPlugins by tasks.registering(Sync::class) {
     }
 }
 
+/**
+ * Stages the language files and themes beside the plugins.
+ *
+ * The app reads both from its data directory, which for manual QA is `build/manual-qa/app-data`.
+ * Only plugins were being staged, so the directories existed — `LocalizationManager` creates them
+ * — and were empty. The interface-language list came up with nothing in it, and no theme but the
+ * built-in ones was selectable, which made every manual pass on localization or theming
+ * impossible to run against a plugin build.
+ *
+ * Sync rather than Copy so a language file deleted from the repository disappears here too.
+ */
+val prepareManualQaLanguages by tasks.registering(Sync::class) {
+    group = "application"
+    description = "Stages the language files for manual QA."
+    from(rootProject.layout.projectDirectory.dir("languages"))
+    into(manualQaDirectory.map { it.dir("app-data/languages") })
+}
+
+val prepareManualQaThemes by tasks.registering(Sync::class) {
+    group = "application"
+    description = "Stages the bundled themes for manual QA."
+    from(rootProject.layout.projectDirectory.dir("themes"))
+    into(manualQaDirectory.map { it.dir("app-data/themes") })
+}
+
 val prepareManualQaRuntime by tasks.registering(Delete::class) {
-    dependsOn(prepareManualQaPlugins)
+    dependsOn(prepareManualQaPlugins, prepareManualQaLanguages, prepareManualQaThemes)
     // Always inspect freshly staged JARs while retaining the tester's other settings.
     delete(manualQaDirectory.map { it.file("app-data/datastore/plugin_registry.preferences_pb") })
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
@@ -283,12 +283,41 @@ class SettingsDialog(
         tree.setSelectionRow(0)
     }
 
+    /**
+     * Recomputes anything that depends on layout direction, after it is known.
+     *
+     * The caller applies an orientation once the dialog is built, so everything decided during
+     * construction was decided left-to-right. The sidebar's divider is the visible case: it is a
+     * `MatteBorder` on an absolute edge, chosen from the orientation, and without this it stayed
+     * on the edge it was given at construction and disappeared against the window frame.
+     */
+    override fun applyComponentOrientation(orientation: ComponentOrientation) {
+        super.applyComponentOrientation(orientation)
+        updateBorders()
+        // Pages already built were reached by super above; ones built later read the dialog's
+        // orientation in createPanel.
+        revalidate()
+        repaint()
+    }
+
     // ── Theme-aware borders ───────────────────────────────────────────────────
 
     private fun updateBorders() {
         val bc = UIManager.getColor("Component.borderColor") ?: Color.GRAY
 
-        sidebarPanel.border = MatteBorder(0, 0, 0, 1, bc)
+        // The divider goes on whichever edge faces the content, which swaps with the layout
+        // direction: the sidebar sits on the right in a right-to-left interface, so a border
+        // fixed to its right edge ends up on the outside of the window against nothing.
+        // MatteBorder takes absolute sides and knows nothing about orientation, so the side is
+        // chosen here.
+        val leftToRight = componentOrientation.isLeftToRight
+        sidebarPanel.border = MatteBorder(
+            0,
+            if (leftToRight) 0 else 1,
+            0,
+            if (leftToRight) 1 else 0,
+            bc
+        )
 
         // Divides the search box from the sections it searches, matching the rule under the
         // header strip on the other side of the sidebar so the two line up as one row of chrome.
@@ -367,7 +396,18 @@ class SettingsDialog(
                     val unit = UIManager.getInt("Tree.leftChildIndent") +
                         UIManager.getInt("Tree.rightChildIndent")
                     val extra = if (!isGroup && depth <= 1) unit else 0
-                    border = BorderFactory.createEmptyBorder(0, 8 + extra, 0, 8)
+
+                    // The indent belongs on the side the rows start from, which is the right in a
+                    // right-to-left interface. EmptyBorder takes absolute sides, so writing it
+                    // always on the left put the whole indent on the wrong edge — pages under a
+                    // group and pages without one stopped lining up, and the padding appeared to
+                    // vanish because it had moved to the far end of the row.
+                    val startInset = 8 + extra
+                    border = if (tree.componentOrientation.isLeftToRight) {
+                        BorderFactory.createEmptyBorder(0, startInset, 0, 8)
+                    } else {
+                        BorderFactory.createEmptyBorder(0, 8, 0, startInset)
+                    }
                     font = font.deriveFont(if (isGroup) Font.BOLD else Font.PLAIN)
                     if (!sel) {
                         foreground = UIManager.getColor(
@@ -709,7 +749,18 @@ class SettingsDialog(
         }
     }
 
-    private fun createPanel(name: String): JPanel = when (name) {
+    /**
+     * Builds a page and gives it the dialog's layout direction.
+     *
+     * Pages are built the first time they are opened, which is after the caller has applied an
+     * orientation to the dialog — and `applyComponentOrientation` only reaches the children that
+     * exist when it runs. So in a right-to-left interface every page except the one showing at
+     * open time was laid out left-to-right, which is why some looked mirrored and others did not.
+     */
+    private fun createPanel(name: String): JPanel =
+        buildPanel(name).apply { applyComponentOrientation(this@SettingsDialog.componentOrientation) }
+
+    private fun buildPanel(name: String): JPanel = when (name) {
         label("general") ->
             GeneralPanel(settingsStore, localizationManager)
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/SettingsDialog.kt
@@ -387,26 +387,36 @@ class SettingsDialog(
                     // rather than competing with the pages it labels.
                     val isGroup = navTree.any { it is Nav.Group && it.label == name }
 
-                    // Every page shares one left edge, whether or not it happens to sit under a
-                    // group, and only the two headings outdent. The tree indents its children by
-                    // one unit on its own, so the pages that have no group are given that unit
-                    // back here. Read from the look and feel rather than hard-coded, since the
-                    // tree's own indent comes from the same numbers.
+                    // Headings and ungrouped pages sit at the base; a page inside a group sits
+                    // further in, so the nesting is visible at a glance.
+                    //
+                    // An earlier version pushed ungrouped pages *out* to meet the grouped ones so
+                    // every page shared one left edge. That reads as a flat list with two stray
+                    // headings in it — the grouping is there in the markup and invisible on
+                    // screen. The hierarchy is the point, so it is the thing to show.
+                    //
+                    // The tree indents its own children, but by an amount the look and feel
+                    // chooses, which can be too small to read as nesting. Whatever it gives is
+                    // topped up to a minimum rather than replaced, so this neither fights the
+                    // look and feel nor depends on it.
                     val depth = (value as? DefaultMutableTreeNode)?.level ?: 1
-                    val unit = UIManager.getInt("Tree.leftChildIndent") +
+                    val treeIndent = UIManager.getInt("Tree.leftChildIndent") +
                         UIManager.getInt("Tree.rightChildIndent")
-                    val extra = if (!isGroup && depth <= 1) unit else 0
-
-                    // The indent belongs on the side the rows start from, which is the right in a
-                    // right-to-left interface. EmptyBorder takes absolute sides, so writing it
-                    // always on the left put the whole indent on the wrong edge — pages under a
-                    // group and pages without one stopped lining up, and the padding appeared to
-                    // vanish because it had moved to the far end of the row.
-                    val startInset = 8 + extra
-                    border = if (tree.componentOrientation.isLeftToRight) {
-                        BorderFactory.createEmptyBorder(0, startInset, 0, 8)
+                    val nesting = if (depth > 1) {
+                        (UIScale.scale(NEST_INDENT) - treeIndent).coerceAtLeast(0)
                     } else {
-                        BorderFactory.createEmptyBorder(0, 8, 0, startInset)
+                        0
+                    }
+
+                    // EmptyBorder takes absolute sides and knows nothing about direction, so the
+                    // leading edge is picked here. Written always on the left, the indent moved to
+                    // the far end of the row in a right-to-left interface.
+                    val base = UIScale.scale(ROW_INSET)
+                    val leading = base + nesting
+                    border = if (tree.componentOrientation.isLeftToRight) {
+                        BorderFactory.createEmptyBorder(0, leading, 0, base)
+                    } else {
+                        BorderFactory.createEmptyBorder(0, base, 0, leading)
                     }
                     font = font.deriveFont(if (isGroup) Font.BOLD else Font.PLAIN)
                     if (!sel) {
@@ -912,5 +922,16 @@ class SettingsDialog(
         const val FLASH_TICK_MILLIS = 30
         /** How much of the flash is held at full strength before it starts fading. */
         const val FLASH_HOLD_FRACTION = 0.6f
+
+        /** Breathing room at the leading and trailing edge of every sidebar row. */
+        const val ROW_INSET = 8
+
+        /**
+         * Smallest gap between an ungrouped page and one nested under a heading.
+         *
+         * A floor, not a fixed value: the tree indents its own children first, and this only
+         * makes up the difference when that comes out too small to read as nesting.
+         */
+        const val NEST_INDENT = 18
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/AppearancePanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/AppearancePanel.kt
@@ -227,7 +227,18 @@ class AppearancePanel(
                     super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
                     text = item.displayName
                     // index < 0 = closed button cell — no extra padding so the combo height stays normal
-                    if (index >= 0) border = BorderFactory.createEmptyBorder(2, 12, 2, 4)
+                    //
+                    // The indent marks a theme as belonging to the header above it, so it goes on
+                    // the side the list reads from. EmptyBorder takes absolute sides, so a fixed
+                    // left inset put it on the trailing edge in a right-to-left interface, where
+                    // it read as ragged spacing rather than as grouping.
+                    if (index >= 0) {
+                        border = if (list?.componentOrientation?.isLeftToRight != false) {
+                            BorderFactory.createEmptyBorder(2, 12, 2, 4)
+                        } else {
+                            BorderFactory.createEmptyBorder(2, 4, 2, 12)
+                        }
+                    }
                 }
                 else -> super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
             }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/DynamicPluginSettingsDialog.kt
@@ -261,12 +261,20 @@ class DynamicPluginSettingsDialog(
             override fun paintComponent(g: Graphics) {
                 super.paintComponent(g)
                 val centerY = label.y + label.height / 2
-                val startX = label.x + label.width + gap
-                if (startX >= width) return
+
+                // Runs from the label's trailing edge to the panel's, which is the left in a
+                // right-to-left interface. Measuring only from the label's right edge put the
+                // start beyond the panel there, so the line never drew at all.
+                val (startX, endX) = if (componentOrientation.isLeftToRight) {
+                    (label.x + label.width + gap) to width
+                } else {
+                    0 to (label.x - gap)
+                }
+                if (endX <= startX) return
                 g.color = UIManager.getColor("Separator.foreground")
                     ?: UIManager.getColor("Component.borderColor")
                             ?: Color.GRAY
-                g.drawLine(startX, centerY, width, centerY)
+                g.drawLine(startX, centerY, endX, centerY)
             }
         }.apply { alignmentX = Component.LEFT_ALIGNMENT }
     }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
@@ -97,6 +97,24 @@ class PluginsPanel(
         }
     }
 
+    /**
+     * Recomputes everything whose side depends on the layout direction.
+     *
+     * The panel is built before the dialog flips it, so the constructor's call to
+     * [refreshLeftBorder] always ran while this was still left-to-right. The divider was baked
+     * onto the list's right edge and nothing revisited it, which left the line on the wrong side
+     * of the list in Arabic. `applyComponentOrientation` sets the property and repaints; it does
+     * not know that a border was derived from it, so the derivation has to run again here.
+     */
+    override fun applyComponentOrientation(orientation: ComponentOrientation) {
+        super.applyComponentOrientation(orientation)
+        // Guarded because a superclass constructor may reach this before the fields it touches
+        // have been assigned.
+        if (!::listHeaderPanel.isInitialized) return
+        refreshLeftBorder()
+        refreshPluginRows()
+    }
+
     init {
         // PluginsPanel overrides the SettingsPanel GridBag layout
         removeAll()
@@ -379,7 +397,12 @@ class PluginsPanel(
                 // leading-edge inset, so it swaps sides with the layout: written absolutely, the
                 // line hung off the wrong edge in a right-to-left interface and stopped lining up
                 // with the name it belongs to.
-                border = if (componentOrientation.isLeftToRight) {
+                //
+                // The direction is read from the panel, not from this label. A component that has
+                // not been added to anything yet reports ComponentOrientation.UNKNOWN, whose
+                // isLeftToRight is true, so asking the label always answered left-to-right and the
+                // indent never moved.
+                border = if (this@PluginsPanel.componentOrientation.isLeftToRight) {
                     BorderFactory.createEmptyBorder(3, NAME_INDENT, 0, 0)
                 } else {
                     BorderFactory.createEmptyBorder(3, 0, 0, NAME_INDENT)

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/PluginsPanel.kt
@@ -375,7 +375,15 @@ class PluginsPanel(
             add(JLabel("v${plugin.manifest.version} · $categories").apply {
                 font = font.deriveFont(font.size - 1f)
                 this.foreground = if (selected) foreground else UIManager.getColor("Label.disabledForeground")
-                border = BorderFactory.createEmptyBorder(3, 32, 0, 0)
+                // Indented to sit under the plugin's name rather than under its icon. That is a
+                // leading-edge inset, so it swaps sides with the layout: written absolutely, the
+                // line hung off the wrong edge in a right-to-left interface and stopped lining up
+                // with the name it belongs to.
+                border = if (componentOrientation.isLeftToRight) {
+                    BorderFactory.createEmptyBorder(3, NAME_INDENT, 0, 0)
+                } else {
+                    BorderFactory.createEmptyBorder(3, 0, 0, NAME_INDENT)
+                }
             })
         }
         val controls = JPanel(FlowLayout(FlowLayout.TRAILING, 2, 0)).apply {
@@ -859,6 +867,11 @@ class PluginsPanel(
             jars.forEach(::installPlugin)
             return true
         }
+    }
+
+    private companion object {
+        /** Aligns a plugin's version line under its name rather than under its icon. */
+        const val NAME_INDENT = 32
     }
 }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/SettingsPanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/SettingsPanel.kt
@@ -62,6 +62,9 @@ abstract class SettingsPanel : JPanel(), Renderable<SettingsState> {
     private val entries = mutableListOf<SettingEntry>()
     private var currentSection: String = ""
 
+    /** Every hint and its source text, so the markup can be regenerated per layout direction. */
+    private val hintLabels = mutableListOf<Pair<JLabel, String>>()
+
     @Volatile
     protected var isUpdatingFromState = false
 
@@ -202,12 +205,23 @@ abstract class SettingsPanel : JPanel(), Renderable<SettingsState> {
                 // Read the label center after layout — this is the Y coordinate of the
                 // separator line that makes it appear visually aligned with the text.
                 val centerY = titleLabel.y + titleLabel.height / 2
-                val startX  = titleLabel.x + titleLabel.width + gap
-                if (startX >= width) return
+
+                // The line fills whatever the label leaves, so it runs from the label's
+                // trailing edge to the panel's trailing edge. FlowLayout.LEADING puts the
+                // label on the right in a right-to-left interface, so measuring from the
+                // label's right edge and drawing to `width` produced a start beyond the
+                // panel: the guard below returned every time and the line simply never
+                // appeared, leaving the heading looking unfinished.
+                val (startX, endX) = if (componentOrientation.isLeftToRight) {
+                    (titleLabel.x + titleLabel.width + gap) to width
+                } else {
+                    0 to (titleLabel.x - gap)
+                }
+                if (endX <= startX) return
                 g.color = UIManager.getColor("Separator.foreground")
                     ?: UIManager.getColor("Component.borderColor")
                     ?: Color.GRAY
-                g.drawLine(startX, centerY, width, centerY)
+                g.drawLine(startX, centerY, endX, centerY)
             }
         }
     }
@@ -257,14 +271,11 @@ abstract class SettingsPanel : JPanel(), Renderable<SettingsState> {
      * Uses an HTML width constraint so long text wraps instead of growing the dialog.
      */
     protected fun addHint(text: String) {
-        val html = text.replace("\n", "<br>")
-        // Swing does not scale pixel widths inside HTML, so an unscaled figure here wraps the
-        // hint at half the intended measure on a 200% display while the font around it doubles.
-        val width = UIScale.scale(HINT_WIDTH)
-        val hint = JLabel("<html><body style='width:${width}px'><i>$html</i></body></html>").apply {
+        val hint = JLabel(hintHtml(text)).apply {
             foreground = UIManager.getColor("Label.disabledForeground")
             font = font.deriveFont(font.size - 1f)
         }
+        hintLabels += hint to text
         gb.nextRow()
             .spanLine()
             .weightX(1.0)
@@ -275,6 +286,43 @@ abstract class SettingsPanel : JPanel(), Renderable<SettingsState> {
         // Attached to the setting above rather than indexed on its own, so searching for a word
         // that only appears in the explanation still finds the control it explains.
         entries.lastOrNull()?.let { entries[entries.lastIndex] = it.copy(hint = text) }
+    }
+
+    /**
+     * Renders a hint's HTML for the current layout direction.
+     *
+     * The fixed measure is what made this direction-sensitive. The label stretches across the row
+     * but the HTML block inside it does not, so the block sits at the leading edge while the text
+     * inside it stays aligned to the left whatever the component does. In Arabic that left the
+     * words starting a full measure in from the right edge, which reads as centred rather than as
+     * text that has simply been aligned the wrong way.
+     *
+     * `dir` is set as well as `text-align` so punctuation and any embedded Latin resolve against
+     * the right base direction instead of being reordered at the end of the line.
+     */
+    private fun hintHtml(text: String): String {
+        val html = text.replace("\n", "<br>")
+        // Swing does not scale pixel widths inside HTML, so an unscaled figure here wraps the
+        // hint at half the intended measure on a 200% display while the font around it doubles.
+        val width = UIScale.scale(HINT_WIDTH)
+        val leftToRight = componentOrientation.isLeftToRight
+        val dir = if (leftToRight) "ltr" else "rtl"
+        val align = if (leftToRight) "left" else "right"
+        return "<html><body dir='$dir' style='width:${width}px; text-align:$align'>" +
+            "<i>$html</i></body></html>"
+    }
+
+    /**
+     * Rebuilds anything whose rendering was derived from the layout direction.
+     *
+     * Panels are built before the dialog flips them, so every hint is first laid out
+     * left-to-right. `applyComponentOrientation` moves components but cannot know that a string of
+     * HTML was generated from the old direction, so the markup is regenerated here. This also
+     * covers the user changing the interface language while the dialog is open.
+     */
+    override fun applyComponentOrientation(orientation: ComponentOrientation) {
+        super.applyComponentOrientation(orientation)
+        hintLabels.forEach { (label, text) -> label.text = hintHtml(text) }
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Fixes the Settings dialog in right-to-left interfaces, and stages the files that made testing any of it impossible.

**Section rules never drew at all in Arabic.** The rule runs from the end of a heading's label to the panel edge, but `FlowLayout.LEADING` puts that label on the *right* in RTL, so the computed start landed past the panel width and the guard bailed on every paint. The line now runs to the trailing edge, whichever edge that is. The same code had been copied into the plugin settings dialog, so it carried the identical bug.

**The plugins divider sat on the wrong side.** The side-picking logic was already correct, but only ran in the constructor, and the dialog flips the panel after building it. `applyComponentOrientation` now re-derives it. While there: the version line under each plugin name read the orientation off a label with no parent yet, and an unparented component reports `ComponentOrientation.UNKNOWN`, whose `isLeftToRight` is `true`, so that indent had never once moved in RTL.

**Hints read as centred.** They wrap at a fixed measure inside HTML while the label stretches across the row, so the block sat correctly at the right edge but its text stayed aligned left, starting a full measure in from the right. The markup now carries `dir` and `text-align`, regenerated on orientation change rather than at build time, so it also follows a language switched while the dialog is open.

**Sidebar nesting was invisible.** Ungrouped pages had been pushed out to meet the grouped ones so every page shared one left edge, which read as a flat list with two stray headings in it. Pages under a heading now sit further in, topped up to a minimum rather than replacing the tree's own indent, and mirrored for RTL.

**`runWithPlugins` staged only plugins.** `LocalizationManager` creates the languages directory, which is why this failed quietly rather than loudly: the interface-language list came up empty and no theme beyond the built-in ones was selectable, so every manual pass over localization or theming was untestable.

## Related issues

## Type of change

- [x] Bug fix
- [x] UI/UX improvement

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Verified manually in Arabic at 125% scale: sidebar nesting, section rules, plugins divider and hints all correct.