### PR TITLE
Better defaults, and make choosing English stick

### DIFF
--- a/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
+++ b/app/src/main/kotlin/com/github/ahatem/qtranslate/app/Main.kt
@@ -94,16 +94,20 @@ fun main() = runBlocking {
         )
     }
 
-    val savedLanguage = if (initialConfig.interfaceLanguage == LanguageCode.ENGLISH.tag) {
+    // Only when the user has not chosen. Keying this off "en" meant an explicit choice of English
+    // was read as no choice at all, so detection ran again on every launch and put the interface
+    // back into the machine's language.
+    val savedLanguage = if (initialConfig.interfaceLanguage.isBlank()) {
         OsLanguageDetector.detect(deps.localizationManager.availableLanguages)
     } else {
         LanguageCode(initialConfig.interfaceLanguage)
     }
     runCatching {
         deps.localizationManager.loadLanguage(savedLanguage)
-        logger.info("Interface language loaded: ${initialConfig.interfaceLanguage}")
+        // The resolved tag, not the stored one, which is blank until the user chooses.
+        logger.info("Interface language loaded: ${savedLanguage.tag}")
     }.onFailure { e ->
-        logger.warn("Failed to load interface language '${initialConfig.interfaceLanguage}': ${e.message}")
+        logger.warn("Failed to load interface language '${savedLanguage.tag}': ${e.message}")
     }
 
     // The window is shown before plugins are loaded. Everything it needs to paint — theme,

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LocalizationManager.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LocalizationManager.kt
@@ -90,6 +90,15 @@ class LocalizationManager(
 
     private fun loadAndCacheLanguage(code: LanguageCode) {
         if (translationCache.containsKey(code)) return
+
+        // English ships inside the JAR as the fallback every other language is completed from, so
+        // it has no file on disk and never needed one. Looking for it and warning made the app
+        // report its own base language as missing on every start, and on every switch to English.
+        if (code == LanguageCode.ENGLISH) {
+            translationCache[code] = embeddedFallback
+            return
+        }
+
         runCatching {
             val file = File(languagesDirectory, "${code.tag}.toml")
             if (!file.exists()) {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -260,7 +260,19 @@ data class Configuration(
     val autoCheckForUpdates: Boolean = true,
     val isGlobalHotkeysEnabled: Boolean = true,
     val isSelectionIconEnabled: Boolean = false,
-    val interfaceLanguage: String = "en",
+    /**
+     * The interface language, or blank for "not chosen yet, follow the operating system".
+     *
+     * Blank rather than "en" because the two have to be told apart and previously could not be.
+     * Configuration is written without its default values, so a user who picked English stored
+     * nothing, which was indistinguishable from never having picked at all — and startup, seeing
+     * "en", ran operating-system detection and overrode them again on every launch. Choosing
+     * English on a non-English machine therefore never stuck.
+     *
+     * With a blank default, picking English stores "en", which differs from the default and so
+     * survives. Detection now runs only when nothing has been chosen, which is what it was for.
+     */
+    val interfaceLanguage: String = "",
     val isInstantTranslationEnabled: Boolean = false,
     val isSpellCheckingEnabled: Boolean = true,
     val extraOutputType: ExtraOutputType = ExtraOutputType.None,
@@ -338,7 +350,12 @@ data class Configuration(
     val useUnifiedTitleBar: Boolean = true,
     val layoutPresetId: String = "classic",
     val toolbarVisibility: ToolbarVisibility = ToolbarVisibility.DEFAULT,
-    val serviceSelectorStyle: ServiceSelectorStyle = ServiceSelectorStyle.CLASSIC,
+    /**
+     * Enhanced by default: it shows which service is active and lets one be swapped in place,
+     * where the classic selector only lists them. Classic remains for anyone who prefers the
+     * denser row.
+     */
+    val serviceSelectorStyle: ServiceSelectorStyle = ServiceSelectorStyle.ENHANCED,
     val serviceSelectorAppearance: ServiceSelectorAppearance = ServiceSelectorAppearance.ICONS_AND_TEXT,
 
     // ---- UI — Quick Panel (Popup) ----

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/AppearancePanel.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/settings/panels/AppearancePanel.kt
@@ -25,6 +25,17 @@ class AppearancePanel(
 
     private val groupedItems: List<ThemeItem> = buildGroupedItems()
 
+    /**
+     * Which entry the language picker should show for a stored [configured] value.
+     *
+     * Blank means the user has never chosen and the interface is following the operating system,
+     * so the picker shows the language actually running rather than nothing at all. Reading the
+     * stored value alone left the control empty on a first run, which reads as a bug in a dialog
+     * whose whole job is to show current settings.
+     */
+    private fun selectedLanguageCode(configured: String): String =
+        configured.ifBlank { localizationManager.activeLanguage.tag }
+
     private lateinit var languageCombo:     JComboBox<LanguageInfo>
     private lateinit var themeCombo:        JComboBox<ThemeItem>
     private lateinit var syncWithOsCheck:   JCheckBox
@@ -149,7 +160,9 @@ class AppearancePanel(
                 withoutTrigger {
                     languageCombo.removeAllItems()
                     languages.forEach { languageCombo.addItem(it) }
-                    val currentCode = store.state.value.workingConfiguration.interfaceLanguage
+                    val currentCode = selectedLanguageCode(
+                        store.state.value.workingConfiguration.interfaceLanguage
+                    )
                     for (i in 0 until languageCombo.itemCount) {
                         if (languageCombo.getItemAt(i).code == currentCode) {
                             languageCombo.selectedIndex = i
@@ -330,7 +343,7 @@ class AppearancePanel(
         val c = state.workingConfiguration
         withoutTrigger {
             for (i in 0 until languageCombo.itemCount) {
-                if (languageCombo.getItemAt(i).code == c.interfaceLanguage) {
+                if (languageCombo.getItemAt(i).code == selectedLanguageCode(c.interfaceLanguage)) {
                     languageCombo.selectedIndex = i
                     break
                 }


### PR DESCRIPTION
## What does this PR do?

> **Sequencing:** this branch sits on top of #185. Until that merges, the diff below also shows its commits and those of #183 and #184. I will rebase this onto `develop` once #185 lands.

**The enhanced service selector becomes the default.** It shows which service is active and lets one be swapped in place, where the classic selector only lists them.

**`interfaceLanguage` now defaults to blank**, meaning "not chosen yet, follow the operating system", and startup runs detection only for that. Keying detection off `"en"` conflated two different states. Configuration is written without its default values, so a user who picked English stored *nothing at all*, which was indistinguishable from never having picked — and every launch then re-ran detection and put the interface back into the machine's language. **Choosing English on a non-English system never survived a restart.** A blank default separates them: picking English now stores `"en"`, which differs from the default and persists.

Since a blank value would leave the language picker showing nothing on a first run, it falls back to displaying the language actually running.

**Stops the app reporting its own base language as missing.** English ships inside the JAR as the fallback that completes every other language, so it has no file on disk and never needed one, but the loader looked anyway and logged a warning on every start and on every switch to English.

**Worth knowing about the mechanism:** `encodeDefaults` is false, so a default change reaches existing users who never set that value, not only new installs. Confirmed against a real profile — 46 keys stored, the rest absent.

**Two defaults deliberately left alone.** The close button still asks, because the prompt offers to remember the answer. The translate popup still hides sooner than the dictionary popup, because that gap is deliberate and documented: definitions get read and compared, translations get glanced at.

## Related issues

## Type of change

- [x] Bug fix
- [x] UI/UX improvement

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Language picker shows a selection rather than an empty control on a fresh profile, and the `Language file not found for 'en'` warning is gone from startup.