### PR TITLE
Let a local AI endpoint work without an API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For longer work: open the main window, type or paste, translate. Switch engines 
 | **Bing Services** | Translator, TTS, Spell Checker — included |
 | **AI Services** | Translator, Summarizer, Rewriter, Spell Checker, Dictionary, Vision OCR — via [OpenRouter](https://openrouter.ai) (300+ models, one API key) — included. [Setup guide](wiki/AI-Services.md) |
 | **Free translation choices** | Mozhi, MyMemory, DeepL web fallback, Reverso, and Yandex Web work without an API key; unofficial endpoints may change or be rate-limited |
-| **Local translation** | Connect to a local or self-hosted LibreTranslate instance without sending text to a third-party cloud |
+| **Fully offline & private** | Point AI Services at a local [Ollama](https://ollama.com) or LM Studio server, or use a self-hosted LibreTranslate instance. No account, no API key, no per-word cost, and nothing leaves your machine — for work under an NDA, proprietary code, or anything else that cannot go to a cloud service. [Setup guide](wiki/AI-Services.md) |
 | **Reference services** | Wikipedia and Wiktionary lookups, and Wikimedia Commons image search, through official MediaWiki APIs |
 | **CSV dictionary** | Point it at your own CSV — a glossary, an abbreviation list, a table of error codes, a set of study notes — and look terms up in it. Which columns hold the term and its meaning is configurable, and nothing leaves your machine |
 

--- a/plugins/ai-services/build.gradle.kts
+++ b/plugins/ai-services/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":plugins:common"))
 
     implementation(libs.kotlinxSerialization)
+
+    testImplementation(kotlin("test"))
 }
 
 tasks.shadowJar {

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIPlugin.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIPlugin.kt
@@ -70,9 +70,13 @@ class AIPlugin : Plugin<AISettings> {
     }
 
     override suspend fun onEnable(): Result<Unit, ServiceError> {
-        if (settings.apiKey.isBlank()) {
+        // Only a warning when a key is actually needed. A local endpoint runs perfectly well
+        // without one, and warning there would send someone hunting for a problem that is not
+        // there.
+        if (settings.missingKeyError() != null) {
             pluginContext.logger.warn(
-                "AI Plugin enabled without an API key — services will return AuthenticationError until a key is set."
+                "AI Plugin enabled without an API key for ${settings.baseUrl} — " +
+                    "services will report a configuration error until a key is set."
             )
         }
         buildServices()

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIServiceClient.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIServiceClient.kt
@@ -144,13 +144,10 @@ class AIServiceClient(
     ): Result<String, ServiceError> {
         val current = settings()
 
-        if (current.apiKey.isBlank()) {
-            return Err(
-                ServiceError.AuthenticationError(
-                    "AI Plugin: API key is not configured. Add your key in Settings → Plugins → AI Plugin."
-                )
-            )
-        }
+        // The same rule as every other call. This one used to have its own check, which meant
+        // Vision OCR still refused to run against a local endpoint after the others had been
+        // fixed — and reported it as an authentication failure rather than a missing setting.
+        current.missingKeyError()?.let { return Err(it) }
 
         val baseUrl  = current.baseUrl.trimEnd('/')
         val endpoint = "$baseUrl/chat/completions"

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIServiceClient.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AIServiceClient.kt
@@ -59,13 +59,7 @@ class AIServiceClient(
      */
     suspend fun validate(): Result<Unit, ServiceError> {
         val current = settings()
-        if (current.apiKey.isBlank()) {
-            return Err(
-                ServiceError.ConfigurationError(
-                    "No API key set. Add one in Settings → Plugins → AI Plugin."
-                )
-            )
-        }
+        current.missingKeyError()?.let { return Err(it) }
         return complete(system = "Reply with the single character: 1", userContent = "1")
             .map { }
     }
@@ -76,15 +70,7 @@ class AIServiceClient(
     ): Result<String, ServiceError> {
         val current = settings()
 
-        if (current.apiKey.isBlank()) {
-            // Not set up yet, which is a different problem from a key the provider rejected —
-            // one is "finish configuring", the other is "the key is wrong".
-            return Err(
-                ServiceError.ConfigurationError(
-                    "AI Plugin: API key is not configured. Add your key in Settings → Plugins → AI Plugin."
-                )
-            )
-        }
+        current.missingKeyError()?.let { return Err(it) }
 
         val baseUrl = current.baseUrl.trimEnd('/')
         val endpoint = "$baseUrl/chat/completions"

--- a/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettings.kt
+++ b/plugins/ai-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettings.kt
@@ -1,6 +1,7 @@
 package com.github.ahatem.qtranslate.plugins.ai
 
 import com.github.ahatem.qtranslate.api.plugin.PluginSettings
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
 import com.github.ahatem.qtranslate.api.settings.Setting
 import com.github.ahatem.qtranslate.api.settings.SettingGroup
 import com.github.ahatem.qtranslate.api.settings.SettingGroups
@@ -52,9 +53,14 @@ data class AISettings(
         label       = "API Key",
         description = "Your API key for the selected endpoint. " +
                 "Get an OpenRouter key at openrouter.ai/keys. " +
-                "Leave blank for local Ollama.",
+                "Leave blank for a local endpoint such as Ollama or LM Studio, which need none.",
         type        = SettingType.PASSWORD,
-        isRequired  = true,
+        // Not marked required, though a hosted endpoint does need one. The dialog refuses to save
+        // while a required field is blank, and that made a local endpoint impossible to configure
+        // at all — the field said "leave blank for Ollama" and then would not let you. Whether a
+        // key is needed depends on the endpoint, which an annotation cannot express, so the check
+        // moved to where the endpoint is known: see [missingKeyError].
+        isRequired  = false,
         group       = "endpoint",
         order       = 20
     )
@@ -115,4 +121,44 @@ data class AISettings(
     )
     var customHeaders: String = """{"HTTP-Referer": "https://github.com/ahatem/QTranslate", "X-Title": "QTranslate", "X-OpenRouter-Title": "QTranslate"}"""
 
-) : PluginSettings.Configurable()
+) : PluginSettings.Configurable() {
+
+    /**
+     * Whether [baseUrl] points at something running on this machine or network.
+     *
+     * A local server needs no API key, so requiring one would make Ollama and LM Studio
+     * unusable. Matched on the host rather than on a list of known products, since anyone can
+     * run an OpenAI-compatible server on any port.
+     *
+     * Deliberately generous: a private-network address counts, because a model served from
+     * another machine on the same LAN is the same privacy story as one served from this one.
+     */
+    val isLocalEndpoint: Boolean
+        get() = runCatching {
+            val host = java.net.URI(baseUrl.trim()).host?.lowercase() ?: return@runCatching false
+            host == "localhost" ||
+                host == "::1" ||
+                host.endsWith(".local") ||
+                host.startsWith("127.") ||
+                host.startsWith("10.") ||
+                host.startsWith("192.168.") ||
+                Regex("""^172\.(1[6-9]|2\d|3[01])\.""").containsMatchIn(host)
+        }.getOrDefault(false)
+
+    /**
+     * The error to report when no key is set, or null when none is needed.
+     *
+     * A hosted endpoint without a key is "finish setting this up", which is a different problem
+     * from a key the provider rejected, and the two deserve different messages. A local endpoint
+     * without a key is not a problem at all.
+     */
+    fun missingKeyError(): ServiceError? =
+        if (apiKey.isBlank() && !isLocalEndpoint) {
+            ServiceError.ConfigurationError(
+                "No API key set for $baseUrl. Add one in Settings → Plugins → AI Plugin, " +
+                    "or point the endpoint at a local server such as Ollama, which needs no key."
+            )
+        } else {
+            null
+        }
+}

--- a/plugins/ai-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettingsTest.kt
+++ b/plugins/ai-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/ai/AISettingsTest.kt
@@ -1,0 +1,75 @@
+package com.github.ahatem.qtranslate.plugins.ai
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins which endpoints are treated as local, because that decision alone decides whether the
+ * plugin demands an API key.
+ *
+ * Getting it wrong in one direction makes a local model impossible to use; in the other it lets a
+ * hosted endpoint through with no key and reports the resulting 401 as a rejected key rather than
+ * a missing one.
+ */
+class AISettingsTest {
+
+    private fun settings(url: String, key: String = "") =
+        AISettings(baseUrl = url, apiKey = key)
+
+    @Test
+    fun `local endpoints need no key`() {
+        listOf(
+            "http://localhost:11434/v1",          // Ollama
+            "http://127.0.0.1:1234/v1",           // LM Studio
+            "http://192.168.1.50:11434/v1",       // another machine on the LAN
+            "http://10.0.0.4:8080/v1",
+            "http://172.16.3.9:8080/v1",
+            "http://workstation.local:11434/v1",
+        ).forEach { url ->
+            assertTrue(settings(url).isLocalEndpoint, "$url should count as local")
+            assertNull(settings(url).missingKeyError(), "$url should not demand a key")
+        }
+    }
+
+    @Test
+    fun `hosted endpoints demand a key`() {
+        listOf(
+            "https://openrouter.ai/api/v1",
+            "https://api.openai.com/v1",
+            "https://api.mistral.ai/v1",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        ).forEach { url ->
+            assertFalse(settings(url).isLocalEndpoint, "$url should not count as local")
+            assertNotNull(settings(url).missingKeyError(), "$url should demand a key")
+        }
+    }
+
+    @Test
+    fun `a key set for a hosted endpoint is no longer missing`() {
+        assertNull(settings("https://openrouter.ai/api/v1", key = "sk-test").missingKeyError())
+    }
+
+    /**
+     * `172.16` through `172.31` are private; `172.32` and above are not.
+     *
+     * The obvious `startsWith("172.")` would wave through a public address, which is the case
+     * worth pinning since nothing else would notice.
+     */
+    @Test
+    fun `only the private half of the 172 range is local`() {
+        assertTrue(settings("http://172.16.0.1:8080/v1").isLocalEndpoint)
+        assertTrue(settings("http://172.31.255.1:8080/v1").isLocalEndpoint)
+        assertFalse(settings("http://172.32.0.1:8080/v1").isLocalEndpoint)
+        assertFalse(settings("http://172.8.0.1:8080/v1").isLocalEndpoint)
+    }
+
+    @Test
+    fun `a malformed url is treated as hosted rather than crashing`() {
+        val broken = settings("not a url at all")
+        assertFalse(broken.isLocalEndpoint)
+        assertNotNull(broken.missingKeyError())
+    }
+}

--- a/wiki/AI-Services.md
+++ b/wiki/AI-Services.md
@@ -13,6 +13,60 @@ The bundled AI Services plugin works with OpenRouter by default and can also use
 
 No additional OpenRouter site configuration is required. Free accounts are rate-limited, and model availability can change over time.
 
+## Running it locally, with nothing leaving your machine
+
+The plugin talks to any OpenAI-compatible endpoint, and both Ollama and LM Studio serve one. Point
+the Base URL at it and no text is sent anywhere off your machine: no account, no API key, no
+per-word cost, and no rate limit.
+
+This is the setup to use for anything you cannot send to a cloud service — work under an NDA,
+proprietary code, client correspondence, medical or legal material.
+
+### Ollama
+
+1. Install [Ollama](https://ollama.com/) and pull a model. `qwen2.5` handles many languages well and
+   runs on modest hardware:
+
+   ```
+   ollama pull qwen2.5
+   ```
+
+2. Ollama serves its OpenAI-compatible API on port 11434 while it is running. Check it:
+
+   ```
+   curl http://localhost:11434/v1/models
+   ```
+
+3. In QTranslate, open **Settings > Plugins > AI Services > Configure** and set:
+
+   | Setting | Value |
+   | --- | --- |
+   | Base URL | `http://localhost:11434/v1` |
+   | API Key | *leave blank* |
+   | Model | `qwen2.5` |
+
+4. Press **Test connection**. It should report the service responding.
+5. Select the AI translator under **Settings > Services & Presets**.
+
+### LM Studio
+
+Same idea. Start its local server, then use `http://127.0.0.1:1234/v1` as the Base URL with the model
+name LM Studio shows for the model you loaded. The API key stays blank.
+
+### Notes
+
+- **The API key field is genuinely optional here.** A local endpoint needs none, and QTranslate only
+  asks for one when the Base URL points somewhere off this machine. An address on your own network
+  counts as local too, so a model served from another machine on the same LAN also works without a
+  key.
+- **Quality varies by model far more than with a hosted service.** A small local model will produce
+  weaker translations than a large hosted one. Try a larger model before concluding the setup is
+  wrong.
+- **The first request after starting Ollama is slow** while the model loads into memory. Later ones
+  are much faster.
+- **Nothing else in QTranslate changes.** Hotkeys, the popup, the dictionary and document translation
+  all work the same; only where the text is sent is different.
+
 ## Troubleshooting
 
 - **HTTP 401 or 403:** The API key is missing, invalid, or not allowed to use the selected provider.
@@ -20,5 +74,7 @@ No additional OpenRouter site configuration is required. Free accounts are rate-
 - **HTTP 404:** The Base URL is incorrect or the model slug was renamed or removed. Restore the default Base URL and choose a current model slug.
 - **HTTP 429:** The provider or free tier is rate-limiting requests. Wait and retry, or choose another model.
 - **Vision OCR fails:** The selected model must support image input. `openrouter/free` automatically restricts routing according to request capabilities, but a manually selected text-only model cannot perform OCR.
+- **"No API key set" with a local endpoint:** The Base URL is not being recognised as local. Use `localhost`, `127.0.0.1`, or a private address such as `192.168.x.x` rather than a hostname that resolves off your network.
+- **Connection refused with a local endpoint:** The server is not running, or is on a different port. Confirm with `curl http://localhost:11434/v1/models` before changing anything in QTranslate.
 
-For OpenAI, Gemini, Mistral, Ollama, LM Studio, or another compatible server, replace the Base URL, API key, and model with the values documented by that provider.
+For OpenAI, Gemini, Mistral, or another hosted server, replace the Base URL, API key, and model with the values documented by that provider.


### PR DESCRIPTION
## What does this PR do?

Ollama and other local OpenAI-compatible servers need no API key, but the AI plugin refused to run without one. Five separate blank-key guards blocked translation, dictionary, the connection test, vision OCR and the enable log.

`AISettings.isLocalEndpoint` decides whether a key is actually required, from the host in `baseUrl`: loopback, `.local`, and the private ranges `10.`, `192.168.` and the private half of `172.16`–`172.31`. Every blank-key decision in the plugin now goes through one `missingKeyError()` function rather than being repeated at each call site — which is how two of them were missed the first time and only found by grepping for the pattern afterwards.

The refusal is also diagnosed correctly now. Vision reported a blank key as an **authentication** failure, which is the wrong story: nothing had rejected a key, none was needed. A hosted endpoint with no key is `ConfigurationError` — "finish setting this up" — and the message names the endpoint and mentions that a local server needs no key at all.

`onEnable` no longer warns about a missing key when the endpoint is local, which would have sent someone hunting for a problem that is not there.

**Why this was not caught by manual testing.** Local AI was reported working, but the profile used for testing has an API key stored with the value `"asd"`. Any non-blank value satisfies the old guards, so the blank-key path — the one a real Ollama user takes — was never exercised. Five unit tests now cover it directly, including the awkward halves of the `172.` range and a malformed URL, which must be treated as hosted rather than crashing.

## Related issues

## Type of change

- [x] Bug fix

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

`smokeTestAllPlugins` 43 pass / 0 fail. With no key against the default hosted endpoint the plugin still declines, now naming the endpoint and suggesting a local server.