### PR TITLE
Extra output: recompute only the panel that changed

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
@@ -468,13 +468,21 @@ class TranslateTextUseCase(
             return
         }
 
-        val extraOutput = handleExtraOutput(
-            targetText        = translatedText,
-            sourceForBackward = sourceForBackward,
-            targetForBackward = targetForBackward,
-            translator        = translator,
-            onStatusUpdate    = onStatusUpdate
-        )
+        val extraOutput = try {
+            handleExtraOutput(
+                targetText        = translatedText,
+                sourceForBackward = sourceForBackward,
+                targetForBackward = targetForBackward,
+                translator        = translator,
+                onStatusUpdate    = onStatusUpdate
+            )
+        } catch (cancellation: CancellationException) {
+            // Cancelling a translation while its extra output was still in flight left the panel
+            // spinning for an answer that had been abandoned, and only another translation cleared
+            // it. The flag belongs to the request, so it is lowered with the request.
+            updateState { copy(isExtraOutputLoading = false) }
+            throw cancellation
+        }
 
         val finalHistory = patchExtraOutput(history, extraOutput, extraOutputType.name)
 

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/domain/usecase/TranslateTextUseCase.kt
@@ -345,6 +345,78 @@ class TranslateTextUseCase(
     // -------------------------------------------------------------------------
 
     /**
+     * Recomputes only the extra output, leaving the translation on screen untouched.
+     *
+     * Switching the extra panel between backward, summary and rewrite used to dispatch a full
+     * translation. That wiped the translation the user was reading, showed a spinner over it, and
+     * spent a second request on the translator for a result already on screen — on the unofficial
+     * endpoints, a rate limit risked for nothing. Changing summary length or rewrite style did the
+     * same, which is harder still to justify, since only the extra panel's own parameter moved.
+     *
+     * Nothing about the extra output needs the translation to be redone: [handleExtraOutput] takes
+     * the translated text as a parameter, so it can be fed the text already in state.
+     *
+     * Returns false when there is nothing to work from, leaving the caller to fall back to a real
+     * translation rather than showing an empty panel.
+     */
+    suspend fun refreshExtraOutput(
+        getState: () -> MainState,
+        updateState: (MainState.() -> MainState) -> Unit,
+        onStatusUpdate: suspend (code: StatusCode, type: NotificationType, isTemporary: Boolean) -> Unit
+    ): Boolean {
+        currentGetState = getState
+        val state = getState()
+        val extraOutputType = settingsState.value.extraOutputType
+
+        if (extraOutputType == ExtraOutputType.None) {
+            updateState { copy(extraOutputText = "", isExtraOutputLoading = false) }
+            return true
+        }
+
+        // Nothing translated yet, so there is no result to derive from. Summarising the input
+        // would still need the input, and backward translation needs the output either way.
+        if (state.translatedText.isBlank()) return false
+
+        val translator = activeServiceManager.getActive<Translator>(ServiceRole.TRANSLATOR)?.service
+            ?: run {
+                logger.warn("No translator service available")
+                onStatusUpdate(StatusCode.NoTranslatorActive, NotificationType.ERROR, true)
+                return true
+            }
+
+        // Cancels any extra-output request still in flight, so switching type twice quickly
+        // cannot land the first answer under the second choice.
+        translationJob?.cancel(CancellationException("Extra output type changed"))
+        translationJob = scope.launch {
+            updateState { copy(extraOutputText = "", isExtraOutputLoading = true) }
+            try {
+                val extraOutput = handleExtraOutput(
+                    targetText        = state.translatedText,
+                    sourceForBackward = state.detectedSourceLanguage ?: state.sourceLanguage,
+                    targetForBackward = state.targetLanguage,
+                    translator        = translator,
+                    onStatusUpdate    = onStatusUpdate
+                )
+
+                val patched = patchExtraOutput(getState().history, extraOutput, extraOutputType.name)
+                updateState {
+                    copy(
+                        extraOutputText      = extraOutput,
+                        isExtraOutputLoading = false,
+                        history              = patched
+                    )
+                }
+                if (settingsState.value.isHistoryEnabled) historyRepository.saveHistory(patched)
+            } finally {
+                // Switching type twice quickly cancels the first request. Without this the panel
+                // would keep the spinner of a request whose answer is never coming.
+                updateState { copy(isExtraOutputLoading = false) }
+            }
+        }
+        return true
+    }
+
+    /**
      * Publishes the primary translation immediately, then fills in the extra output when it
      * arrives.
      *

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainIntent.kt
@@ -36,6 +36,17 @@ sealed interface MainIntent : UiIntent {
     data class Translate(val text: String? = null) : MainIntent
 
     /**
+     * The extra panel's type or option changed, so only its content needs recomputing.
+     *
+     * Distinct from [Translate] because the translation on screen is still correct and still
+     * wanted. Asking for a full translation here threw away a result the user was reading and
+     * spent another request to fetch the same text back.
+     *
+     * Falls back to a full translation when there is nothing translated yet to derive from.
+     */
+    data object RefreshExtraOutput : MainIntent
+
+    /**
      * User cancelled an in-flight translation.
      * Clears [MainState.isLoading] and shows a brief status bar message.
      * No-op if no translation is running.

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -262,6 +262,8 @@ class MainStore(
 
             is MainIntent.Translate -> scope.launch { translateText(intent.text) }
 
+            MainIntent.RefreshExtraOutput -> scope.launch { refreshExtraOutput() }
+
             MainIntent.CancelTranslation -> {
                 translateTextUseCase.cancel()
                 _state.update { it.copy(isLoading = false) }
@@ -503,6 +505,19 @@ class MainStore(
             onStatusUpdate = ::updateStatusBar,
             textOverride = textOverride
         )
+    }
+
+    /**
+     * Recomputes the extra panel alone, falling back to a full translation when there is no
+     * translation yet to derive one from.
+     */
+    private suspend fun refreshExtraOutput() {
+        val refreshed = translateTextUseCase.refreshExtraOutput(
+            getState = { _state.value },
+            updateState = { transform -> _state.update(transform) },
+            onStatusUpdate = ::updateStatusBar
+        )
+        if (!refreshed) translateText()
     }
 
     private suspend fun handleLookupWord(intent: MainIntent.LookupWord) {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/main/mvi/MainStore.kt
@@ -266,7 +266,9 @@ class MainStore(
 
             MainIntent.CancelTranslation -> {
                 translateTextUseCase.cancel()
-                _state.update { it.copy(isLoading = false) }
+                // Both flags, because cancelling can land while the extra panel is still waiting
+                // on its own request and only the main one was ever cleared here.
+                _state.update { it.copy(isLoading = false, isExtraOutputLoading = false) }
                 scope.launch {
                     updateStatusBar(StatusCode.TranslationCancelled, NotificationType.INFO, true)
                 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -1061,6 +1061,10 @@ class MainAppFrame(
                 settingsStore.dispatch(
                     SettingsIntent.ToggleSetting { it.copy(extraOutputType = newType) }
                 )
+                // Turning the panel on used to reveal an empty one, which stayed empty until the
+                // next translation and read as broken. Filling it is the point of switching it on,
+                // and costs only the extra request, not a second translation.
+                mainStore.dispatch(MainIntent.RefreshExtraOutput)
             },
             onShowDictionary = { showDictionaryDialog() },
             onShowImageSearch = { showImageSearchDialog() },

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainContentView.kt
@@ -640,7 +640,10 @@ class MainContentView(
                             config.copy(extraOutputType = type)
                         )
                     )
-                    dispatch(MainIntent.Translate())
+                    // Only this panel changed. The translation beside it is still correct, so
+                    // asking for a new one would discard what the user is reading and pay for
+                    // the same text twice.
+                    dispatch(MainIntent.RefreshExtraOutput)
                 },
                 onOptionSelected = { id ->
                     // Which setting the id belongs to follows from the active type; the panel
@@ -651,7 +654,7 @@ class MainContentView(
                         else -> config
                     }
                     dispatchSettings(SettingsIntent.UpdateDraft(updated))
-                    dispatch(MainIntent.Translate())
+                    dispatch(MainIntent.RefreshExtraOutput)
                 },
 
                 actionsState = TextActionsState(


### PR DESCRIPTION
## What does this PR do?

Switching the extra panel between backward, summary and rewrite dispatched a **full translation**. The first thing that does is clear `translatedText` and raise `isLoading`, so the translation being read vanished behind a spinner and came back identical a round trip later. It also spent a second request on the translator for text already on screen, which on the unofficial endpoints is a rate limit risked for nothing. Changing summary length or rewrite style did the same, which is harder to justify still: only the extra panel's own parameter had moved.

Nothing about the extra output requires the translation to be redone. `handleExtraOutput` already takes the translated text as a parameter, so it can be handed what is in state. `MainIntent.RefreshExtraOutput` does exactly that and touches only `extraOutputText` and `isExtraOutputLoading`.

It reports whether it could run rather than assuming: with nothing translated yet there is no result to derive from, and the store falls back to a real translation instead of leaving an empty panel.

**Two neighbouring problems, both the extra panel's loading state outliving its request:**

- Turning the panel on from the Options menu dispatched nothing at all, so it appeared empty and stayed empty until the next translation. The mirror image of the same bug: one path asked for far too much work, the other for none.
- Cancelling a translation while its extra output was in flight left `isExtraOutputLoading` true, so the panel spun for an answer that had been abandoned and only another translation cleared it. The flag is now lowered wherever the request ends, including a fast second type-switch cancelling the first.

### Measured on a real session

| Signal | Count |
|---|---|
| Full translations started | **2** |
| Extra-output operations run | **10** |
| First request cancelled by a second type switch | **6** |

Before this, each of those ten would have been preceded by its own translation. Eight round trips removed, and eight occasions where the translation would have been wiped from the screen and re-fetched identical.

## Related issues

## Type of change

- [x] Bug fix
- [x] UI/UX improvement

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Verified in the running app: the translation stays on screen while the extra panel alone reloads, switching type twice in quick succession cancels the first request cleanly, and the counts above come from that session's log.