### PR TITLE
Stop a translation and a second monitor from taking down a window

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LocalizationManager.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/localization/LocalizationManager.kt
@@ -25,6 +25,9 @@ class LocalizationManager(
     // @Volatile ensures EDT always sees the latest reference written by IO dispatcher.
     @Volatile private var activeTranslations: Map<String, String> = emptyMap()
 
+    /** Keys already reported as unformattable, so one bad string is logged once, not per repaint. */
+    private val brokenStringsReported = ConcurrentHashMap.newKeySet<String>()
+
     private val _activeLanguage = MutableStateFlow(LanguageCode.ENGLISH)
     val activeLanguageFlow: StateFlow<LanguageCode> = _activeLanguage.asStateFlow()
     val activeLanguage: LanguageCode get() = _activeLanguage.value
@@ -151,6 +154,10 @@ class LocalizationManager(
         languageMetaCache.remove(code)
         coverageCache.remove(code)
 
+        // A language just edited may have had its broken string fixed, and the report is only
+        // useful if the fixed version can earn a new one.
+        brokenStringsReported.clear()
+
         // Strings are served from activeTranslations, a snapshot taken when the language was
         // loaded, so clearing the caches alone changed nothing on screen. Someone editing the
         // language they were running saw none of their own work until they switched away and
@@ -190,12 +197,56 @@ class LocalizationManager(
     // String resolution
     // -------------------------------------------------------------------------
 
+    /**
+     * The string for [key] in the active language, formatted with [args] when there are any.
+     *
+     * ### Why the formatting is guarded
+     * `format` throws when a string's placeholders do not match the arguments given, and these
+     * strings come from files anyone can write. The language editor warns about a mismatch but
+     * deliberately does not block one, and a file dropped into `languages/` by hand never passes
+     * the editor at all. It does not even take a mistake: a translator writing an ordinary percent
+     * sign, as in "(100%)", produces an unknown conversion. Unguarded, that throws from the middle
+     * of building whatever screen asked for the string, so one careless character in one
+     * translation takes out a window.
+     *
+     * A translation that cannot be formatted therefore falls back to the English text, and English
+     * that cannot be formatted either falls back to the unformatted string. A label reading "%s" is
+     * a bug report someone can act on; a stack trace out of a paint call is a broken application.
+     */
     fun getString(key: String, vararg args: Any): String {
         val raw = activeTranslations[key]
             ?: translationCache[LanguageCode.ENGLISH]?.get(key)
             ?: embeddedFallback[key]
             ?: key
-        return if (args.isEmpty()) raw else raw.format(*args)
+        if (args.isEmpty()) return raw
+
+        formatOrNull(raw, args)?.let { return it }
+        reportBrokenString(key, raw)
+
+        // English is the one text whose placeholders are checked by a test, so it is worth trying
+        // before giving up on formatting entirely.
+        val english = embeddedFallback[key]
+        if (english != null && english != raw) {
+            formatOrNull(english, args)?.let { return it }
+        }
+        return raw
+    }
+
+    private fun formatOrNull(template: String, args: Array<out Any>): String? =
+        runCatching { template.format(*args) }.getOrNull()
+
+    /**
+     * Logs a broken string the first time it is seen.
+     *
+     * [getString] is called while building and repainting the interface, so logging on every call
+     * would fill the log file with a single bad label and bury whatever the user was reporting.
+     */
+    private fun reportBrokenString(key: String, template: String) {
+        if (!brokenStringsReported.add(key)) return
+        logger.warn(
+            "Localization: '$key' could not be formatted in '${_activeLanguage.value.tag}' " +
+                "and fell back to English. Its placeholders do not match the arguments: \"$template\""
+        )
     }
 
     fun getLanguageMeta(language: LanguageCode): LocalizedLanguageMeta? =

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/settings/data/Configuration.kt
@@ -65,10 +65,22 @@ data class Size(val width: Int, val height: Int) {
     init { require(width > 0 && height > 0) { "Size must be positive, was ${width}x${height}." } }
 }
 
+/**
+ * A saved window position, in the virtual screen coordinates AWT reports.
+ *
+ * Deliberately unconstrained. This used to require both coordinates to be non-negative, which is
+ * simply not true of a real desktop: a display arranged to the left of or above the primary one
+ * occupies negative coordinates, and a window sitting on it has an ordinary, valid, negative
+ * position. The requirement turned that into an IllegalArgumentException thrown from the middle of
+ * saving, so call sites clamped to zero to get past it, which then moved the window to the primary
+ * display on the next launch.
+ *
+ * A position that is no longer on any connected display is a genuine worry, but it belongs to the
+ * moment the window is placed rather than the moment the number is stored, because the displays
+ * can change in between. `isPositionReachable` in ui-swing handles it there.
+ */
 @Serializable
-data class Position(val x: Int, val y: Int) {
-    init { require(x >= 0 && y >= 0) { "Position must be non-negative, was ($x, $y)." } }
-}
+data class Position(val x: Int, val y: Int)
 
 // -------------------------------------------------------------------------
 // Hotkeys

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/localization/LocalizationFormatSafetyTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/localization/LocalizationFormatSafetyTest.kt
@@ -1,0 +1,126 @@
+package com.github.ahatem.qtranslate.core.localization
+
+import com.github.ahatem.qtranslate.api.core.Logger
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * That a badly formatted translation degrades instead of throwing.
+ *
+ * `getString` finishes by running the string through `format`, and the strings come from files
+ * anyone can write. The language editor warns about a placeholder mismatch but deliberately does
+ * not block one, and a file dropped into `languages/` by hand never passes the editor at all. So
+ * the application has to survive a string it cannot format, because it will meet one.
+ *
+ * The percent case is the one worth keeping in mind: it is not a mistake with placeholders at all,
+ * it is a translator writing "(100%)" in ordinary prose. The editor's mismatch check does not even
+ * flag it, because its pattern needs a letter after the `%`.
+ */
+class LocalizationFormatSafetyTest {
+
+    /** A real key that takes one argument, so the test breaks if the English file changes shape. */
+    private val key = "settings_appearance.delete_confirm"
+
+    @Test
+    fun `a translation with an extra placeholder falls back to English rather than throwing`() = runTest {
+        val (manager, _) = managerWith("Supprimer la traduction %s de %s ?")
+
+        val result = manager.getString(key, "fr-FR")
+
+        assertEquals(manager.englishStrings().getValue(key).format("fr-FR"), result)
+    }
+
+    @Test
+    fun `an ordinary percent sign in prose does not throw`() = runTest {
+        // Unflagged by the editor and fatal at runtime: the case this whole guard exists for.
+        val (manager, _) = managerWith("Supprimer %s (100%) ?")
+
+        val result = manager.getString(key, "fr-FR")
+
+        assertEquals(manager.englishStrings().getValue(key).format("fr-FR"), result)
+    }
+
+    @Test
+    fun `a translation that changes the conversion type falls back`() = runTest {
+        val (manager, _) = managerWith("Supprimer %d ?")
+
+        val result = manager.getString(key, "fr-FR")
+
+        assertEquals(manager.englishStrings().getValue(key).format("fr-FR"), result)
+    }
+
+    @Test
+    fun `a correct translation is still used`() {
+        // The guard must not quietly swallow good translations along with bad ones.
+        val (manager, _) = managerWith("Supprimer la traduction %s ?")
+
+        assertEquals("Supprimer la traduction fr-FR ?", manager.getString(key, "fr-FR"))
+    }
+
+    @Test
+    fun `dropping a placeholder is left alone, because format accepts it`() {
+        // Extra arguments are ignored by String.format, so this never threw and must not start
+        // being rewritten to English now.
+        val (manager, _) = managerWith("Supprimer cette traduction ?")
+
+        assertEquals("Supprimer cette traduction ?", manager.getString(key, "fr-FR"))
+    }
+
+    @Test
+    fun `a broken string is reported once, not on every repaint`() {
+        val (manager, warnings) = managerWith("Supprimer %s de %s ?")
+
+        repeat(20) { manager.getString(key, "fr-FR") }
+
+        assertEquals(1, warnings.count { key in it }, "Expected exactly one warning, got: $warnings")
+    }
+
+    @Test
+    fun `no arguments means no formatting, so a lone percent is safe`() {
+        // Nothing to substitute, so the string is handed back untouched. Formatting it anyway
+        // would break strings that were never meant to be formatted.
+        val (manager, _) = managerWith("Progression : 100%")
+
+        assertEquals("Progression : 100%", manager.getString(key))
+    }
+
+    // -------------------------------------------------------------------------
+
+    /** A manager whose active language holds [translation] for [key], plus the warnings it logs. */
+    private fun managerWith(translation: String): Pair<LocalizationManager, List<String>> {
+        val dir = createTempDirectory("qtranslate-loc").toFile().apply { deleteOnExit() }
+        File(dir, "languages").apply { mkdirs() }
+            .resolve("fr-FR.toml")
+            .writeText(
+                """
+                [meta]
+                name = "French"
+
+                [settings_appearance]
+                ${key.substringAfter('.')} = "$translation"
+                """.trimIndent()
+            )
+
+        val warnings = mutableListOf<String>()
+        val logger = object : Logger {
+            override fun debug(message: String) = Unit
+            override fun info(message: String) = Unit
+            override fun warn(message: String) { warnings += message }
+            override fun error(message: String, error: Throwable?) = Unit
+        }
+
+        val manager = LocalizationManager(dir, LanguageTomlParser(), logger)
+        kotlinx.coroutines.runBlocking { manager.loadLanguage(LanguageCode("fr-FR")) }
+
+        assertTrue(
+            manager.englishStrings().containsKey(key),
+            "The English file no longer has '$key'; this test needs a key that takes an argument"
+        )
+        return manager to warnings
+    }
+}

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/settings/data/WindowPositionTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/settings/data/WindowPositionTest.kt
@@ -1,0 +1,50 @@
+package com.github.ahatem.qtranslate.core.settings.data
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * That a window position on a display left of the primary one can be stored at all.
+ *
+ * [Position] used to require both coordinates to be non-negative. A display arranged to the left of
+ * or above the primary one occupies negative coordinates, so a window on it threw from the middle
+ * of saving. Five of the seven call sites had grown a `coerceAtLeast(0)` to get past it, which is
+ * how the constraint survived: the crash only reached the two that had not.
+ */
+class WindowPositionTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    @Test
+    fun `a position on a display left of the primary one is accepted`() {
+        val position = Position(x = -1720, y = 240)
+
+        assertEquals(-1720, position.x)
+        assertEquals(240, position.y)
+    }
+
+    @Test
+    fun `a position above the primary display is accepted`() {
+        assertEquals(-980, Position(x = 300, y = -980).y)
+    }
+
+    @Test
+    fun `a negative position survives a round trip through storage`() {
+        // Serialising was never the problem; reading it back on the next launch is where a
+        // constructor requirement would have bitten instead.
+        val original = Configuration.DEFAULT.copy(mainWindowPosition = Position(-1720, -300))
+
+        val restored = json.decodeFromString<Configuration>(json.encodeToString(original))
+
+        assertEquals(Position(-1720, -300), restored.mainWindowPosition)
+    }
+
+    @Test
+    fun `a size must still be positive`() {
+        // The matching requirement on Size is correct and stays: there is no such thing as a
+        // window minus four pixels wide, and it is not what negative coordinates mean.
+        val failure = runCatching { Size(width = -1, height = 100) }.exceptionOrNull()
+        assertEquals(IllegalArgumentException::class, failure!!::class)
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/dictionary/QuickDictionaryDialog.kt
@@ -19,6 +19,8 @@ import javax.swing.*
 import javax.swing.border.EmptyBorder
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.Icons
 import com.github.ahatem.qtranslate.ui.swing.shared.widgets.ServiceInfoRenderer
+import com.github.ahatem.qtranslate.ui.swing.shared.util.connectedScreenBounds
+import com.github.ahatem.qtranslate.ui.swing.shared.util.isPositionReachable
 
 /**
  * Floating, always-on-top dictionary popup.
@@ -550,7 +552,7 @@ class QuickDictionaryDialog(
         focusableWindowState = false
         val pos = location
         val sz = size
-        currentState?.onSavePosition?.invoke(Position(pos.x.coerceAtLeast(0), pos.y.coerceAtLeast(0)))
+        currentState?.onSavePosition?.invoke(Position(pos.x, pos.y))
         currentState?.onSaveSize?.invoke(Size(sz.width, sz.height))
     }
 
@@ -609,7 +611,12 @@ class QuickDictionaryDialog(
         }
         when {
             !config.autoPositionEnabled -> {
-                location = config.lastKnownPosition.toPoint()
+                val saved = config.lastKnownPosition
+                if (isPositionReachable(Rectangle(saved.x, saved.y, width, height), connectedScreenBounds())) {
+                    location = saved.toPoint()
+                } else {
+                    setLocationRelativeTo(owner)
+                }
             }
             !config.positionNearMouse -> {
                 // Auto-triggered from translation — position adjacent to the owner window
@@ -687,7 +694,7 @@ class QuickDictionaryDialog(
                 isDragging = false
                 val pos = location
                 currentState?.onSavePosition?.invoke(
-                    Position(pos.x.coerceAtLeast(0), pos.y.coerceAtLeast(0))
+                    Position(pos.x, pos.y)
                 )
                 if (!isPinned) startIdleHide()
             }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/imagesearch/ImageSearchDialog.kt
@@ -598,7 +598,7 @@ class ImageSearchDialog(
     }
 
     private fun saveGeometry() {
-        currentState?.onSavePosition?.invoke(Position(location.x.coerceAtLeast(0), location.y.coerceAtLeast(0)))
+        currentState?.onSavePosition?.invoke(Position(location.x, location.y))
         currentState?.onSaveSize?.invoke(Size(size.width, size.height))
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainAppFrame.kt
@@ -71,6 +71,8 @@ import javax.imageio.ImageIO
 import javax.swing.*
 import kotlin.system.exitProcess
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.Icons
+import com.github.ahatem.qtranslate.ui.swing.shared.util.connectedScreenBounds
+import com.github.ahatem.qtranslate.ui.swing.shared.util.isPositionReachable
 
 class MainAppFrame(
     private val mainStore: MainStore,
@@ -425,15 +427,13 @@ class MainAppFrame(
                 )
             }
 
-            val savedPosition = config.mainWindowPosition
-            if (savedPosition != null) {
-                setLocation(savedPosition.x, savedPosition.y)
-            }
             iconImages = loadIcons()
 
             mainContentView.render(mainStore.state.value, settingsStore.state.value)
             pack()
-            if (config.mainWindowPosition == null) setLocationRelativeTo(null)
+            // After pack, because deciding whether a position is still reachable needs the size
+            // the window actually ended up with.
+            restorePosition(config.mainWindowPosition)
 
             // Enforce Input → Output → Extra (→ Input) Tab cycle across all layouts.
             // In Compact layout the policy also switches tabs so hidden panes become
@@ -1270,10 +1270,30 @@ class MainAppFrame(
             SettingsIntent.ToggleSetting {
                 it.copy(
                     mainWindowSize = Size(s.width, s.height),
-                    mainWindowPosition = Position(p.x.coerceAtLeast(0), p.y.coerceAtLeast(0))
+                    mainWindowPosition = Position(p.x, p.y)
                 )
             }
         )
+    }
+
+    /**
+     * Puts the window back where it was left, unless that is nowhere the user could see it.
+     *
+     * A position saved on a display that is no longer attached restores a window that is running
+     * and focusable and entirely invisible, which is indistinguishable from the application having
+     * failed to start.
+     */
+    private fun restorePosition(saved: Position?) {
+        if (saved == null) {
+            setLocationRelativeTo(null)
+            return
+        }
+        if (isPositionReachable(Rectangle(saved.x, saved.y, width, height), connectedScreenBounds())) {
+            setLocation(saved.x, saved.y)
+        } else {
+            logger.info("Saved window position (${saved.x}, ${saved.y}) is off every connected display; centring instead")
+            setLocationRelativeTo(null)
+        }
     }
 
     /**

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quicktranslate/QuickTranslateDialog.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/quicktranslate/QuickTranslateDialog.kt
@@ -27,6 +27,8 @@ import javax.swing.border.EmptyBorder
 import kotlin.math.abs
 import kotlin.math.max
 import com.github.ahatem.qtranslate.ui.swing.shared.icon.Icons
+import com.github.ahatem.qtranslate.ui.swing.shared.util.connectedScreenBounds
+import com.github.ahatem.qtranslate.ui.swing.shared.util.isPositionReachable
 
 
 class QuickTranslateDialog(
@@ -583,7 +585,12 @@ class QuickTranslateDialog(
 
             setLocation(x, y)
         } else {
-            location = config.lastKnownPosition.toPoint()
+            val saved = config.lastKnownPosition
+            if (isPositionReachable(Rectangle(saved.x, saved.y, width, height), connectedScreenBounds())) {
+                location = saved.toPoint()
+            } else {
+                setLocationRelativeTo(owner)
+            }
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ScreenBounds.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ScreenBounds.kt
@@ -1,0 +1,48 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.util
+
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+
+/**
+ * Whether a window restored to [bounds] would land somewhere the user can still reach it.
+ *
+ * Saved positions outlive the desktop they were saved on. A window put on a second display and
+ * closed there has a position that means nothing once that display is unplugged, and restoring it
+ * anyway produces a window that is running, focusable and completely invisible, which reads as the
+ * application having failed to start.
+ *
+ * "Reachable" is deliberately weaker than "fully visible": a window the user deliberately pushed
+ * half off the edge should stay where they put it. All this asks is that enough of it overlaps a
+ * display to be seen and dragged back.
+ *
+ * @param screens the connected displays. Empty means they could not be read, in which case the
+ *   saved position is trusted rather than second-guessed, since overriding on no information would
+ *   move windows for people whose setup is fine.
+ */
+fun isPositionReachable(bounds: Rectangle, screens: List<Rectangle>): Boolean {
+    if (screens.isEmpty()) return true
+    return screens.any { screen ->
+        val visible = screen.intersection(bounds)
+        // Rectangle.intersection returns a negative-sized rectangle when there is no overlap,
+        // which isEmpty covers.
+        !visible.isEmpty &&
+            visible.width >= minOf(MIN_VISIBLE_WIDTH, bounds.width) &&
+            visible.height >= minOf(MIN_VISIBLE_HEIGHT, bounds.height)
+    }
+}
+
+/**
+ * The bounds of every connected display, or empty if they cannot be read.
+ *
+ * Empty rather than an exception on a headless or otherwise unusual environment: the callers are
+ * all restoring a window position, and none of them has anything useful to do with a failure.
+ */
+fun connectedScreenBounds(): List<Rectangle> = runCatching {
+    GraphicsEnvironment.getLocalGraphicsEnvironment()
+        .screenDevices
+        .map { it.defaultConfiguration.bounds }
+}.getOrDefault(emptyList())
+
+/** Roughly a grabbable corner: enough to see the window and drag it somewhere better. */
+private const val MIN_VISIBLE_WIDTH = 120
+private const val MIN_VISIBLE_HEIGHT = 40

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ScreenBoundsTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/util/ScreenBoundsTest.kt
@@ -1,0 +1,77 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.util
+
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * That a saved window position is judged against the displays that exist now.
+ *
+ * Positions outlive the desktop they were saved on. Restoring one onto a display that has since
+ * been unplugged gives a window that is running, focusable and invisible, which looks exactly like
+ * the application having failed to start. The rule is deliberately permissive: a window someone
+ * pushed half off the edge should stay where they put it.
+ */
+class ScreenBoundsTest {
+
+    private val primary = Rectangle(0, 0, 1920, 1080)
+
+    /** A display arranged to the left of the primary one, which is where negatives come from. */
+    private val leftOfPrimary = Rectangle(-1920, 0, 1920, 1080)
+
+    @Test
+    fun `a window on the primary display is reachable`() {
+        assertTrue(isPositionReachable(Rectangle(100, 100, 800, 600), listOf(primary)))
+    }
+
+    @Test
+    fun `a window at negative coordinates is reachable when that display is attached`() {
+        // The whole point of dropping the non-negative requirement on Position.
+        assertTrue(isPositionReachable(Rectangle(-1500, 200, 800, 600), listOf(primary, leftOfPrimary)))
+    }
+
+    @Test
+    fun `the same window is not reachable once that display is gone`() {
+        assertFalse(isPositionReachable(Rectangle(-1500, 200, 800, 600), listOf(primary)))
+    }
+
+    @Test
+    fun `a window deliberately pushed half off the edge is left alone`() {
+        // Overlaps the primary by 1520px of its width. A stricter "fully visible" rule would
+        // yank this back and undo something the user did on purpose.
+        assertTrue(isPositionReachable(Rectangle(1520, 400, 800, 600), listOf(primary)))
+    }
+
+    @Test
+    fun `a sliver too small to grab does not count as reachable`() {
+        // Two pixels of overlap is visible in the arithmetic and useless to a person.
+        assertFalse(isPositionReachable(Rectangle(1918, 400, 800, 600), listOf(primary)))
+    }
+
+    @Test
+    fun `a window entirely below the desktop is not reachable`() {
+        assertFalse(isPositionReachable(Rectangle(100, 4000, 800, 600), listOf(primary)))
+    }
+
+    @Test
+    fun `unknown displays mean the saved position is trusted`() {
+        // Headless, or a graphics environment that would not answer. Overriding on no information
+        // would move windows for people whose setup is perfectly fine.
+        assertTrue(isPositionReachable(Rectangle(-9000, -9000, 800, 600), emptyList()))
+    }
+
+    @Test
+    fun `a window smaller than the minimum is judged on its own size`() {
+        // A window narrower than the grabbable minimum can still be fully visible, and must not be
+        // declared unreachable for being small.
+        val tiny = Rectangle(10, 10, 60, 20)
+        assertTrue(isPositionReachable(tiny, listOf(primary)))
+    }
+
+    @Test
+    fun `reading the real displays never throws`() {
+        // Returns empty rather than failing when there is no display, which is what CI is.
+        connectedScreenBounds()
+    }
+}


### PR DESCRIPTION
Two independent crashes found while reviewing the configuration and localization subsystems. Both are reachable without doing anything unusual, and neither had a test.

## A translation could throw where it was used

`LocalizationManager.getString` ended with `raw.format(*args)`, unguarded. These strings come from files anyone can write: the language editor warns about a placeholder mismatch but **deliberately does not block one** (a documented, reasonable decision), and a file dropped into `languages/` by hand never passes the editor at all.

It does not even take a mistake. A translator writing an ordinary percent sign produces an unknown conversion, and the editor's own check does not flag it, because its pattern requires a letter after the `%`:

```
english placeholders     : [%s]        // "Progress: %s"
translation placeholders : [%s]        // "Progres : %s (100%)"
editor flags a mismatch? : false
runtime                  : THROWS UnknownFormatConversionException
```

What each mistake actually does, measured rather than assumed:

| Translator does this | Before |
|---|---|
| Adds a placeholder | `MissingFormatArgumentException` |
| Changes `%s` to `%d` | `IllegalFormatConversionException` |
| Writes prose like `(100%)` | `UnknownFormatConversionException` |
| Drops a placeholder | safe, extra args are ignored |

The exception surfaced from the middle of building whatever screen wanted the string, so one careless character in one translation took out a window.

**Now:** a string that cannot be formatted falls back to the English text, and English that cannot be formatted either falls back to the unformatted string. A label reading `%s` is a bug report someone can act on. The failure is logged **once per key** rather than per call, because `getString` runs on every repaint and a single bad label would otherwise fill the log file that #200 just wired up.

## A window on a second monitor could throw where it was saved

`Position` required both coordinates to be non-negative. That is not true of a real desktop: a display arranged to the left of or above the primary one occupies negative coordinates, and a window on it has an ordinary, valid, negative position.

Five of the seven save sites had grown a `.coerceAtLeast(0)` to get past this, which is exactly why the constraint survived. The exception only reached the two that had not, both in `QuickTranslateDialog`:

- `mouseReleased` — drag the popup onto that monitor and release, and it threw before `startIdleHide()`, leaving **the popup stuck open**.
- `hideDialog()` — threw before the next line, so **the size was never saved**.

**Now:** the requirement is gone, and the clamps with it, since clamping to zero was its own bug (it moved the window to the primary display on the next launch). What the constraint was reaching for belongs at *restore* time instead, because the displays can change while the app is closed. `isPositionReachable` asks only that enough of the window overlap a connected display to be seen and dragged, so a window deliberately pushed half off the edge stays where it was put, while one saved on a monitor that is now unplugged is centred rather than restored invisibly. `Size` keeps its own requirement, which is correct.

## Testing

Three new test classes, 20 tests. **Each was checked against the bug it describes**: with both bugs reintroduced, exactly the tests that should fail did, and the control cases (dropping a placeholder, a correct translation, no-args, positive `Size`) stayed green.

`./gradlew build` passes.

## Note on the configuration migrator

Reviewed and **no bugs found**. Fresh installs are stamped with `CURRENT_VERSION` while the field default stays 1, the loop cannot spin on a step that forgets to bump, a newer-than-current config is returned untouched, and `ignoreUnknownKeys` means a future field removal will not reset anyone's settings. Nothing to change there.