### PR TITLE
Show the download count in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 **The translation tool that Questsoft abandoned. Rebuilt from scratch. Built to last.**
 
 [![Release](https://img.shields.io/github/v/release/ahatem/QTranslate?style=flat-square&color=4A90D9&label=latest)](https://github.com/ahatem/QTranslate/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/ahatem/QTranslate/total?style=flat-square&color=4A90D9&label=downloads)](https://github.com/ahatem/QTranslate/releases)
 [![License](https://img.shields.io/github/license/ahatem/QTranslate?style=flat-square)](LICENSE)
 [![Build](https://img.shields.io/github/actions/workflow/status/ahatem/QTranslate/ci.yml?branch=develop&style=flat-square&label=build)](https://github.com/ahatem/QTranslate/actions)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](CONTRIBUTING.md)


### PR DESCRIPTION
Adds a total-downloads badge beside the existing release badge.

```
[![Downloads](https://img.shields.io/github/downloads/ahatem/QTranslate/total?style=flat-square&color=4A90D9&label=downloads)](https://github.com/ahatem/QTranslate/releases)
```

Placed next to the release badge and given the same `4A90D9` as that badge, since it counts the same thing from the other side. It links to the releases page.

### Checked before committing

Fetched the exact URL that is now in the file, rather than assuming the shields path was right:

```
<title>downloads: 9.8k</title>
```

That is every asset across all releases, which the API confirms as **9,756**:

| Release | Downloads |
|---|---|
| v1.3.0 | 725 |
| v1.2.1 | 6,402 |
| v1.2.0 | 324 |
| v1.1.0 | 839 |
| v1.0.0 | 1,401 |
| v1.4.0-rc.1 | 65 |

I used the all-releases total rather than `latest/total`, which currently reads 725 and would drop back to near zero every time you tag a release.