### PR TITLE
Offer the application for download, not the first plugin

### DIFF
--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/ReleaseAssets.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/ReleaseAssets.kt
@@ -1,0 +1,49 @@
+package com.github.ahatem.qtranslate.core.updater
+
+/**
+ * Which file the update dialog's Download button should fetch.
+ *
+ * A release carries the application in three shapes alongside a plugin JAR for every bundled
+ * plugin, and the updater used to take whichever asset GitHub listed first. GitHub lists them
+ * alphabetically, so first has always meant `ai-plugin-<version>.jar`: pressing Download in a
+ * release-shipping application handed the user a single plugin and called it an update. Nothing
+ * failed, and nothing said anything was wrong, which is why it survived several releases.
+ *
+ * Matching is therefore by name and deliberately narrow. There is no "first asset" fallback and
+ * there must never be one: an asset this cannot identify is far more likely to be a plugin than
+ * the application, so the caller falls back to the release page, where a person can choose.
+ */
+internal object ReleaseAssets {
+
+    /**
+     * The asset name a user on this platform should be given, or `null` if none is recognisable.
+     *
+     * Windows is offered the packaged build first because it carries its own Java runtime and is
+     * the answer for most people there. Everywhere else the portable archive is the equivalent,
+     * and the bare application JAR is the last resort on either.
+     */
+    fun selectDownload(assetNames: List<String>, onWindows: Boolean): String? {
+        val preference = if (onWindows) {
+            listOf(WINDOWS_PACKAGE, PORTABLE, APP_ONLY)
+        } else {
+            listOf(PORTABLE, APP_ONLY)
+        }
+        return preference.firstNotNullOfOrNull { shape ->
+            assetNames.firstOrNull { shape.matches(it) }
+        }
+    }
+
+    /** `QTranslate-1.4.0-windows-x64.zip`, the build with a bundled runtime. */
+    private val WINDOWS_PACKAGE = Regex("""QTranslate-\d[^-]*-windows.*\.zip""", RegexOption.IGNORE_CASE)
+
+    /**
+     * `QTranslate-1.4.0.zip`, the portable archive.
+     *
+     * The `[^-]*` is what separates this from the Windows package: both begin `QTranslate-` and
+     * end `.zip`, and only the absence of a further hyphenated part tells them apart.
+     */
+    private val PORTABLE = Regex("""QTranslate-\d[^-]*\.zip""", RegexOption.IGNORE_CASE)
+
+    /** `QTranslate-App-1.4.0.jar`, the application with no plugins. */
+    private val APP_ONLY = Regex("""QTranslate-App-\d[^-]*\.jar""", RegexOption.IGNORE_CASE)
+}

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/Updater.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/Updater.kt
@@ -80,6 +80,29 @@ class Updater(
     // Internal
     // -------------------------------------------------------------------------
 
+
+    /**
+     * The asset to offer for download, or the release page when none can be identified.
+     *
+     * Falling back to the page rather than to some asset is the point. An unrecognised name is far
+     * more likely to be one of the eleven plugin JARs than the application, and handing someone a
+     * plugin while calling it an update is worse than asking them to choose.
+     */
+    private fun downloadUrlFor(response: GitHubReleaseResponse): String? {
+        val chosen = ReleaseAssets.selectDownload(
+            assetNames = response.assets.map { it.name },
+            onWindows = System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+        )
+        if (chosen == null) {
+            logger.warn(
+                "No recognisable application asset in ${response.tagName} " +
+                    "(saw ${response.assets.size}); offering the release page instead"
+            )
+            return response.htmlUrl.takeIf { it.isNotBlank() }
+        }
+        return response.assets.first { it.name == chosen }.downloadUrl
+    }
+
     private suspend fun fetchRelease(): Result<VersionInfo, UpdaterError> =
         try {
             val response: GitHubReleaseResponse = httpClient.get(releasesUrl) {
@@ -92,7 +115,7 @@ class Updater(
                     versionTag   = response.tagName,
                     releaseName  = response.name,
                     releaseNotes = response.releaseNotes,
-                    downloadUrl  = response.assets.firstOrNull()?.downloadUrl,
+                    downloadUrl  = downloadUrlFor(response),
                     releaseUrl   = response.htmlUrl.takeIf { it.isNotBlank() }
                 )
             )

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/data/GitHubReleaseResponse.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/updater/data/GitHubReleaseResponse.kt
@@ -21,5 +21,6 @@ internal data class GitHubReleaseResponse(
 
 @Serializable
 internal data class GitHubAsset(
+    @SerialName("name") val name: String = "",
     @SerialName("browser_download_url") val downloadUrl: String
 )

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/updater/ReleaseAssetsTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/updater/ReleaseAssetsTest.kt
@@ -1,0 +1,130 @@
+package com.github.ahatem.qtranslate.core.updater
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * That Download offers the application rather than whatever GitHub happens to list first.
+ *
+ * The updater took `assets.firstOrNull()`. GitHub returns assets alphabetically, and every release
+ * ships a plugin JAR per bundled plugin, so first has always resolved to `ai-plugin-<version>.jar`.
+ * Pressing Download downloaded one plugin and presented it as the new version. Nothing threw and
+ * nothing logged, which is how it survived releases: it takes someone opening the file to notice.
+ *
+ * The lists below are the real asset names from v1.3.0 and v1.4.0, taken from the API, so this
+ * tests the arrangement that actually shipped rather than a tidied version of it.
+ */
+class ReleaseAssetsTest {
+
+    private val v140 = listOf(
+        "ai-plugin-2.0.0.jar",
+        "bing-services-1.0.0.jar",
+        "csv-services-1.0.0.jar",
+        "deepl-services-1.1.0.jar",
+        "google-services-1.0.0.jar",
+        "libretranslate-services-1.0.0.jar",
+        "mozhi-services-1.0.0.jar",
+        "mymemory-services-1.0.0.jar",
+        "QTranslate-1.4.0-windows-x64.zip",
+        "QTranslate-1.4.0.zip",
+        "QTranslate-App-1.4.0.jar",
+        "release-metadata.json",
+        "reverso-services-1.0.0.jar",
+        "SHA256SUMS.txt",
+        "SIZE_REPORT.md",
+        "wikimedia-reference-1.0.0.jar",
+        "yandex-web-services-1.0.0.jar",
+    )
+
+    private val v130 = listOf(
+        "ai-plugin-2.0.0.jar",
+        "bing-services-1.0.0.jar",
+        "deepl-services-1.1.0.jar",
+        "google-services-1.0.0.jar",
+        "libretranslate-services-1.0.0.jar",
+        "mozhi-services-1.0.0.jar",
+        "mymemory-services-1.0.0.jar",
+        "QTranslate-1.3.0-windows-x64.zip",
+        "QTranslate-1.3.0.zip",
+        "QTranslate-App-1.3.0.jar",
+        "release-metadata.json",
+        "reverso-services-1.0.0.jar",
+        "SHA256SUMS.txt",
+        "SIZE_REPORT.md",
+        "wikimedia-reference-1.0.0.jar",
+        "yandex-web-services-1.0.0.jar",
+    )
+
+    @Test
+    fun `Windows is offered the packaged build`() {
+        assertEquals("QTranslate-1.4.0-windows-x64.zip", ReleaseAssets.selectDownload(v140, onWindows = true))
+    }
+
+    @Test
+    fun `everywhere else is offered the portable archive`() {
+        assertEquals("QTranslate-1.4.0.zip", ReleaseAssets.selectDownload(v140, onWindows = false))
+    }
+
+    @Test
+    fun `the release that shipped the bug selects correctly too`() {
+        assertEquals("QTranslate-1.3.0-windows-x64.zip", ReleaseAssets.selectDownload(v130, onWindows = true))
+        assertEquals("QTranslate-1.3.0.zip", ReleaseAssets.selectDownload(v130, onWindows = false))
+    }
+
+    @Test
+    fun `no plugin jar is ever chosen`() {
+        // The whole point. Stated as a property over both real releases and both platforms rather
+        // than as one assertion about the alphabetically first name, so a future plugin sorting
+        // ahead of ai-plugin cannot quietly reintroduce this.
+        listOf(v130, v140).forEach { assets ->
+            listOf(true, false).forEach { onWindows ->
+                val chosen = ReleaseAssets.selectDownload(assets, onWindows)
+                assertTrue(
+                    chosen != null && chosen.startsWith("QTranslate", ignoreCase = true),
+                    "Chose '$chosen', which is not the application"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the portable archive is not mistaken for the Windows package`() {
+        // Both begin QTranslate- and end .zip. Only the absence of a further hyphenated part
+        // separates them, which is the fiddliest part of the matching.
+        val portableOnly = listOf("ai-plugin-2.0.0.jar", "QTranslate-1.4.0.zip")
+        assertEquals("QTranslate-1.4.0.zip", ReleaseAssets.selectDownload(portableOnly, onWindows = true))
+
+        val windowsOnly = listOf("ai-plugin-2.0.0.jar", "QTranslate-1.4.0-windows-x64.zip")
+        assertNull(
+            ReleaseAssets.selectDownload(windowsOnly, onWindows = false),
+            "A non-Windows user must not be handed the Windows package with its bundled runtime"
+        )
+    }
+
+    @Test
+    fun `the app-only jar is the last resort, not the first choice`() {
+        val everything = listOf("QTranslate-App-1.4.0.jar", "QTranslate-1.4.0.zip")
+        assertEquals("QTranslate-1.4.0.zip", ReleaseAssets.selectDownload(everything, onWindows = false))
+
+        val jarOnly = listOf("ai-plugin-2.0.0.jar", "QTranslate-App-1.4.0.jar")
+        assertEquals("QTranslate-App-1.4.0.jar", ReleaseAssets.selectDownload(jarOnly, onWindows = false))
+    }
+
+    @Test
+    fun `an unrecognisable release yields nothing rather than a guess`() {
+        // So the caller can fall back to the release page. Returning "something" here is exactly
+        // how a plugin ended up being served as an update.
+        val noAppAssets = listOf("ai-plugin-2.0.0.jar", "SHA256SUMS.txt", "release-metadata.json")
+        assertNull(ReleaseAssets.selectDownload(noAppAssets, onWindows = true))
+        assertNull(ReleaseAssets.selectDownload(noAppAssets, onWindows = false))
+        assertNull(ReleaseAssets.selectDownload(emptyList(), onWindows = true))
+    }
+
+    @Test
+    fun `the checksum and metadata files are never offered`() {
+        val decoys = listOf("SHA256SUMS.txt", "SIZE_REPORT.md", "release-metadata.json")
+        assertNull(ReleaseAssets.selectDownload(decoys, onWindows = true))
+    }
+}

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/updater/UpdaterAssetSelectionTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/updater/UpdaterAssetSelectionTest.kt
@@ -1,0 +1,110 @@
+package com.github.ahatem.qtranslate.core.updater
+
+import com.github.ahatem.qtranslate.api.core.Logger
+import com.github.ahatem.qtranslate.core.updater.data.UpdateCheckResult
+import com.github.michaelbull.result.get
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The same defect end to end, through the real JSON the GitHub API returns.
+ *
+ * [ReleaseAssetsTest] covers the choosing. This covers the wiring around it, and one thing that
+ * test cannot see: the asset name has to be parsed off the wire at all. `GitHubAsset` only ever
+ * read `browser_download_url`, so before this fix there was no name to match on, and adding the
+ * field is as load-bearing as the matching itself.
+ */
+class UpdaterAssetSelectionTest {
+
+    private val silentLogger = object : Logger {
+        override fun debug(message: String) = Unit
+        override fun info(message: String) = Unit
+        override fun warn(message: String) = Unit
+        override fun error(message: String, error: Throwable?) = Unit
+    }
+
+    /** Shaped like the real response, plugin JARs first, as GitHub orders them. */
+    private fun releaseJson(tag: String = "v9.9.9") = """
+        {
+          "tag_name": "$tag",
+          "name": "QTranslate 9.9.9",
+          "body": "notes",
+          "html_url": "https://github.com/ahatem/QTranslate/releases/tag/$tag",
+          "assets": [
+            {"name": "ai-plugin-2.0.0.jar", "browser_download_url": "https://example.invalid/ai-plugin-2.0.0.jar"},
+            {"name": "bing-services-1.0.0.jar", "browser_download_url": "https://example.invalid/bing-services-1.0.0.jar"},
+            {"name": "QTranslate-9.9.9-windows-x64.zip", "browser_download_url": "https://example.invalid/QTranslate-9.9.9-windows-x64.zip"},
+            {"name": "QTranslate-9.9.9.zip", "browser_download_url": "https://example.invalid/QTranslate-9.9.9.zip"},
+            {"name": "QTranslate-App-9.9.9.jar", "browser_download_url": "https://example.invalid/QTranslate-App-9.9.9.jar"},
+            {"name": "SHA256SUMS.txt", "browser_download_url": "https://example.invalid/SHA256SUMS.txt"}
+          ]
+        }
+    """.trimIndent()
+
+    private fun updaterReturning(body: String): Updater {
+        val engine = MockEngine {
+            respond(
+                content = body,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; isLenient = true }) }
+        }
+        return Updater("ahatem", "qtranslate", client, silentLogger)
+    }
+
+    @Test
+    fun `the offered download is the application, never the first asset`() = runTest {
+        val result = updaterReturning(releaseJson()).checkForUpdate(currentVersion = "1.0.0")
+
+        val available = result.get() as UpdateCheckResult.UpdateAvailable
+        val url = available.info.downloadUrl
+        assertNotNull(url, "An update with application assets must offer a download")
+
+        // Windows or not, it must be one of the application archives. Asserted as a property
+        // because the platform decides which, and CI is not Windows.
+        assertTrue(
+            url.endsWith("QTranslate-9.9.9-windows-x64.zip") || url.endsWith("QTranslate-9.9.9.zip"),
+            "Offered '$url', which is not the application"
+        )
+        assertTrue("plugin" !in url && "services" !in url, "Offered a plugin: $url")
+    }
+
+    @Test
+    fun `a release with no application assets falls back to the release page`() = runTest {
+        val pluginsOnly = """
+            {
+              "tag_name": "v9.9.9",
+              "name": "QTranslate 9.9.9",
+              "body": "notes",
+              "html_url": "https://github.com/ahatem/QTranslate/releases/tag/v9.9.9",
+              "assets": [
+                {"name": "ai-plugin-2.0.0.jar", "browser_download_url": "https://example.invalid/ai-plugin-2.0.0.jar"}
+              ]
+            }
+        """.trimIndent()
+
+        val result = updaterReturning(pluginsOnly).checkForUpdate(currentVersion = "1.0.0")
+
+        val available = result.get() as UpdateCheckResult.UpdateAvailable
+        // The page, so a person can choose, rather than the one plugin that happens to be there.
+        assertTrue(
+            available.info.downloadUrl == "https://github.com/ahatem/QTranslate/releases/tag/v9.9.9",
+            "Expected the release page, got ${available.info.downloadUrl}"
+        )
+    }
+}


### PR DESCRIPTION
Clicking **Download** in the update dialog downloaded `ai-plugin-2.0.0.jar`.

## Why

`Updater` took `assets.firstOrNull()`. GitHub returns release assets **sorted by name**, and every release ships a JAR for each bundled plugin, so the first asset is always `ai-plugin-<version>.jar`:

```
ai-plugin-2.0.0.jar          ← what Download handed you
bing-services-1.0.0.jar
csv-services-1.0.0.jar
...
QTranslate-1.4.0-windows-x64.zip
QTranslate-1.4.0.zip
QTranslate-App-1.4.0.jar
```

Nothing failed and nothing was logged. The request succeeds, a real file arrives, and only opening it shows what it is.

**This is not new in 1.4.0.** v1.3.0 has the same ordering, so the dialog has been doing this for at least two releases. Both real asset lists are in the test.

## The fix

Assets are matched by name, which first meant **parsing the name at all**: `GitHubAsset` read only `browser_download_url`, so there was nothing to match on. Windows is offered the packaged build (it carries its own Java runtime and is the answer for most people there), everywhere else the portable archive, with the bare app JAR as a last resort on either.

**There is deliberately no "first asset" fallback, and there must never be one.** An unrecognisable name is far likelier to be one of the eleven plugin JARs than the application, so an unrecognised release offers the release page and lets a person choose. That is also what a future rename of the archives gets, rather than quietly serving a plugin again.

## Testing

10 tests across two classes. The unit tests run against the **real asset lists** from v1.3.0 and v1.4.0 rather than a tidied version, and the key one is stated as a property over both releases and both platforms, so a future plugin sorting ahead of `ai-plugin` cannot reintroduce this.

Both halves were checked against the bug:

- Selection reverted to `assets.firstOrNull()` → **all 8 unit tests fail**.
- Asset name left unparsed → **the end-to-end test fails**.

`./gradlew build` passes: 262 tests, 0 failures.

## What this does not fix

**Anyone already on 1.4.0 or earlier keeps the broken behaviour.** Their copy has the old selection logic and will take the first asset until they update by hand. The workaround in the meantime is the dialog's existing **View on GitHub** button, which goes to the release page.

Uploading the archives earlier would not rescue them either: the API sorts by name, not upload order, and `release.yml` already lists the archives first.