### PR TITLE
fix(distribution): ship icon sets and third-party licenses beside languages and themes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,8 @@ jobs:
           Copy-Item portable-distribution/QTranslate/plugins windows-package/QTranslate/plugins -Recurse
           Copy-Item portable-distribution/QTranslate/languages windows-package/QTranslate/languages -Recurse
           Copy-Item portable-distribution/QTranslate/themes windows-package/QTranslate/themes -Recurse
+          Copy-Item portable-distribution/QTranslate/icons windows-package/QTranslate/icons -Recurse
+          Copy-Item portable-distribution/QTranslate/THIRD_PARTY_LICENSES windows-package/QTranslate/THIRD_PARTY_LICENSES -Recurse
           Compress-Archive -Path windows-package/QTranslate -DestinationPath "QTranslate-$version-windows-x64.zip"
 
       - name: Upload Windows package

--- a/README.md
+++ b/README.md
@@ -169,11 +169,20 @@ QTranslate/
   │     └── ...
   ├── themes/
   │     └── kokedera.theme.json       ← community theme included; drop more .theme.json files here
-  └── languages/
-        ├── ar-SA.toml
-        ├── zh-CN.toml
-        ├── de-DE.toml
-        └── ...
+  ├── languages/
+  │     ├── ar-SA.toml
+  │     ├── zh-CN.toml
+  │     ├── de-DE.toml
+  │     └── ...
+  ├── icons/
+  │     ├── material-symbols/
+  │     ├── tabler/
+  │     ├── phosphor/
+  │     └── heroicons/                ← extra icon sets; drop a set's folder in to add it
+  └── THIRD_PARTY_LICENSES/
+        ├── Lucide-ISC.txt
+        ├── MaterialSymbols-Apache-2.0.txt
+        └── ...                       ← licenses for every bundled font, icon set and theme
 ```
 
 Bundled plugins: Google, Bing, AI Services, DeepL, Mozhi, MyMemory, LibreTranslate Local, Reverso, Yandex Web, Wikimedia Reference, and CSV Dictionary. Configure a service from the service selector or **Settings → Plugins**.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,12 @@ fun Zip.configurePortableBundle(plugins: List<BundledPlugin>) {
         from(rootProject.file("themes")) {
             into("themes")
         }
+        from(rootProject.file("icons")) {
+            into("icons")
+        }
+        from(rootProject.file("THIRD_PARTY_LICENSES")) {
+            into("THIRD_PARTY_LICENSES")
+        }
         plugins.forEach { plugin ->
             from(plugin.thinArchiveFile) {
                 into("plugins")


### PR DESCRIPTION
## What does this PR do?

The portable distribution copied `languages/` and `themes/` beside the JAR but not `icons/`, so every released build shipped with only the bundled Lucide set. The icon-set chooser (from #195) was a no-op in exactly the artifacts users download. The Windows jpackage package had the same gap.

This ships the four extra sets in root `icons/` (Material Symbols, Tabler, Phosphor, Heroicons — ~60 KB of SVGs) in both the portable ZIP and the Windows package, mirroring how languages and themes are handled. It also bundles the `THIRD_PARTY_LICENSES/` folder so every shipped font, icon set and theme carries its license, and documents the new folders in the README's install tree.

## Related issues

None. Found while reviewing the release layout.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Verification

- `./gradlew assemblePortable` → the ZIP now contains `QTranslate/icons/` (all four sets) and `QTranslate/THIRD_PARTY_LICENSES/`
- `./gradlew validateReleaseSizes` → Portable ZIP 45.24 MiB / 52 MiB budget — PASS

## Screenshots (if UI changes)

No UI change.