### PR TITLE
Prepare the 1.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-08-18
+
+### Fixed
+- **The update dialog offered a plugin, not the application.** Clicking **Download** handed over `ai-plugin-2.0.0.jar` — the API sorts release assets by name and every release ships a JAR for each bundled plugin, so the "first asset" was always a plugin. Downloads are now matched by name: Windows gets the self-contained build, everywhere else the portable archive, and the bare application JAR is the last resort. Nothing ever falls back to "the first asset" again, because an unrecognisable name is far likelier to be a plugin than the application; a release that does not resolve offers the release page instead. The old behaviour had been there for at least two releases
+- The **app icon set was missing from the downloads.** Releases ship the languages and themes folders beside the JAR but not the icon sets, so every released build could only ever offer the bundled Lucide set. The portable ZIP and the Windows package now carry the four extra sets — Material Symbols, Tabler, Phosphor and Heroicons — plus the folder of licenses for every bundled font, icon set and theme
+
+### Changed
+- **The application icon is a single multi-resolution set** with sizes from 16 to 1024 pixels, named `icon-N.png`. The window and the tray load it through a multi-resolution image so Windows picks the size that suits its context — a tray icon that used to be scaled up from one small copy is now drawn at a native size
+
 ## [1.4.0] — 2026-08-18
 
 ### Added
@@ -262,7 +271,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/ahatem/QTranslate/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/ahatem/QTranslate/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/ahatem/QTranslate/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/ahatem/QTranslate/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ahatem/QTranslate/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/ahatem/QTranslate/compare/v1.2.0...v1.2.1

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/shared/AppConstants.kt
@@ -18,7 +18,7 @@ object AppConstants {
      * would have shipped an app that compares its own 1.3.0 against the 1.4.0 release it came
      * from and tells every new user an update is waiting.
      */
-    const val APP_VERSION = "1.4.0"
+    const val APP_VERSION = "1.4.1"
 
     // ============================================================
     // Timing


### PR DESCRIPTION
## What does this PR do?

Release preparation for **1.4.1**, per [Releasing.md](wiki/Releasing.md):

- Bumps `AppConstants.APP_VERSION` from `1.4.0` to `1.4.1`. This is the version compiled into the app (About dialog, log, updater comparison); the Release workflow fails if it does not match the tag.
- Adds the `## [1.4.1] — 2026-08-18` changelog section covering the five merged-but-unreleased PRs since 1.4.0:
  - **Fixed:** the updater offering a plugin instead of the application (#205), and the release downloads missing the icon sets and licenses (#207)
  - **Changed:** the multi-resolution application icon set with native tray rendering (#206)
- Updates the comparison links at the bottom and leaves a fresh empty `[Unreleased]` section.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [ ] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

No UI change.