### PR TITLE
chore(i18n): credit Ukrainian translator

### DIFF
--- a/languages/uk-UA.toml
+++ b/languages/uk-UA.toml
@@ -5,7 +5,7 @@
 name = "Ukrainian"
 native_name = "Українська"
 locale = "uk-UA"
-translators = ["AOgit"]
+translators = ["AOgit", "kopejkin"]
 rtl = false
 
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?

Adds `kopejkin` to the Ukrainian translator credits.

## Related issues

Related to #217

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [ ] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

Not applicable.
