### PR TITLE
fix: keep IME composition intact while the state cycle echoes text back

### DIFF
--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPane.kt
@@ -339,6 +339,29 @@ class AdvancedTextPane(
     private var lastRenderedCorrections: List<Correction> = emptyList()
     private var lastEmittedText: String? = null
 
+    /**
+     * True while an input method holds composition text the user has not committed yet — the
+     * half-typed Bopomofo, kana or jamo an IME shows before it becomes a word.
+     *
+     * Swing keeps that text *inside the document* and remembers where it sits with two Positions,
+     * which it uses to take the text back out on the next input-method event. A rewrite of the
+     * document from anywhere else collapses those Positions: the next event then removes nothing,
+     * and the half-typed characters are stranded in the pane as ordinary text. Typing 測試 with
+     * Bopomofo came out as ㄘㄜ測ㄕ測試 — one stranded snapshot per rewrite.
+     *
+     * The rewrite was this pane's own state cycle. Text is reported upwards on every document
+     * change, the store echoes it back, and the echo reaches the EDT by way of a background
+     * dispatcher, so it can arrive a keystroke late — and a stale echo does not match
+     * [lastRenderedText], which is exactly the condition [render] rewrites the document on.
+     * Composition makes that race trivial to hit because one keystroke changes the document
+     * twice: the old composition is removed and the new one inserted, and the state from between
+     * those two is stale the moment it is emitted.
+     *
+     * So while this is true the pane neither reports its text upwards nor writes to the document.
+     * Both resume on commit, when the document holds real text again.
+     */
+    private var isComposingText = false
+
     private val documentListener = object : DocumentListener {
         override fun insertUpdate(e: DocumentEvent?) = onUserTextChange()
         override fun removeUpdate(e: DocumentEvent?) = onUserTextChange()
@@ -373,6 +396,34 @@ class AdvancedTextPane(
         fallbackListener = FontFallbackDocumentListener(this)
         document.addDocumentListener(fallbackListener)
 
+        // A listener rather than an override of processInputMethodEvent, because Component
+        // notifies listeners before JTextComponent applies the event to the document — so
+        // isComposingText is already correct when the document listeners above run for that
+        // same event. Listening does not consume the event; the pane still receives the text.
+        addInputMethodListener(object : InputMethodListener {
+            override fun inputMethodTextChanged(e: InputMethodEvent) {
+                val text = e.text
+                val composedLength =
+                    if (text == null) 0
+                    else text.endIndex - text.beginIndex - e.committedCharacterCount
+                isComposingText = composedLength > 0
+            }
+
+            override fun caretPositionChanged(e: InputMethodEvent) = Unit
+        })
+
+        addFocusListener(object : FocusAdapter() {
+            // A composition cannot outlive the focus feeding it. Clearing here means a missed
+            // end-of-composition event cannot leave the pane permanently silent, and flushes
+            // whatever was typed before focus moved on.
+            override fun focusLost(e: FocusEvent) {
+                if (isComposingText) {
+                    isComposingText = false
+                    onUserTextChange()
+                }
+            }
+        })
+
         addComponentListener(object : ComponentAdapter() {
             override fun componentResized(e: ComponentEvent?) {
                 putClientProperty("repaintManager.doubleBufferingEnabled", true)
@@ -401,7 +452,9 @@ class AdvancedTextPane(
 
             var textWasChanged = false
 
-            if (lastRenderedText != text) {
+            // Never while a composition is open — see [isComposingText]. A state arriving then is
+            // a stale echo of half-typed text, and writing it would strand the composition.
+            if (lastRenderedText != text && !isComposingText) {
                 document.removeDocumentListener(documentListener)
                 document.removeDocumentListener(fallbackListener)
 
@@ -430,6 +483,11 @@ class AdvancedTextPane(
     }
 
     private fun onUserTextChange() {
+        // Composition text is not the user's text yet. Reporting it upwards would translate,
+        // spell-check and store half-typed Bopomofo, and would send back the stale echo that
+        // strands it. The commit fires this again with the finished text.
+        if (isComposingText) return
+
         val currentText = text
         if (currentText != lastEmittedText) {
             lastEmittedText  = currentText

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPaneCompositionTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/widgets/AdvancedTextPaneCompositionTest.kt
@@ -1,0 +1,87 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.widgets
+
+import java.awt.event.InputMethodEvent
+import java.text.AttributedString
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Typing Chinese, Japanese or Korean goes through an input method: the keystrokes first appear as
+ * provisional characters (Bopomofo, kana, jamo) that the IME later replaces with the real word.
+ * Swing keeps those provisional characters inside the document and remembers where they are with
+ * two Positions.
+ *
+ * Rewriting the document while that is going on collapses those Positions, so the IME's next
+ * event removes nothing and the provisional characters stay behind for good — typing 測試 landed
+ * in the pane as ㄘㄜ測ㄕ測試. The rewrite came from the pane's own state cycle: text is reported
+ * upwards on every document change and echoed back through a background dispatcher, so an echo
+ * carrying older text can arrive mid-composition and be written over the live one.
+ */
+class AdvancedTextPaneCompositionTest {
+
+    /**
+     * One input-method event. [committed] is text the IME has settled on and hands over for good;
+     * [composing] is still provisional and will be replaced by the next event.
+     */
+    private fun AdvancedTextPane.imeEvent(committed: String, composing: String) {
+        dispatchEvent(
+            InputMethodEvent(
+                this,
+                InputMethodEvent.INPUT_METHOD_TEXT_CHANGED,
+                AttributedString(committed + composing).iterator,
+                committed.length,
+                null,
+                null,
+            )
+        )
+    }
+
+    private fun pane(onTextChanged: (String) -> Unit = {}): AdvancedTextPane {
+        lateinit var created: AdvancedTextPane
+        SwingUtilities.invokeAndWait {
+            created = AdvancedTextPane(
+                onTextChanged = onTextChanged,
+                onTranslateRequest = {},
+                onListenRequest = {},
+            )
+        }
+        return created
+    }
+
+    @Test
+    fun `a stale state echo during composition does not strand the half-typed characters`() {
+        val emitted = mutableListOf<String>()
+        val pane = pane { emitted += it }
+
+        SwingUtilities.invokeAndWait {
+            pane.imeEvent(committed = "", composing = "ㄘ")
+            pane.imeEvent(committed = "", composing = "ㄘㄜ")
+
+            // The state cycle echoing back what the pane said a keystroke ago. It disagrees with
+            // what the pane now holds, which is the condition render() rewrites the document on.
+            pane.render("ㄘ", emptyList(), isEditable = true)
+
+            // The IME resolves the syllables into the word and commits it.
+            pane.imeEvent(committed = "測試", composing = "")
+        }
+
+        assertEquals("測試", pane.text)
+        // Half-typed Bopomofo is not text the app should translate, spell-check or store.
+        assertEquals(listOf("測試"), emitted)
+    }
+
+    @Test
+    fun `text typed without an input method is still reported upwards`() {
+        val emitted = mutableListOf<String>()
+        val pane = pane { emitted += it }
+
+        SwingUtilities.invokeAndWait {
+            pane.render("hello", emptyList(), isEditable = true)
+            pane.document.insertString(5, "!", null)
+        }
+
+        assertEquals("hello!", pane.text)
+        assertEquals(listOf("hello!"), emitted)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes typing with a composing input method (Bopomofo/Zhuyin, pinyin, kana, jamo). Typing 測試 with the Microsoft Bopomofo IME left the phonetic characters behind in the input pane — `ㄘㄜ測ㄕ測試` — which makes the pane unusable for typing CJK by hand.

**Cause.** Swing keeps composition text inside the document and remembers where it sits with two `Position`s, which `JTextComponent.replaceInputMethodText` uses to take that text back out on the next input-method event. `AdvancedTextPane` rewrites the whole document from `render()` whenever the state it is handed differs from `lastRenderedText` — and `MainAppFrame` collects that state on `Dispatchers.Default` before hopping to `Dispatchers.Swing`, so an echo can reach the EDT a keystroke late. A stale echo landing mid-composition collapses the Positions: the IME's next event then removes nothing, and the provisional characters stay for good.

Composition makes the race easy to hit because one keystroke changes the document **twice** — the old composition removed, the new one inserted — so the state emitted between those two changes is stale the moment it is sent. The same race can drop characters while typing Latin text fast; composition just makes it reproducible every time.

**Fix.** While a composition is open the pane neither reports its text upwards nor writes to the document; both resume on commit, when the document holds real text again. The flag is kept by an `InputMethodListener` rather than an override of `processInputMethodEvent`, because `Component` notifies listeners *before* `JTextComponent` applies the event to the document — so the flag is already correct when the document listeners run for that same event. A `focusLost` reset makes a missed end-of-composition event unable to leave the pane permanently silent.

Not reporting half-typed text upwards is also the right behaviour on its own: provisional Bopomofo should not reach translation, spell-check or history.

`FontFallbackDocumentListener` is deliberately left alone. It only writes character attributes, which does not move Positions, and suppressing it during composition would show composed CJK in the primary font — tofu whenever the primary font has no CJK coverage.

## Related issues

Closes #233

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [ ] The build passes locally (`./gradlew build`) — see note below
- [x] MVI architecture respected — no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)` (n/a — no I/O added)
- [x] Public API has KDoc
- [x] I have read CONTRIBUTING.md

**On the local build:** I have no JDK on the machine this was written on, so `./gradlew build` was not run locally. It was run on CI in my fork instead, on this exact commit: [CI green on `develop` + this commit](https://github.com/EddieSu/QTranslate/actions/runs/33234061976).

## Verification

The regression test drives synthetic `InputMethodEvent`s plus one stale `render()`, so the race is covered without an IME on the runner. To show it is not a test that passes either way, I ran it against unmodified `main` (= v1.4.1) with the fix removed:

```
org.opentest4j.AssertionFailedError: expected: <測試> but was: <ㄘ測試>
    at AdvancedTextPaneCompositionTest.kt:69
```

[That run](https://github.com/EddieSu/QTranslate/actions/runs/33234481680) is red without the fix; CI is green with it.

I also built the Windows package from this fix on the release workflow and diffed it against the official 1.4.1 package — the archives contain the same 354 entries, so nothing about the packaging changed.

## Screenshots (if UI changes)

No visual change.
