### PR TITLE
fix(plugins): bypass unhealthy Google primary endpoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,11 @@
 *.gz   binary
 *.zip  binary
 
+# Committed with CRLF before the normalisation above. Pinning the path keeps CR-at-EOL out of the
+# whitespace check and stops an edit to one line from renormalising the whole file, which would show
+# as a full rewrite and bury the actual change.
+plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GooglePlugin.kt -text whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+
 # Must stay CRLF to run on Windows.
 *.bat       text eol=crlf
 *.cmd       text eol=crlf

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "2.0.0"  // only bump when the API interface changes
+version = "2.1.0"  // only bump when the API interface changes
 
 plugins {
     id("buildsrc.convention.kotlin-jvm")

--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/core/ApiVersion.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/core/ApiVersion.kt
@@ -56,7 +56,7 @@ public object ApiVersion {
     public const val MAJOR: Int = 2
 
     /** The minor version. Incrementing this signals new backwards-compatible features. */
-    public const val MINOR: Int = 0
+    public const val MINOR: Int = 1
 
     /** The patch version. Incrementing this signals backwards-compatible bug fixes. */
     public const val PATCH: Int = 0

--- a/api/src/main/kotlin/com/github/ahatem/qtranslate/api/plugin/SingleAttemptHttpClient.kt
+++ b/api/src/main/kotlin/com/github/ahatem/qtranslate/api/plugin/SingleAttemptHttpClient.kt
@@ -1,0 +1,44 @@
+package com.github.ahatem.qtranslate.api.plugin
+
+import com.github.michaelbull.result.Result
+
+/**
+ * An [HttpClient] that can also send a GET without the transport's own retry policy.
+ *
+ * ### Why this is a separate interface
+ * The transport retries some failures before a caller ever sees them, and that is the right
+ * default: a transient error often clears on its own, and leaving every caller to notice would
+ * mean every caller reimplementing the same loop. A caller that owns a policy of its own over
+ * those same failures needs the opposite, because retries happening underneath it, and the delay
+ * before them, make the timing of the request something the caller cannot account for. Adding a
+ * method to [HttpClient] for that would oblige every existing and third-party implementation to
+ * grow one, including implementations whose transport does not retry at all and could only ignore
+ * it. A capability only some transports provide belongs on an interface they can opt into instead.
+ *
+ * ### Using it
+ * [getOnce] is a statement about what the transport is asked to do, not about what the wire sees:
+ * a client that never retries has nothing to opt out of. A caller should therefore test for this
+ * interface and fall back to [HttpClient.get] when the transport does not implement it:
+ *
+ * ```kotlin
+ * val response = (client as? SingleAttemptHttpClient)?.getOnce(url) ?: client.get(url)
+ * ```
+ */
+public interface SingleAttemptHttpClient : HttpClient {
+
+    /**
+     * Performs a single GET attempt, leaving the transport's retry policy out of it.
+     *
+     * The first response, or the first failure, is returned as it arrives and is not automatically
+     * sent again. Everything else matches [HttpClient.get], so a rate limit still arrives as
+     * [ServiceError.RateLimitError] carrying whatever `Retry-After` hint the server sent, and it is
+     * then the caller's to act on.
+     *
+     * The parameters behave as they do on [HttpClient.get].
+     */
+    public suspend fun getOnce(
+        url: String,
+        headers: Map<String, String> = emptyMap(),
+        queryParams: Map<String, Any?> = emptyMap()
+    ): Result<String, ServiceError>
+}

--- a/api/src/test/kotlin/com/github/ahatem/qtranslate/api/translator/BatchTranslatorTest.kt
+++ b/api/src/test/kotlin/com/github/ahatem/qtranslate/api/translator/BatchTranslatorTest.kt
@@ -32,7 +32,7 @@ class BatchTranslatorTest {
 
     @Test
     fun `host accepts plugins built against an earlier minor of the same major`() {
-        assertEquals("2.0.0", ApiVersion.VERSION)
+        assertEquals("2.1.0", ApiVersion.VERSION)
         assertIs<ApiVersion.CompatibilityResult.Compatible>(ApiVersion.isCompatible("2.0.0"))
     }
 

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClient.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClient.kt
@@ -40,6 +40,9 @@ private val IDEMPOTENT_METHODS = setOf(
 
 private const val TOO_MANY_REQUESTS = 429
 
+// Callers back off for however long this tells them, so a server's number is bounded, not believed.
+private const val MAX_RETRY_AFTER_SECONDS = 600
+
 internal class KtorHttpClient(
     private val logger: Logger,
     private val json: Json = Json {
@@ -308,6 +311,13 @@ internal class KtorHttpClient(
 
     // ========== RESPONSE HANDLING ==========
 
+    private fun retryAfterSeconds(response: HttpResponse): Int? {
+        val header = response.headers[HttpHeaders.RetryAfter] ?: return null
+        val seconds = header.trim().toIntOrNull() ?: return null
+        if (seconds < 0) return null
+        return seconds.coerceAtMost(MAX_RETRY_AFTER_SECONDS)
+    }
+
     private suspend fun handleResponse(
         response: HttpResponse,
         url: String
@@ -319,7 +329,7 @@ internal class KtorHttpClient(
             )
 
             HttpStatusCode.TooManyRequests -> Err(
-                ServiceError.RateLimitError("Rate limit exceeded for $url")
+                ServiceError.RateLimitError("Rate limit exceeded for $url", retryAfterSeconds(response))
             )
 
             HttpStatusCode.PaymentRequired -> {
@@ -353,7 +363,7 @@ internal class KtorHttpClient(
             )
 
             HttpStatusCode.TooManyRequests -> Err(
-                ServiceError.RateLimitError("Rate limit exceeded for $url")
+                ServiceError.RateLimitError("Rate limit exceeded for $url", retryAfterSeconds(response))
             )
 
             else -> {

--- a/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClient.kt
+++ b/core/src/main/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClient.kt
@@ -1,14 +1,14 @@
 package com.github.ahatem.qtranslate.core.plugin.http
 
-import com.github.ahatem.qtranslate.api.plugin.HttpClient
 import com.github.ahatem.qtranslate.api.core.Logger
 import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.ahatem.qtranslate.api.plugin.SingleAttemptHttpClient
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import io.ktor.client.*
-// Both this file's supertype and Ktor's own client are called HttpClient. Ours is now imported by
-// name, which beats the star import below, so Ktor's needs an alias to stay reachable.
+// Ktor's own client type, aliased so the one place that constructs it reads distinctly from the
+// API interface this class implements.
 import io.ktor.client.HttpClient as KtorClient
 import io.ktor.client.call.*
 import io.ktor.client.engine.HttpClientEngine
@@ -28,6 +28,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.Closeable
+import java.time.Duration
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.Base64
 
 /**
@@ -70,7 +74,7 @@ internal class KtorHttpClient(
      * that shares an engine across clients should decide for itself when it dies.
      */
     private val ownsEngine: Boolean = true
-) : HttpClient, Closeable {
+) : SingleAttemptHttpClient, Closeable {
 
     private val client = KtorClient(engine) {
         install(ContentNegotiation) {
@@ -178,6 +182,23 @@ internal class KtorHttpClient(
         url: String,
         headers: Map<String, String>,
         queryParams: Map<String, Any?>
+    ): Result<String, ServiceError> = getShared(url, headers, queryParams, useRetryPolicy = true)
+
+    override suspend fun getOnce(
+        url: String,
+        headers: Map<String, String>,
+        queryParams: Map<String, Any?>
+    ): Result<String, ServiceError> = getShared(url, headers, queryParams, useRetryPolicy = false)
+
+    // Only the retry decision differs between these two. A caller wants a single attempt when a
+    // retry, or the delay before it, would arrive too late to be of use, and it needs the first
+    // answer rather than the last. Everything else stays shared, so the request and the error it
+    // maps to are identical on either path.
+    private suspend fun getShared(
+        url: String,
+        headers: Map<String, String>,
+        queryParams: Map<String, Any?>,
+        useRetryPolicy: Boolean
     ): Result<String, ServiceError> = withContext(Dispatchers.IO) {
         try {
             val response: HttpResponse = client.get(url) {
@@ -190,6 +211,7 @@ internal class KtorHttpClient(
                         else -> value?.let { parameter(key, it.toString()) }
                     }
                 }
+                if (!useRetryPolicy) retry { noRetry() }
             }
             handleResponse(response, url)
         } catch (e: HttpRequestTimeoutException) {
@@ -312,10 +334,23 @@ internal class KtorHttpClient(
     // ========== RESPONSE HANDLING ==========
 
     private fun retryAfterSeconds(response: HttpResponse): Int? {
-        val header = response.headers[HttpHeaders.RetryAfter] ?: return null
-        val seconds = header.trim().toIntOrNull() ?: return null
-        if (seconds < 0) return null
-        return seconds.coerceAtMost(MAX_RETRY_AFTER_SECONDS)
+        val header = response.headers[HttpHeaders.RetryAfter]?.trim() ?: return null
+        val seconds = header.toIntOrNull()?.takeIf { it >= 0 }?.toLong()
+            ?: retryAfterSecondsFromDate(header)
+            ?: return null
+        return seconds.coerceAtMost(MAX_RETRY_AFTER_SECONDS.toLong()).toInt()
+    }
+
+    /**
+     * Reads the HTTP-date form of `Retry-After` (for example `Wed, 21 Oct 2015 07:28:00 GMT`) as
+     * whole seconds from now. Null when the value is not a date or is not in the future, so a
+     * malformed header, or one whose moment has already passed, leaves the hint unset.
+     */
+    private fun retryAfterSecondsFromDate(header: String): Long? {
+        val instant = runCatching {
+            ZonedDateTime.parse(header, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant()
+        }.getOrNull() ?: return null
+        return Duration.between(Instant.now(), instant).seconds.takeIf { it > 0 }
     }
 
     private suspend fun handleResponse(

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClientRetryTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClientRetryTest.kt
@@ -1,6 +1,8 @@
 package com.github.ahatem.qtranslate.core.plugin.http
 
 import com.github.ahatem.qtranslate.api.core.Logger
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.michaelbull.result.getError
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
@@ -11,6 +13,8 @@ import kotlinx.coroutines.test.runTest
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -34,21 +38,22 @@ class KtorHttpClientRetryTest {
     private fun countingEngine(
         status: HttpStatusCode,
         calls: AtomicInteger,
-        retryAfterSeconds: Long? = null
+        retryAfterSeconds: Long? = null,
+        retryAfterHeader: String? = null
     ) = MockEngine {
         calls.incrementAndGet()
         respond(
             content = "body",
             status = status,
-            headers = retryAfterSeconds
-                ?.let { headersOf(HttpHeaders.RetryAfter, it.toString()) }
+            headers = (retryAfterHeader ?: retryAfterSeconds?.toString())
+                ?.let { headersOf(HttpHeaders.RetryAfter, it) }
                 ?: headersOf()
         )
     }
 
-    private fun clientOn(engine: MockEngine, maxRetries: Int = 2) = KtorHttpClient(
+    private fun clientOn(engine: MockEngine, maxRetries: Int = 2, enableRetry: Boolean = true) = KtorHttpClient(
         logger = silentLogger,
-        config = HttpClientConfig(enableRetry = true, maxRetries = maxRetries),
+        config = HttpClientConfig(enableRetry = enableRetry, maxRetries = maxRetries),
         engine = engine,
         ownsEngine = false
     )
@@ -156,5 +161,69 @@ class KtorHttpClientRetryTest {
             waitedMillis >= 2_500,
             "expected to wait the configured 3s before retrying, waited only ${waitedMillis}ms"
         )
+    }
+
+    @Test
+    fun `a 429 reports the server's Retry-After in seconds`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.TooManyRequests, calls, retryAfterSeconds = 7)
+
+        val error = clientOn(engine, enableRetry = false)
+            .use { it.get("https://example.invalid/languages") }
+            .getError()
+
+        assertEquals(7, assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
+    }
+
+    @Test
+    fun `a 429 without a Retry-After leaves the hint unset`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.TooManyRequests, calls)
+
+        val error = clientOn(engine, enableRetry = false)
+            .use { it.get("https://example.invalid/languages") }
+            .getError()
+
+        assertNull(assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
+    }
+
+    @Test
+    fun `a 429 whose Retry-After is an HTTP-date leaves the hint unset`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(
+            HttpStatusCode.TooManyRequests,
+            calls,
+            retryAfterHeader = "Wed, 21 Oct 2015 07:28:00 GMT"
+        )
+
+        val error = clientOn(engine, enableRetry = false)
+            .use { it.get("https://example.invalid/languages") }
+            .getError()
+
+        assertNull(assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
+    }
+
+    @Test
+    fun `an absurd Retry-After is clamped to the bound`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.TooManyRequests, calls, retryAfterSeconds = 86_400)
+
+        val error = clientOn(engine, enableRetry = false)
+            .use { it.get("https://example.invalid/languages") }
+            .getError()
+
+        assertEquals(600, assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
+    }
+
+    @Test
+    fun `a negative Retry-After is treated as absent`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.TooManyRequests, calls, retryAfterSeconds = -1)
+
+        val error = clientOn(engine, enableRetry = false)
+            .use { it.get("https://example.invalid/languages") }
+            .getError()
+
+        assertNull(assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
     }
 }

--- a/core/src/test/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClientRetryTest.kt
+++ b/core/src/test/kotlin/com/github/ahatem/qtranslate/core/plugin/http/KtorHttpClientRetryTest.kt
@@ -10,10 +10,14 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -57,6 +61,10 @@ class KtorHttpClientRetryTest {
         engine = engine,
         ownsEngine = false
     )
+
+    /** An RFC 1123 HTTP-date [seconds] from now, the form `Retry-After` also allows. */
+    private fun httpDateFromNow(seconds: Long): String =
+        DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(seconds))
 
     @Test
     fun `a POST answered with 500 is sent exactly once`() = runTest {
@@ -225,5 +233,97 @@ class KtorHttpClientRetryTest {
             .getError()
 
         assertNull(assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
+    }
+
+    @Test
+    fun `a Retry-After HTTP-date in the future is reported as seconds`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(
+            HttpStatusCode.TooManyRequests,
+            calls,
+            retryAfterHeader = httpDateFromNow(30)
+        )
+
+        val error = clientOn(engine, enableRetry = false)
+            .use { it.get("https://example.invalid/languages") }
+            .getError()
+
+        val reported = assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds
+        assertNotNull(reported, "an HTTP-date in the future should be converted to seconds")
+        // The date has whole-second resolution, so the conversion may land a second either side.
+        assertTrue(reported in 28..31, "expected roughly 30s from a date 30s ahead, got $reported")
+    }
+
+    @Test
+    fun `a Retry-After HTTP-date in the past leaves the hint unset`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(
+            HttpStatusCode.TooManyRequests,
+            calls,
+            retryAfterHeader = httpDateFromNow(-3_600)
+        )
+
+        val error = clientOn(engine, enableRetry = false)
+            .use { it.get("https://example.invalid/languages") }
+            .getError()
+
+        assertNull(assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
+    }
+
+    @Test
+    fun `a single-attempt 429 makes exactly one wire attempt even with retries enabled`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.TooManyRequests, calls)
+
+        val error = clientOn(engine, maxRetries = 2).use {
+            it.getOnce("https://example.invalid/languages")
+        }.getError()
+
+        // The transport would otherwise send this three times and sleep in between; the caller
+        // asking for one attempt must get exactly one, so its own policy can run instead.
+        assertEquals(1, calls.get(), "getOnce must not be retried")
+        assertIs<ServiceError.RateLimitError>(error)
+    }
+
+    @Test
+    fun `a single-attempt 429 does not wait out Retry-After`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.TooManyRequests, calls, retryAfterSeconds = 5)
+
+        // A real clock, as in the other timing tests: the send runs on Dispatchers.IO, outside the
+        // test scheduler. A retrying client would sleep the full Retry-After here, so a pass below
+        // two seconds is evidence that no such sleep happened on the single-attempt path.
+        val startedAt = System.nanoTime()
+        val error = clientOn(engine, maxRetries = 2).use {
+            it.getOnce("https://example.invalid/languages")
+        }.getError()
+        val waitedMillis = (System.nanoTime() - startedAt) / 1_000_000
+
+        assertEquals(1, calls.get(), "getOnce must not be retried")
+        assertTrue(
+            waitedMillis < 2_000,
+            "a single attempt must not sleep out Retry-After, but waited ${waitedMillis}ms"
+        )
+        assertEquals(5, assertIs<ServiceError.RateLimitError>(error).retryAfterSeconds)
+    }
+
+    @Test
+    fun `a single-attempt retryable 5xx makes exactly one wire attempt`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.InternalServerError, calls)
+
+        clientOn(engine, maxRetries = 2).use { it.getOnce("https://example.invalid/languages") }
+
+        assertEquals(1, calls.get(), "a plain GET would make 3 attempts")
+    }
+
+    @Test
+    fun `an ordinary GET still uses the retry policy`() = runTest {
+        val calls = AtomicInteger()
+        val engine = countingEngine(HttpStatusCode.TooManyRequests, calls)
+
+        clientOn(engine, maxRetries = 2).use { it.get("https://example.invalid/languages") }
+
+        assertEquals(3, calls.get(), "the default must be untouched: 1 attempt + 2 retries")
     }
 }

--- a/plugins/common/src/main/kotlin/com/github/ahatem/qtranslate/plugins/common/HttpRequestRetry.kt
+++ b/plugins/common/src/main/kotlin/com/github/ahatem/qtranslate/plugins/common/HttpRequestRetry.kt
@@ -1,0 +1,28 @@
+package com.github.ahatem.qtranslate.plugins.common
+
+import com.github.ahatem.qtranslate.api.plugin.HttpClient
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.ahatem.qtranslate.api.plugin.SingleAttemptHttpClient
+import com.github.michaelbull.result.Result
+
+/**
+ * Performs a GET without the transport's retry policy, where the transport can opt out of it.
+ *
+ * A transport that retries on its own, and waits before each retry, puts that delay between the
+ * caller and a failure the caller already knows how to act on. A caller that owns a policy over
+ * those same failures wants the first answer instead, so this sends one attempt when the transport
+ * offers that. A transport that cannot opt out, because it does not retry or does not say so, still
+ * answers the call: it degrades to an ordinary [HttpClient.get] and the caller sees whatever that
+ * transport would have returned.
+ *
+ * The cast is what keeps this from calling itself. It narrows the receiver to the interface that
+ * declares `getOnce` as a member, and a member always wins over an extension of the same name, so
+ * the member is chosen over this function.
+ */
+suspend fun HttpClient.getOnce(
+    url: String,
+    headers: Map<String, String> = emptyMap(),
+    queryParams: Map<String, Any?> = emptyMap()
+): Result<String, ServiceError> =
+    (this as? SingleAttemptHttpClient)?.getOnce(url, headers, queryParams)
+        ?: get(url, headers, queryParams)

--- a/plugins/google-services/build.gradle.kts
+++ b/plugins/google-services/build.gradle.kts
@@ -9,6 +9,10 @@ dependencies {
     implementation(project(":plugins:common"))
 
     implementation(libs.kotlinxSerialization)
+
+    testImplementation(kotlin("test"))
+    testImplementation(testFixtures(project(":plugins:common")))
+    testImplementation(libs.kotlinxCoroutines)
 }
 
 tasks.shadowJar {

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealth.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealth.kt
@@ -1,0 +1,106 @@
+package com.github.ahatem.qtranslate.plugins.google
+
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.random.Random
+
+/**
+ * Tracks the health of the primary Google endpoint shared by the translator and the spell checker.
+ *
+ * The unofficial primary host throttles intermittently. Waiting for its request timeout on every
+ * call is what turns a throttled endpoint into a repeated multi-second stall, so callers consult
+ * [tryAcquirePrimary] first: while the circuit is open they skip the primary entirely and use their
+ * fallback. Once the cooldown elapses a single probe is permitted, and its outcome decides whether
+ * the circuit closes or reopens.
+ *
+ * Only the primary endpoint is tracked. The fallback and the official API are separate hosts and do
+ * not feed this state.
+ *
+ * [clock] and [jitterMillis] are injectable so cooldown and half-open transitions are deterministic
+ * in tests.
+ */
+class GoogleEndpointHealth(
+    private val clock: () -> Long = { System.currentTimeMillis() },
+    private val jitterMillis: () -> Long = { Random.nextLong(JITTER_MILLIS + 1) }
+) {
+
+    enum class State { HEALTHY, OPEN_COOLDOWN, HALF_OPEN }
+
+    private val mutex = Mutex()
+    private var state = State.HEALTHY
+    private var consecutiveFailures = 0
+    private var openCount = 0
+    private var openUntilMillis = 0L
+    private var probeDeadlineMillis = 0L
+
+    /**
+     * Returns true when the caller may request the primary endpoint now.
+     *
+     * While healthy every caller may proceed. While the circuit is open the caller is sent to its
+     * fallback immediately, without paying the primary request timeout. After the cooldown, exactly
+     * one caller is promoted to a half-open probe; the rest keep using their fallback until the
+     * probe resolves.
+     */
+    suspend fun tryAcquirePrimary(): Boolean = mutex.withLock {
+        when (state) {
+            State.HEALTHY -> true
+            State.OPEN_COOLDOWN -> if (clock() >= openUntilMillis) beginProbe() else false
+            State.HALF_OPEN -> if (clock() >= probeDeadlineMillis) beginProbe() else false
+        }
+    }
+
+    /** Records a successful primary response and closes the circuit. */
+    suspend fun recordSuccess() = mutex.withLock {
+        state = State.HEALTHY
+        consecutiveFailures = 0
+        openCount = 0
+        openUntilMillis = 0L
+        probeDeadlineMillis = 0L
+    }
+
+    /**
+     * Records a transient primary failure. Opens the circuit on the second consecutive failure, on
+     * an explicit Retry-After, or when a half-open probe fails.
+     */
+    suspend fun recordTransientFailure(error: ServiceError) = mutex.withLock {
+        consecutiveFailures++
+        val retryAfterSeconds = (error as? ServiceError.RateLimitError)?.retryAfterSeconds
+        val shouldOpen = state == State.HALF_OPEN ||
+            retryAfterSeconds != null ||
+            consecutiveFailures >= FAILURE_THRESHOLD
+        if (shouldOpen) {
+            openCount++
+            state = State.OPEN_COOLDOWN
+            openUntilMillis = clock() + cooldownMillis(retryAfterSeconds)
+        }
+    }
+
+    private fun beginProbe(): Boolean {
+        state = State.HALF_OPEN
+        probeDeadlineMillis = clock() + PROBE_TIMEOUT_MILLIS
+        return true
+    }
+
+    private fun cooldownMillis(retryAfterSeconds: Int?): Long {
+        var backoff = BASE_COOLDOWN_MILLIS
+        repeat((openCount - 1).coerceIn(0, MAX_DOUBLINGS)) {
+            backoff = (backoff * 2).coerceAtMost(MAX_COOLDOWN_MILLIS)
+        }
+        val retryAfterMillis = retryAfterSeconds?.coerceAtLeast(0)?.let { it * 1_000L }
+        return if (retryAfterMillis != null) {
+            maxOf(retryAfterMillis, backoff)
+        } else {
+            backoff + jitterMillis()
+        }
+    }
+
+    companion object {
+        private const val FAILURE_THRESHOLD = 2
+        private const val BASE_COOLDOWN_MILLIS = 2_000L
+        private const val MAX_COOLDOWN_MILLIS = 60_000L
+        private const val MAX_DOUBLINGS = 5
+        private const val PROBE_TIMEOUT_MILLIS = 10_000L
+        private const val JITTER_MILLIS = 1_000L
+    }
+}

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealth.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealth.kt
@@ -14,6 +14,10 @@ import kotlin.random.Random
  * fallback. Once the cooldown elapses a single probe is permitted, and its outcome decides whether
  * the circuit closes or reopens.
  *
+ * A caller holds a [Permit] for the whole request. Every phase change bumps [generation], and a
+ * permit only counts while it still matches the current generation, so a request that began before a
+ * transition can never rewrite the newer state.
+ *
  * Only the primary endpoint is tracked. The fallback and the official API are separate hosts and do
  * not feed this state.
  *
@@ -27,59 +31,106 @@ class GoogleEndpointHealth(
 
     enum class State { HEALTHY, OPEN_COOLDOWN, HALF_OPEN }
 
+    /**
+     * Permission to call the primary endpoint. It stays valid only while the circuit's generation is
+     * unchanged; a permit from an older generation is ignored by every recorder.
+     *
+     * [isProbe] marks the single request allowed while the circuit is half open. A probe heals or
+     * reopens the circuit when it resolves, so a request that produces no outcome must hand its
+     * permit back with [releasePrimary].
+     */
+    class Permit internal constructor(
+        internal val generation: Long,
+        val isProbe: Boolean
+    )
+
     private val mutex = Mutex()
     private var state = State.HEALTHY
+    private var generation = 0L
     private var consecutiveFailures = 0
     private var openCount = 0
     private var openUntilMillis = 0L
-    private var probeDeadlineMillis = 0L
+    private var probeInFlight = false
 
     /**
-     * Returns true when the caller may request the primary endpoint now.
+     * Returns a permit when the caller may request the primary endpoint now, or null when it must use
+     * its fallback instead.
      *
-     * While healthy every caller may proceed. While the circuit is open the caller is sent to its
-     * fallback immediately, without paying the primary request timeout. After the cooldown, exactly
-     * one caller is promoted to a half-open probe; the rest keep using their fallback until the
-     * probe resolves.
+     * While healthy every caller is admitted. While the circuit is open callers are sent to their
+     * fallback immediately, without paying the primary request timeout. After the cooldown exactly
+     * one caller is promoted to a half-open probe; every other caller keeps using its fallback until
+     * that probe resolves.
      */
-    suspend fun tryAcquirePrimary(): Boolean = mutex.withLock {
-        when (state) {
-            State.HEALTHY -> true
-            State.OPEN_COOLDOWN -> if (clock() >= openUntilMillis) beginProbe() else false
-            State.HALF_OPEN -> if (clock() >= probeDeadlineMillis) beginProbe() else false
+    suspend fun tryAcquirePrimary(): Permit? = mutex.withLock {
+        when {
+            state == State.HEALTHY -> Permit(generation, isProbe = false)
+            state == State.OPEN_COOLDOWN && clock() >= openUntilMillis && !probeInFlight -> beginProbe()
+            else -> null
         }
-    }
-
-    /** Records a successful primary response and closes the circuit. */
-    suspend fun recordSuccess() = mutex.withLock {
-        state = State.HEALTHY
-        consecutiveFailures = 0
-        openCount = 0
-        openUntilMillis = 0L
-        probeDeadlineMillis = 0L
     }
 
     /**
-     * Records a transient primary failure. Opens the circuit on the second consecutive failure, on
-     * an explicit Retry-After, or when a half-open probe fails.
+     * Records a successful primary response. A probe heals the circuit; an ordinary request only
+     * clears the consecutive-failure count.
      */
-    suspend fun recordTransientFailure(error: ServiceError) = mutex.withLock {
-        consecutiveFailures++
-        val retryAfterSeconds = (error as? ServiceError.RateLimitError)?.retryAfterSeconds
-        val shouldOpen = state == State.HALF_OPEN ||
-            retryAfterSeconds != null ||
-            consecutiveFailures >= FAILURE_THRESHOLD
-        if (shouldOpen) {
-            openCount++
-            state = State.OPEN_COOLDOWN
-            openUntilMillis = clock() + cooldownMillis(retryAfterSeconds)
+    suspend fun recordSuccess(permit: Permit) = mutex.withLock {
+        if (permit.generation != generation) return@withLock
+        if (permit.isProbe) {
+            state = State.HEALTHY
+            consecutiveFailures = 0
+            openCount = 0
+            openUntilMillis = 0L
+            probeInFlight = false
+            generation++
+        } else {
+            consecutiveFailures = 0
         }
     }
 
-    private fun beginProbe(): Boolean {
+    /**
+     * Records a transient primary failure. A probe reopens the cooldown. An ordinary request opens
+     * the cooldown on the second consecutive failure, or immediately on a rate limit; a Retry-After
+     * hint lengthens the cooldown when present.
+     */
+    suspend fun recordTransientFailure(permit: Permit, error: ServiceError) = mutex.withLock {
+        if (permit.generation != generation) return@withLock
+        val retryAfterSeconds = (error as? ServiceError.RateLimitError)?.retryAfterSeconds
+        if (permit.isProbe) {
+            openCooldown(retryAfterSeconds)
+            return@withLock
+        }
+        consecutiveFailures++
+        if (error is ServiceError.RateLimitError || consecutiveFailures >= FAILURE_THRESHOLD) {
+            openCooldown(retryAfterSeconds)
+        }
+    }
+
+    /**
+     * Returns a permit that produced no usable outcome, for example a cancelled request. It records
+     * neither success nor failure. An ordinary permit changes nothing; a probe permit reopens the
+     * cooldown so the circuit can never be left waiting on a probe that will not return.
+     */
+    suspend fun releasePrimary(permit: Permit) = mutex.withLock {
+        if (permit.generation != generation) return@withLock
+        if (!permit.isProbe) return@withLock
+        probeInFlight = false
+        state = State.OPEN_COOLDOWN
+        openUntilMillis = clock() + cooldownMillis(null)
+        generation++
+    }
+
+    private fun beginProbe(): Permit {
         state = State.HALF_OPEN
-        probeDeadlineMillis = clock() + PROBE_TIMEOUT_MILLIS
-        return true
+        probeInFlight = true
+        return Permit(generation, isProbe = true)
+    }
+
+    private fun openCooldown(retryAfterSeconds: Int?) {
+        openCount++
+        state = State.OPEN_COOLDOWN
+        openUntilMillis = clock() + cooldownMillis(retryAfterSeconds)
+        probeInFlight = false
+        generation++
     }
 
     private fun cooldownMillis(retryAfterSeconds: Int?): Long {
@@ -100,7 +151,6 @@ class GoogleEndpointHealth(
         private const val BASE_COOLDOWN_MILLIS = 2_000L
         private const val MAX_COOLDOWN_MILLIS = 60_000L
         private const val MAX_DOUBLINGS = 5
-        private const val PROBE_TIMEOUT_MILLIS = 10_000L
         private const val JITTER_MILLIS = 1_000L
     }
 }

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealth.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealth.kt
@@ -1,8 +1,10 @@
 package com.github.ahatem.qtranslate.plugins.google
 
 import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlin.random.Random
 
 /**
@@ -109,14 +111,22 @@ class GoogleEndpointHealth(
      * Returns a permit that produced no usable outcome, for example a cancelled request. It records
      * neither success nor failure. An ordinary permit changes nothing; a probe permit reopens the
      * cooldown so the circuit can never be left waiting on a probe that will not return.
+     *
+     * This is called from `finally` blocks, so it runs on the cancellation path too. The cleanup
+     * itself is therefore non-cancellable: a cancelled coroutine must still be able to take the
+     * lock when another caller holds it, or a probe released during cancellation would leave
+     * [probeInFlight] set and strand the circuit half open for good. Only the release is protected;
+     * the request that produced the permit stays cancellable.
      */
-    suspend fun releasePrimary(permit: Permit) = mutex.withLock {
-        if (permit.generation != generation) return@withLock
-        if (!permit.isProbe) return@withLock
-        probeInFlight = false
-        state = State.OPEN_COOLDOWN
-        openUntilMillis = clock() + cooldownMillis(null)
-        generation++
+    suspend fun releasePrimary(permit: Permit) = withContext(NonCancellable) {
+        mutex.withLock {
+            if (permit.generation != generation) return@withLock
+            if (!permit.isProbe) return@withLock
+            probeInFlight = false
+            state = State.OPEN_COOLDOWN
+            openUntilMillis = clock() + cooldownMillis(null)
+            generation++
+        }
     }
 
     private fun beginProbe(): Permit {

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GooglePlugin.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GooglePlugin.kt
@@ -30,7 +30,7 @@ class GooglePlugin : Plugin<GoogleSettings> {
         this.settings = GoogleSettings(
             visionApiKey = context.secrets.get("visionApiKey") ?: "",
             translateApiKey = context.secrets.get("translateApiKey") ?: ""
-        )
+        )
         pluginContext.logger.info("Google Plugin initialized")
         return Ok(Unit)
     }
@@ -53,15 +53,18 @@ class GooglePlugin : Plugin<GoogleSettings> {
     }
 
     private fun buildServices() {
+        // One health tracker for the primary endpoint, shared by the translator and spell checker so
+        // they do not each rediscover that it is throttled.
+        val endpointHealth = GoogleEndpointHealth()
         activeServices = buildList {
             // OCR requires a Vision API key — only register the service when one is configured.
             if (settings.visionApiKey.isNotBlank()) {
                 add(GoogleOCRService(pluginContext, settings, httpClient, languageMapper, apiConfig))
             }
-            add(GoogleTranslatorService(pluginContext, settings, httpClient, languageMapper, apiConfig))
+            add(GoogleTranslatorService(pluginContext, settings, httpClient, languageMapper, apiConfig, endpointHealth))
             add(GoogleTTSService(pluginContext, httpClient, languageMapper, apiConfig))
             add(GoogleDictionaryService(pluginContext, httpClient, languageMapper, apiConfig))
-            add(GoogleSpellCheckerService(pluginContext, httpClient, languageMapper, apiConfig))
+            add(GoogleSpellCheckerService(pluginContext, httpClient, languageMapper, apiConfig, endpointHealth))
         }
         pluginContext.logger.info("Built ${activeServices.size} active Google services.")
     }
@@ -72,7 +75,7 @@ class GooglePlugin : Plugin<GoogleSettings> {
     }
 
     override suspend fun shutdown() {
-        pluginContext.logger.info("Google Plugin shutting down")
+        pluginContext.logger.info("Google Plugin shutting down")
     }
 
     override fun getServices(): List<Service> = activeServices

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GooglePlugin.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GooglePlugin.kt
@@ -30,7 +30,7 @@ class GooglePlugin : Plugin<GoogleSettings> {
         this.settings = GoogleSettings(
             visionApiKey = context.secrets.get("visionApiKey") ?: "",
             translateApiKey = context.secrets.get("translateApiKey") ?: ""
-        )
+        )
         pluginContext.logger.info("Google Plugin initialized")
         return Ok(Unit)
     }
@@ -75,7 +75,7 @@ class GooglePlugin : Plugin<GoogleSettings> {
     }
 
     override suspend fun shutdown() {
-        pluginContext.logger.info("Google Plugin shutting down")
+        pluginContext.logger.info("Google Plugin shutting down")
     }
 
     override fun getServices(): List<Service> = activeServices

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerService.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerService.kt
@@ -16,17 +16,21 @@ import com.github.ahatem.qtranslate.plugins.common.createJsonParser
 import com.github.ahatem.qtranslate.plugins.google.common.GoogleLanguageMapper
 import com.github.ahatem.qtranslate.plugins.google.common.TranslateResponse
 import com.github.michaelbull.result.*
-import com.github.michaelbull.result.coroutines.coroutineBinding
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.util.*
 
 class GoogleSpellCheckerService(
     private val pluginContext: PluginContext,
     private val httpClient: HttpClient,
     private val languageMapper: GoogleLanguageMapper,
-    private val apiConfig: ApiConfig
+    private val apiConfig: ApiConfig,
+    private val endpointHealth: GoogleEndpointHealth
 ) : SpellChecker {
 
 
@@ -37,6 +41,8 @@ class GoogleSpellCheckerService(
 
     private val parser = createJsonParser<TranslateResponse>(pluginContext)
 
+    private val requestSemaphore = Semaphore(SPELL_CHECK_MAX_CONCURRENCY)
+
     private val cache = Collections.synchronizedMap(object :
         LinkedHashMap<String, Result<SpellCheckResponse, ServiceError>>(200, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Result<SpellCheckResponse, ServiceError>>?): Boolean {
@@ -46,6 +52,7 @@ class GoogleSpellCheckerService(
 
     companion object {
         private const val TRANSLATE_PRIMARY = "https://translate.googleapis.com/translate_a/single"
+        private const val SPELL_CHECK_MAX_CONCURRENCY = 4
     }
 
     override val supportedLanguages: SupportedLanguages = SupportedLanguages.Dynamic
@@ -113,9 +120,13 @@ class GoogleSpellCheckerService(
         sentence: String,
         language: LanguageCode
     ): Result<SpellCheckResponse, ServiceError> {
-        return coroutineBinding {
-            val langTag = languageMapper.toProviderCode(language)
-            val responseString = httpClient.get(
+        if (!endpointHealth.tryAcquirePrimary()) {
+            return Err(ServiceError.ServiceUnavailableError("Google spell check endpoint is temporarily unavailable", null))
+        }
+
+        val langTag = languageMapper.toProviderCode(language)
+        val response = requestSemaphore.withPermit {
+            httpClient.get(
                 url = TRANSLATE_PRIMARY,
                 headers = apiConfig.createHeaders(),
                 queryParams = mapOf(
@@ -126,9 +137,23 @@ class GoogleSpellCheckerService(
                     "q" to sentence,
                     "dt" to "qc"
                 )
-            ).bind()
-            parseSpellCheck(responseString, sentence).bind()
+            )
         }
+
+        return response.fold(
+            success = { body ->
+                currentCoroutineContext().ensureActive()
+                endpointHealth.recordSuccess()
+                parseSpellCheck(body, sentence)
+            },
+            failure = { error ->
+                currentCoroutineContext().ensureActive()
+                if (error.isRetryable) {
+                    endpointHealth.recordTransientFailure(error)
+                }
+                Err(error)
+            }
+        )
     }
 
     private suspend fun parseSpellCheck(
@@ -136,6 +161,16 @@ class GoogleSpellCheckerService(
         requestText: String
     ): Result<SpellCheckResponse, ServiceError> {
         return parser.parse(responseString).andThen { translateResponse ->
+            // A throttled or errored body decodes into an all-defaults payload under the lenient
+            // parser; treat anything without a translate or spell section as unrecognised so it is
+            // never mistaken for "no corrections" and cached.
+            if (translateResponse.sentences.isEmpty() &&
+                translateResponse.spell == null &&
+                translateResponse.sourceLanguage.isBlank()
+            ) {
+                return@andThen Err(ServiceError.InvalidResponseError("Unrecognised spell check response", null))
+            }
+
             val spell = translateResponse.spell
             val correctedText = spell?.correctedText
             val html = spell?.spellHtmlRes

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerService.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerService.kt
@@ -13,6 +13,7 @@ import com.github.ahatem.qtranslate.api.spellchecker.SpellCheckResponse
 import com.github.ahatem.qtranslate.api.spellchecker.SpellChecker
 import com.github.ahatem.qtranslate.plugins.common.ApiConfig
 import com.github.ahatem.qtranslate.plugins.common.createJsonParser
+import com.github.ahatem.qtranslate.plugins.common.getOnce
 import com.github.ahatem.qtranslate.plugins.google.common.GoogleLanguageMapper
 import com.github.ahatem.qtranslate.plugins.google.common.TranslateResponse
 import com.github.michaelbull.result.*
@@ -136,7 +137,7 @@ class GoogleSpellCheckerService(
             // Released on every path exactly once, including cancellation, so an abandoned probe
             // never strands the circuit.
             try {
-                val response = httpClient.get(
+                val response = httpClient.getOnce(
                     url = TRANSLATE_PRIMARY,
                     headers = apiConfig.createHeaders(),
                     queryParams = mapOf(

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerService.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerService.kt
@@ -120,40 +120,57 @@ class GoogleSpellCheckerService(
         sentence: String,
         language: LanguageCode
     ): Result<SpellCheckResponse, ServiceError> {
-        if (!endpointHealth.tryAcquirePrimary()) {
-            return Err(ServiceError.ServiceUnavailableError("Google spell check endpoint is temporarily unavailable", null))
-        }
-
         val langTag = languageMapper.toProviderCode(language)
-        val response = requestSemaphore.withPermit {
-            httpClient.get(
-                url = TRANSLATE_PRIMARY,
-                headers = apiConfig.createHeaders(),
-                queryParams = mapOf(
-                    "client" to "gtx",
-                    "dj" to 1,
-                    "sl" to langTag,
-                    "tl" to "zu",
-                    "q" to sentence,
-                    "dt" to "qc"
-                )
-            )
-        }
 
-        return response.fold(
-            success = { body ->
-                currentCoroutineContext().ensureActive()
-                endpointHealth.recordSuccess()
-                parseSpellCheck(body, sentence)
-            },
-            failure = { error ->
-                currentCoroutineContext().ensureActive()
-                if (error.isRetryable) {
-                    endpointHealth.recordTransientFailure(error)
-                }
-                Err(error)
+        return requestSemaphore.withPermit {
+            // The circuit permit is taken only once a request slot is free, so a sentence queued
+            // while the endpoint was healthy cannot slip past a circuit that opened in the meantime.
+            val permit = endpointHealth.tryAcquirePrimary()
+                ?: return@withPermit Err(
+                    ServiceError.ServiceUnavailableError(
+                        "Google spell check endpoint is temporarily unavailable",
+                        null
+                    )
+                )
+
+            // Released on every path exactly once, including cancellation, so an abandoned probe
+            // never strands the circuit.
+            try {
+                val response = httpClient.get(
+                    url = TRANSLATE_PRIMARY,
+                    headers = apiConfig.createHeaders(),
+                    queryParams = mapOf(
+                        "client" to "gtx",
+                        "dj" to 1,
+                        "sl" to langTag,
+                        "tl" to "zu",
+                        "q" to sentence,
+                        "dt" to "qc"
+                    )
+                )
+
+                response.fold(
+                    success = { body ->
+                        currentCoroutineContext().ensureActive()
+                        val parsed = parseSpellCheck(body, sentence)
+                        // Only a recognised payload heals the circuit. An unrecognised one means the
+                        // endpoint answered unusably, which is neutral: the finally releases the
+                        // permit without healing or counting a failure.
+                        if (parsed.isOk) endpointHealth.recordSuccess(permit)
+                        parsed
+                    },
+                    failure = { error ->
+                        currentCoroutineContext().ensureActive()
+                        // A non-retryable failure leaves the permit to the finally, which records
+                        // nothing on the circuit.
+                        if (error.isRetryable) endpointHealth.recordTransientFailure(permit, error)
+                        Err(error)
+                    }
+                )
+            } finally {
+                endpointHealth.releasePrimary(permit)
             }
-        )
+        }
     }
 
     private suspend fun parseSpellCheck(

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorService.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorService.kt
@@ -12,6 +12,7 @@ import com.github.ahatem.qtranslate.api.translator.Translator
 import com.github.ahatem.qtranslate.plugins.common.ApiConfig
 import com.github.ahatem.qtranslate.plugins.common.PluginJson
 import com.github.ahatem.qtranslate.plugins.common.createJsonParser
+import com.github.ahatem.qtranslate.plugins.common.getOnce
 import com.github.ahatem.qtranslate.plugins.common.sendJson
 import com.github.ahatem.qtranslate.plugins.google.common.GoogleLanguageMapper
 import com.github.ahatem.qtranslate.plugins.google.common.OfficialTranslateResponse
@@ -158,7 +159,7 @@ class GoogleTranslatorService(
         sourceTag: String,
         targetTag: String
     ): Result<TranslationResponse, ServiceError> = coroutineBinding {
-        val responseString = httpClient.get(
+        val responseString = httpClient.getOnce(
             url = TRANSLATE_PRIMARY,
             headers = apiConfig.createHeaders(),
             queryParams = mapOf(

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorService.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorService.kt
@@ -107,23 +107,30 @@ class GoogleTranslatorService(
         val sourceTag = languageMapper.toProviderCode(request.sourceLanguage)
         val targetTag = languageMapper.toProviderCode(request.targetLanguage)
 
-        if (endpointHealth.tryAcquirePrimary()) {
-            val primaryResult = tryPrimaryEndpoint(request.text, sourceTag, targetTag)
-            primaryResult.fold(
-                success = {
-                    currentCoroutineContext().ensureActive()
-                    endpointHealth.recordSuccess()
-                    return primaryResult
-                },
-                failure = { error ->
-                    currentCoroutineContext().ensureActive()
-                    if (error.suppressesFallback()) return Err(error)
-                    if (error.isRetryable) endpointHealth.recordTransientFailure(error)
-                }
-            )
-            pluginContext.logger.info("Primary endpoint failed, trying fallback")
-        } else {
+        val permit = endpointHealth.tryAcquirePrimary()
+        if (permit == null) {
             pluginContext.logger.info("Primary endpoint unhealthy, using fallback")
+        } else {
+            // The permit is released on every path exactly once, including cancellation and any
+            // error escaping the primary attempt, so an abandoned probe never strands the circuit.
+            try {
+                val primaryResult = tryPrimaryEndpoint(request.text, sourceTag, targetTag)
+                primaryResult.fold(
+                    success = {
+                        currentCoroutineContext().ensureActive()
+                        endpointHealth.recordSuccess(permit)
+                        return primaryResult
+                    },
+                    failure = { error ->
+                        currentCoroutineContext().ensureActive()
+                        if (error.suppressesFallback()) return Err(error)
+                        if (error.isRetryable) endpointHealth.recordTransientFailure(permit, error)
+                    }
+                )
+                pluginContext.logger.info("Primary endpoint failed, trying fallback")
+            } finally {
+                endpointHealth.releasePrimary(permit)
+            }
         }
 
         currentCoroutineContext().ensureActive()
@@ -133,8 +140,8 @@ class GoogleTranslatorService(
     /**
      * Whether a primary failure is about the request itself rather than the endpoint's reachability.
      * The request would fail identically against the fallback, so these errors are returned as-is
-     * and leave the circuit untouched. Every other error — including a 200 response whose body the
-     * parser cannot decode — still falls back, because the secondary host speaks a different protocol
+     * and leave the circuit untouched. Every other error, including a 200 response whose body the
+     * parser cannot decode, still falls back, because the secondary host speaks a different protocol
      * and may well serve it.
      */
     private fun ServiceError.suppressesFallback(): Boolean = when (this) {

--- a/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorService.kt
+++ b/plugins/google-services/src/main/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorService.kt
@@ -10,22 +10,31 @@ import com.github.ahatem.qtranslate.api.translator.TranslationRequest
 import com.github.ahatem.qtranslate.api.translator.TranslationResponse
 import com.github.ahatem.qtranslate.api.translator.Translator
 import com.github.ahatem.qtranslate.plugins.common.ApiConfig
+import com.github.ahatem.qtranslate.plugins.common.PluginJson
 import com.github.ahatem.qtranslate.plugins.common.createJsonParser
-import com.github.ahatem.qtranslate.plugins.common.fetchJson
 import com.github.ahatem.qtranslate.plugins.common.sendJson
 import com.github.ahatem.qtranslate.plugins.google.common.GoogleLanguageMapper
 import com.github.ahatem.qtranslate.plugins.google.common.OfficialTranslateResponse
 import com.github.ahatem.qtranslate.plugins.google.common.TranslateResponse
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.coroutines.coroutineBinding
+import com.github.michaelbull.result.fold
 import com.github.michaelbull.result.toResultOr
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 
 class GoogleTranslatorService(
     private val pluginContext: PluginContext,
     private val settings: GoogleSettings,
     private val httpClient: HttpClient,
     private val languageMapper: GoogleLanguageMapper,
-    private val apiConfig: ApiConfig
+    private val apiConfig: ApiConfig,
+    private val endpointHealth: GoogleEndpointHealth
 ) : Translator {
 
 
@@ -98,11 +107,43 @@ class GoogleTranslatorService(
         val sourceTag = languageMapper.toProviderCode(request.sourceLanguage)
         val targetTag = languageMapper.toProviderCode(request.targetLanguage)
 
-        val primaryResult = tryPrimaryEndpoint(request.text, sourceTag, targetTag)
-        if (primaryResult.isOk) return primaryResult
+        if (endpointHealth.tryAcquirePrimary()) {
+            val primaryResult = tryPrimaryEndpoint(request.text, sourceTag, targetTag)
+            primaryResult.fold(
+                success = {
+                    currentCoroutineContext().ensureActive()
+                    endpointHealth.recordSuccess()
+                    return primaryResult
+                },
+                failure = { error ->
+                    currentCoroutineContext().ensureActive()
+                    if (error.suppressesFallback()) return Err(error)
+                    if (error.isRetryable) endpointHealth.recordTransientFailure(error)
+                }
+            )
+            pluginContext.logger.info("Primary endpoint failed, trying fallback")
+        } else {
+            pluginContext.logger.info("Primary endpoint unhealthy, using fallback")
+        }
 
-        pluginContext.logger.info("Primary endpoint failed, trying fallback")
+        currentCoroutineContext().ensureActive()
         return tryFallbackEndpoint(request.text, sourceTag, targetTag)
+    }
+
+    /**
+     * Whether a primary failure is about the request itself rather than the endpoint's reachability.
+     * The request would fail identically against the fallback, so these errors are returned as-is
+     * and leave the circuit untouched. Every other error — including a 200 response whose body the
+     * parser cannot decode — still falls back, because the secondary host speaks a different protocol
+     * and may well serve it.
+     */
+    private fun ServiceError.suppressesFallback(): Boolean = when (this) {
+        is ServiceError.AuthenticationError,
+        is ServiceError.InvalidInputError,
+        is ServiceError.ValidationError,
+        is ServiceError.UnsupportedLanguageError,
+        is ServiceError.ConfigurationError -> true
+        else -> false
     }
 
     private suspend fun tryPrimaryEndpoint(
@@ -142,7 +183,7 @@ class GoogleTranslatorService(
         sourceTag: String,
         targetTag: String
     ): Result<TranslationResponse, ServiceError> = coroutineBinding {
-        val parsed: List<List<String>> = httpClient.fetchJson<List<List<String>>>(
+        val responseString = httpClient.get(
             url = TRANSLATE_FALLBACK,
             headers = apiConfig.createHeaders(),
             queryParams = mapOf(
@@ -154,17 +195,49 @@ class GoogleTranslatorService(
             )
         ).bind()
 
-        val translatedText = parsed.getOrNull(0)?.getOrNull(0)
-            .toResultOr { ServiceError.InvalidResponseError("No translation in fallback response", null) }
-            .bind()
+        parseFallbackResponse(responseString).bind()
+    }
 
-        val detectedLang = parsed.getOrNull(0)?.getOrNull(1)
+    /**
+     * Parses the fallback endpoint's response, which is not documented and has been observed in two
+     * array shapes. The payload is inspected field by field rather than decoded into a fixed type, so
+     * an unexpected shape fails normally instead of throwing while indexing.
+     */
+    private fun parseFallbackResponse(
+        responseString: String
+    ): Result<TranslationResponse, ServiceError> {
+        val root = runCatching { PluginJson.parseToJsonElement(responseString) }
+            .getOrElse { return Err(ServiceError.InvalidResponseError("Fallback response is not valid JSON", it)) }
+
+        val fields = fallbackFields(root)
+            ?: return Err(ServiceError.InvalidResponseError("Unsupported fallback response shape", null))
+
+        val translatedText = fields.firstOrNull()?.stringOrNull()?.trim()
+        if (translatedText.isNullOrEmpty()) {
+            return Err(ServiceError.InvalidResponseError("No translation in fallback response", null))
+        }
+
+        val detectedLanguage = fields.getOrNull(1)
+            ?.stringOrNull()
             ?.let { languageMapper.fromProviderCode(it) }
 
-        TranslationResponse(
-            translatedText = translatedText.trim(),
-            detectedLanguage = detectedLang
-        )
+        return Ok(TranslationResponse(translatedText = translatedText, detectedLanguage = detectedLanguage))
     }
+
+    /**
+     * Extracts the flat field list from the two known fallback shapes: a nested
+     * `[[translated, src, ...]]` or a flat `[translated, src, ...]`. Any other shape yields null.
+     */
+    private fun fallbackFields(root: JsonElement): List<JsonElement>? = when (root) {
+        is JsonArray -> when (val first = root.firstOrNull()) {
+            is JsonArray -> first.toList()
+            is JsonPrimitive -> root.toList()
+            else -> null
+        }
+        else -> null
+    }
+
+    private fun JsonElement.stringOrNull(): String? =
+        (this as? JsonPrimitive)?.takeIf { it.isString }?.content
 
 }

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealthTest.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleEndpointHealthTest.kt
@@ -1,0 +1,76 @@
+package com.github.ahatem.qtranslate.plugins.google
+
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class GoogleEndpointHealthTest {
+
+    /**
+     * The permit release runs from a `finally`, so it is on the cancellation path too. If the
+     * release could itself be cancelled while it waited for the mutex, a contended circuit would
+     * keep a probe lease that never clears and stay half open. This holds the mutex from the test
+     * and cancels the release while it waits, so the cleanup has to survive.
+     *
+     * The clock seam cannot be used to hold the mutex here: `tryAcquirePrimary` only reads the
+     * clock on the open-cooldown branch, and a permit is only valid in the half-open state, so no
+     * operation that reads the clock can run while a live probe permit exists. Holding the mutex
+     * through the state's own lock is therefore the only deterministic construction.
+     */
+    @Test
+    fun `a probe release cancelled while it waits for the mutex still cleans up`() = runBlocking {
+        val clock = AtomicLong(0)
+        val health = GoogleEndpointHealth({ clock.get() }, { 0L })
+
+        // Two transient failures open the circuit; once the cooldown elapses a probe is admitted.
+        health.recordTransientFailure(health.tryAcquirePrimary()!!, ServiceError.TimeoutError("down"))
+        health.recordTransientFailure(health.tryAcquirePrimary()!!, ServiceError.TimeoutError("down"))
+        clock.set(2_000)
+        val probe = health.tryAcquirePrimary()!!
+
+        // Hold the health mutex so the release below has to wait for it, the way it would when
+        // another caller is mid transition.
+        val mutex = mutexOf(health)
+        val holding = CompletableDeferred<Unit>()
+        val releaseHolder = CompletableDeferred<Unit>()
+        val holder = launch {
+            mutex.lock()
+            holding.complete(Unit)
+            releaseHolder.await()
+            mutex.unlock()
+        }
+        holding.await()
+
+        // The release reaches the held mutex and waits there. Cancelling the coroutine at this
+        // point is what the cleanup has to survive; the mutex is not released until after the
+        // cancel, so a cancellable wait would drop the cleanup.
+        val reachedRelease = CompletableDeferred<Unit>()
+        val releaser = launch {
+            reachedRelease.complete(Unit)
+            health.releasePrimary(probe)
+        }
+        reachedRelease.await()
+        releaser.cancel()
+
+        releaseHolder.complete(Unit)
+        holder.join()
+        releaser.join()
+
+        // The release reopened the cooldown, so a probe is admissible again once it elapses. Had
+        // the cleanup been skipped, the circuit would still be half open and this would be null.
+        clock.set(4_000)
+        assertNotNull(health.tryAcquirePrimary())
+        Unit
+    }
+
+    private fun mutexOf(health: GoogleEndpointHealth): Mutex {
+        val field = GoogleEndpointHealth::class.java.getDeclaredField("mutex")
+        field.isAccessible = true
+        return field.get(health) as Mutex
+    }
+}

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerServiceTest.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerServiceTest.kt
@@ -109,6 +109,20 @@ class GoogleSpellCheckerServiceTest {
     }
 
     @Test
+    fun `a rate limited spell check is attempted once per sentence`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.RateLimitError("rate limited")) }
+        )
+        val spellChecker = createService(client)
+
+        assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isErr)
+
+        // The lone sentence is tried once. A plain GET would have retried the rate limit twice
+        // before the failure reached the circuit.
+        assertEquals(1, client.primaryCalls)
+    }
+
+    @Test
     fun `unrecognised spell payload is not treated as no corrections and is not cached`() = runBlocking {
         val client = GoogleTestHttpClient(
             primaryHandler = { Ok("""{"error":{"code":429}}""") }

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerServiceTest.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerServiceTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -129,6 +130,29 @@ class GoogleSpellCheckerServiceTest {
         assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isOk)
 
         assertEquals(1, client.primaryCalls)
+    }
+
+    @Test
+    fun `spell check queued behind the semaphore does not hit the primary after the circuit opens`() = runBlocking {
+        val entered = AtomicInteger(0)
+        val fourInFlight = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = {
+                if (entered.incrementAndGet() == 4) fourInFlight.complete(Unit)
+                gate.await()
+                Err(ServiceError.RateLimitError("rate limited"))
+            }
+        )
+        val spellChecker = createService(client)
+
+        val job = async { spellChecker.check(requestWithTenSentences()) }
+        fourInFlight.await()
+        gate.complete(Unit)
+
+        // The first failure opens the circuit, so the six queued sentences issue no more requests.
+        assertTrue(job.await().isErr)
+        assertEquals(4, client.primaryCalls)
     }
 
     private fun requestWithTenSentences() =

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerServiceTest.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleSpellCheckerServiceTest.kt
@@ -1,0 +1,140 @@
+package com.github.ahatem.qtranslate.plugins.google
+
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.ahatem.qtranslate.api.spellchecker.SpellCheckRequest
+import com.github.ahatem.qtranslate.api.translator.TranslationRequest
+import com.github.ahatem.qtranslate.plugins.common.ApiConfig
+import com.github.ahatem.qtranslate.plugins.common.FakePluginContext
+import com.github.ahatem.qtranslate.plugins.google.common.GoogleLanguageMapper
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.fold
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class GoogleSpellCheckerServiceTest {
+
+    private fun createService(
+        client: GoogleTestHttpClient,
+        health: GoogleEndpointHealth = GoogleEndpointHealth({ 0L }, { 0L })
+    ) = GoogleSpellCheckerService(
+        FakePluginContext(),
+        client,
+        GoogleLanguageMapper,
+        ApiConfig(),
+        health
+    )
+
+    @Test
+    fun `open primary circuit fails spell check without a request`() = runBlocking {
+        val clock = AtomicLong(0)
+        val health = GoogleEndpointHealth({ clock.get() }, { 0L })
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                if (index < 2) Err(ServiceError.TimeoutError("timed out")) else Ok(SPELL_JSON)
+            },
+            fallbackHandler = { Ok("""["Bonjour","en"]""") }
+        )
+        val translator = GoogleTranslatorService(
+            FakePluginContext(),
+            GoogleSettings(),
+            client,
+            GoogleLanguageMapper,
+            ApiConfig(),
+            health
+        )
+        val spellChecker = createService(client, health)
+
+        val translationRequest = TranslationRequest("Hello", LanguageCode.AUTO, LanguageCode.FRENCH)
+        translator.translate(translationRequest)
+        translator.translate(translationRequest)
+        assertEquals(2, client.primaryCalls)
+
+        val result = spellChecker.check(SpellCheckRequest("Helo world."))
+
+        assertTrue(result.isErr)
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `spell check request concurrency is bounded`() = runBlocking {
+        val release = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = {
+                release.await()
+                Ok(SPELL_JSON)
+            }
+        )
+        val spellChecker = createService(client)
+
+        val job = async { spellChecker.check(requestWithTenSentences()) }
+
+        var attempts = 0
+        while (client.maxInFlight < 4 && attempts < 10_000) {
+            yield()
+            attempts++
+        }
+
+        assertEquals(4, client.maxInFlight)
+        release.complete(Unit)
+        job.await().fold(
+            success = {},
+            failure = { fail(it.message) }
+        )
+        assertEquals(4, client.maxInFlight)
+    }
+
+    @Test
+    fun `failed spell request is not cached`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                if (index == 0) Err(ServiceError.TimeoutError("timed out")) else Ok(SPELL_JSON)
+            }
+        )
+        val spellChecker = createService(client)
+
+        assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isErr)
+        assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isOk)
+
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `unrecognised spell payload is not treated as no corrections and is not cached`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Ok("""{"error":{"code":429}}""") }
+        )
+        val spellChecker = createService(client)
+
+        assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isErr)
+        assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isErr)
+
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `genuine no-correction response is cached`() = runBlocking {
+        val client = GoogleTestHttpClient(primaryHandler = { Ok(SPELL_JSON) })
+        val spellChecker = createService(client)
+
+        assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isOk)
+        assertTrue(spellChecker.check(SpellCheckRequest("Helo world.")).isOk)
+
+        assertEquals(1, client.primaryCalls)
+    }
+
+    private fun requestWithTenSentences() =
+        SpellCheckRequest(text = (1..10).joinToString(" ") { "Sentence$it." })
+
+    private companion object {
+        const val SPELL_JSON = """{"sentences":[{"trans":"translated","orig":"original"}],"src":"en"}"""
+    }
+}

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTestHttpClient.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTestHttpClient.kt
@@ -1,19 +1,27 @@
 package com.github.ahatem.qtranslate.plugins.google
 
 import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.ahatem.qtranslate.api.plugin.SingleAttemptHttpClient
 import com.github.ahatem.qtranslate.plugins.common.TextHttpClient
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getError
 
 /**
  * Routes requests by host so the primary and fallback endpoints can be scripted independently, and
  * records call counts plus the peak number of in-flight requests for concurrency assertions.
+ *
+ * It also mirrors the transport's retry policy. The transport retries a 429 up to twice, so a plain
+ * [get] that meets a rate limit calls the handler three times in all before returning the last
+ * result, while [getOnce] sends a single attempt and hands back the first answer. Every attempt the
+ * handler serves is counted, so [primaryCalls] and [fallbackCalls] are wire attempts rather than
+ * call sites: the same rate limited request counts three through [get] and one through [getOnce].
  */
 internal class GoogleTestHttpClient(
     private val primaryHandler: suspend (Int) -> Result<String, ServiceError>,
     private val fallbackHandler: suspend (Int) -> Result<String, ServiceError> =
         { Err(ServiceError.NetworkError("no fallback arranged")) }
-) : TextHttpClient() {
+) : TextHttpClient(), SingleAttemptHttpClient {
 
     private val lock = Any()
     private val requestLog = mutableListOf<String>()
@@ -32,6 +40,22 @@ internal class GoogleTestHttpClient(
         headers: Map<String, String>,
         queryParams: Map<String, Any?>
     ): Result<String, ServiceError> {
+        var result = attempt(url)
+        var retries = 0
+        while (retries < TRANSPORT_RETRIES && result.getError() is ServiceError.RateLimitError) {
+            result = attempt(url)
+            retries++
+        }
+        return result
+    }
+
+    override suspend fun getOnce(
+        url: String,
+        headers: Map<String, String>,
+        queryParams: Map<String, Any?>
+    ): Result<String, ServiceError> = attempt(url)
+
+    private suspend fun attempt(url: String): Result<String, ServiceError> {
         val isFallback = url.contains("clients5.google.com")
         val index: Int
         synchronized(lock) {
@@ -53,4 +77,9 @@ internal class GoogleTestHttpClient(
         body: String?,
         queryParams: Map<String, Any?>
     ): Result<String, ServiceError> = Err(ServiceError.InvalidInputError("unexpected POST to $url"))
+
+    private companion object {
+        // A rate limit gets one attempt plus two retries on the transport.
+        const val TRANSPORT_RETRIES = 2
+    }
 }

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTestHttpClient.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTestHttpClient.kt
@@ -1,0 +1,56 @@
+package com.github.ahatem.qtranslate.plugins.google
+
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.ahatem.qtranslate.plugins.common.TextHttpClient
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+
+/**
+ * Routes requests by host so the primary and fallback endpoints can be scripted independently, and
+ * records call counts plus the peak number of in-flight requests for concurrency assertions.
+ */
+internal class GoogleTestHttpClient(
+    private val primaryHandler: suspend (Int) -> Result<String, ServiceError>,
+    private val fallbackHandler: suspend (Int) -> Result<String, ServiceError> =
+        { Err(ServiceError.NetworkError("no fallback arranged")) }
+) : TextHttpClient() {
+
+    private val lock = Any()
+    private val requestLog = mutableListOf<String>()
+    private var primaryCallCount = 0
+    private var fallbackCallCount = 0
+    private var inFlightNow = 0
+    private var maxInFlightNow = 0
+
+    val urls: List<String> get() = synchronized(lock) { requestLog.toList() }
+    val primaryCalls: Int get() = synchronized(lock) { primaryCallCount }
+    val fallbackCalls: Int get() = synchronized(lock) { fallbackCallCount }
+    val maxInFlight: Int get() = synchronized(lock) { maxInFlightNow }
+
+    override suspend fun get(
+        url: String,
+        headers: Map<String, String>,
+        queryParams: Map<String, Any?>
+    ): Result<String, ServiceError> {
+        val isFallback = url.contains("clients5.google.com")
+        val index: Int
+        synchronized(lock) {
+            requestLog += url
+            inFlightNow++
+            if (inFlightNow > maxInFlightNow) maxInFlightNow = inFlightNow
+            index = if (isFallback) fallbackCallCount++ else primaryCallCount++
+        }
+        return try {
+            if (isFallback) fallbackHandler(index) else primaryHandler(index)
+        } finally {
+            synchronized(lock) { inFlightNow-- }
+        }
+    }
+
+    override suspend fun post(
+        url: String,
+        headers: Map<String, String>,
+        body: String?,
+        queryParams: Map<String, Any?>
+    ): Result<String, ServiceError> = Err(ServiceError.InvalidInputError("unexpected POST to $url"))
+}

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorServiceTest.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorServiceTest.kt
@@ -13,6 +13,7 @@ import com.github.michaelbull.result.getError
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicLong
@@ -487,6 +488,231 @@ class GoogleTranslatorServiceTest {
         )
         assertEquals(3, client.primaryCalls)
         assertEquals(1, client.fallbackCalls)
+    }
+
+    @Test
+    fun `rate limit without retry-after opens the circuit immediately`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.RateLimitError("rate limited")) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request)
+        service.translate(request)
+
+        // The first rate limit opens the circuit, so the second call never reaches the primary.
+        assertEquals(1, client.primaryCalls)
+        assertEquals(2, client.fallbackCalls)
+    }
+
+    @Test
+    fun `a stale success cannot close a circuit opened after its request began`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                when (index) {
+                    0 -> {
+                        started.complete(Unit)
+                        gate.await()
+                        Ok(PRIMARY_JSON)
+                    }
+                    1, 2 -> Err(ServiceError.TimeoutError("timed out"))
+                    else -> Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        val older = async { service.translate(request) }
+        started.await()
+
+        // Two transient failures open the circuit while the older request is still in flight.
+        service.translate(request)
+        service.translate(request)
+        assertEquals(3, client.primaryCalls)
+
+        gate.complete(Unit)
+        older.await().fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+
+        // The older success belongs to a previous generation and must not heal the circuit.
+        service.translate(request)
+        assertEquals(3, client.primaryCalls)
+        assertEquals(3, client.fallbackCalls)
+    }
+
+    @Test
+    fun `stale failures cannot reopen a circuit healed by a successful probe`() = runBlocking {
+        val firstStarted = CompletableDeferred<Unit>()
+        val secondStarted = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val clock = AtomicLong(0)
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                when (index) {
+                    0 -> {
+                        firstStarted.complete(Unit)
+                        gate.await()
+                        Err(ServiceError.TimeoutError("timed out"))
+                    }
+                    1 -> {
+                        secondStarted.complete(Unit)
+                        gate.await()
+                        Err(ServiceError.TimeoutError("timed out"))
+                    }
+                    2, 3 -> Err(ServiceError.TimeoutError("timed out"))
+                    else -> Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        val first = async { service.translate(request) }
+        firstStarted.await()
+        val second = async { service.translate(request) }
+        secondStarted.await()
+
+        // Two further failures open the circuit while the older requests are still in flight.
+        service.translate(request)
+        service.translate(request)
+        assertEquals(4, client.primaryCalls)
+
+        clock.set(2_000)
+        service.translate(request)
+        assertEquals(5, client.primaryCalls)
+
+        // The probe heals the circuit; the older requests now resolve with stale failures.
+        gate.complete(Unit)
+        first.await()
+        second.await()
+
+        service.translate(request)
+        assertEquals(6, client.primaryCalls)
+    }
+
+    @Test
+    fun `cancelling a half-open probe does not strand the circuit`() = runBlocking {
+        val clock = AtomicLong(0)
+        val probeStarted = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                when (index) {
+                    0, 1 -> Err(ServiceError.TimeoutError("timed out"))
+                    2 -> {
+                        probeStarted.complete(Unit)
+                        gate.await()
+                        Ok(PRIMARY_JSON)
+                    }
+                    else -> Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        service.translate(request)
+        service.translate(request)
+        assertEquals(2, client.primaryCalls)
+
+        clock.set(2_000)
+        val probe = async { service.translate(request) }
+        probeStarted.await()
+        probe.cancelAndJoin()
+
+        // The abandoned probe reopens the cooldown instead of leaving the circuit half open.
+        service.translate(request)
+        assertEquals(3, client.primaryCalls)
+
+        clock.set(4_000)
+        service.translate(request)
+        assertEquals(4, client.primaryCalls)
+        assertEquals(3, client.fallbackCalls)
+    }
+
+    @Test
+    fun `a cancelled probe is not recorded as success or failure`() = runBlocking {
+        val clock = AtomicLong(0)
+        val probeStarted = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                when (index) {
+                    0, 1 -> Err(ServiceError.TimeoutError("timed out"))
+                    2 -> {
+                        probeStarted.complete(Unit)
+                        gate.await()
+                        Ok(PRIMARY_JSON)
+                    }
+                    else -> Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        service.translate(request)
+        service.translate(request)
+        clock.set(2_000)
+
+        val probe = async { service.translate(request) }
+        probeStarted.await()
+        probe.cancelAndJoin()
+
+        // Before the reopened cooldown elapses a call must not reach the primary, so the cancelled
+        // probe neither healed the circuit nor reset it.
+        clock.set(2_999)
+        service.translate(request)
+        assertEquals(3, client.primaryCalls)
+        assertEquals(3, client.fallbackCalls)
+    }
+
+    @Test
+    fun `only one half-open probe is live at a time`() = runBlocking {
+        val clock = AtomicLong(0)
+        val probeStarted = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                when (index) {
+                    0, 1 -> Err(ServiceError.TimeoutError("timed out"))
+                    2 -> {
+                        probeStarted.complete(Unit)
+                        gate.await()
+                        Ok(PRIMARY_JSON)
+                    }
+                    else -> Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        service.translate(request)
+        service.translate(request)
+        clock.set(2_000)
+
+        val probe = async { service.translate(request) }
+        probeStarted.await()
+
+        val others = List(5) { async { service.translate(request) } }
+        others.awaitAll()
+
+        // The probe lease is outstanding, so no other caller may reach the primary.
+        assertEquals(3, client.primaryCalls)
+
+        gate.complete(Unit)
+        probe.await().fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+        assertEquals(3, client.primaryCalls)
     }
 
     private companion object {

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorServiceTest.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorServiceTest.kt
@@ -116,6 +116,67 @@ class GoogleTranslatorServiceTest {
     }
 
     @Test
+    fun `the primary is attempted once when the transport would have retried a rate limit`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.RateLimitError("rate limited")) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request).fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+
+        // The primary is tried once from the first answer. A plain GET would have spent two retries
+        // on the rate limit before the circuit ever saw the failure.
+        assertEquals(1, client.primaryCalls)
+        assertEquals(1, client.fallbackCalls)
+    }
+
+    @Test
+    fun `a second translation while the circuit is open makes no primary attempt`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.RateLimitError("rate limited")) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        repeat(2) { attempt ->
+            service.translate(request).fold(
+                success = { assertEquals("Bonjour", it.translatedText) },
+                failure = { fail("attempt $attempt failed: ${it.message}") }
+            )
+        }
+
+        // The single rate-limited attempt opens the circuit, so the second call never reaches the
+        // primary and both translations come from the fallback.
+        assertEquals(1, client.primaryCalls)
+        assertEquals(2, client.fallbackCalls)
+    }
+
+    @Test
+    fun `a rate limited primary does not delay the fallback`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.RateLimitError("rate limited", retryAfterSeconds = 5)) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        val startedAt = System.nanoTime()
+        service.translate(request).fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+        val elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000
+
+        // The request is not held for the Retry-After the transport would otherwise have honoured
+        // before retrying; the fallback answers straight away.
+        assertEquals(1, client.primaryCalls)
+        assertTrue(elapsedMillis < 2_000, "translation took ${elapsedMillis}ms")
+    }
+
+    @Test
     fun `usable retry-after delays the next probe`() = runBlocking {
         val clock = AtomicLong(0)
         val client = GoogleTestHttpClient(

--- a/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorServiceTest.kt
+++ b/plugins/google-services/src/test/kotlin/com/github/ahatem/qtranslate/plugins/google/GoogleTranslatorServiceTest.kt
@@ -1,0 +1,496 @@
+package com.github.ahatem.qtranslate.plugins.google
+
+import com.github.ahatem.qtranslate.api.language.LanguageCode
+import com.github.ahatem.qtranslate.api.plugin.ServiceError
+import com.github.ahatem.qtranslate.api.translator.TranslationRequest
+import com.github.ahatem.qtranslate.plugins.common.ApiConfig
+import com.github.ahatem.qtranslate.plugins.common.FakePluginContext
+import com.github.ahatem.qtranslate.plugins.google.common.GoogleLanguageMapper
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.fold
+import com.github.michaelbull.result.getError
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class GoogleTranslatorServiceTest {
+
+    private val request = TranslationRequest(
+        text = "Hello",
+        sourceLanguage = LanguageCode.AUTO,
+        targetLanguage = LanguageCode.FRENCH
+    )
+
+    private fun createService(
+        client: GoogleTestHttpClient,
+        clock: AtomicLong
+    ) = GoogleTranslatorService(
+        FakePluginContext(),
+        GoogleSettings(),
+        client,
+        GoogleLanguageMapper,
+        ApiConfig(),
+        GoogleEndpointHealth({ clock.get() }, { 0L })
+    )
+
+    @Test
+    fun `healthy primary is used once and never falls back`() = runBlocking {
+        val client = GoogleTestHttpClient(primaryHandler = { Ok(PRIMARY_JSON) })
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request).fold(
+            success = {
+                assertEquals("Bonjour", it.translatedText)
+                assertEquals(LanguageCode.ENGLISH, it.detectedLanguage)
+            },
+            failure = { fail(it.message) }
+        )
+
+        assertEquals(1, client.primaryCalls)
+        assertEquals(0, client.fallbackCalls)
+    }
+
+    @Test
+    fun `primary timeout falls back to the fallback endpoint`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request).fold(
+            success = {
+                assertEquals("Bonjour", it.translatedText)
+                assertEquals(LanguageCode.ENGLISH, it.detectedLanguage)
+            },
+            failure = { fail(it.message) }
+        )
+
+        assertEquals(1, client.primaryCalls)
+        assertEquals(1, client.fallbackCalls)
+    }
+
+    @Test
+    fun `repeated transient failures open the circuit and bypass the primary`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        repeat(3) { attempt ->
+            service.translate(request).fold(
+                success = { assertEquals("Bonjour", it.translatedText) },
+                failure = { fail("attempt $attempt failed: ${it.message}") }
+            )
+        }
+
+        // Two failures open the circuit; the third call must not touch the primary at all.
+        assertEquals(2, client.primaryCalls)
+        assertEquals(3, client.fallbackCalls)
+    }
+
+    @Test
+    fun `rate limit response opens the circuit immediately`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.RateLimitError("rate limited", retryAfterSeconds = 30)) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        repeat(2) { service.translate(request) }
+
+        assertEquals(1, client.primaryCalls)
+        assertEquals(2, client.fallbackCalls)
+    }
+
+    @Test
+    fun `usable retry-after delays the next probe`() = runBlocking {
+        val clock = AtomicLong(0)
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                if (index == 0) Err(ServiceError.RateLimitError("rate limited", retryAfterSeconds = 30))
+                else Ok(PRIMARY_JSON)
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        service.translate(request)
+        assertEquals(1, client.primaryCalls)
+
+        clock.set(29_999)
+        service.translate(request)
+        assertEquals(1, client.primaryCalls)
+
+        clock.set(30_000)
+        service.translate(request)
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `transient service unavailable counts toward opening the circuit`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.ServiceUnavailableError("bad gateway")) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        repeat(3) { service.translate(request) }
+
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `authentication error is returned unchanged and does not open the circuit`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.AuthenticationError("invalid key")) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        val first = service.translate(request)
+        assertIs<ServiceError.AuthenticationError>(first.getError())
+        assertEquals(0, client.fallbackCalls)
+        assertEquals(1, client.primaryCalls)
+
+        service.translate(request)
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `invalid input error is returned unchanged and does not open the circuit`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.InvalidInputError("bad request")) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        val first = service.translate(request)
+        assertIs<ServiceError.InvalidInputError>(first.getError())
+        assertEquals(0, client.fallbackCalls)
+        assertEquals(1, client.primaryCalls)
+
+        service.translate(request)
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `unparseable primary body falls back to the fallback endpoint`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Ok("<html>nope</html>") },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request).fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+
+        assertEquals(1, client.primaryCalls)
+        assertEquals(1, client.fallbackCalls)
+    }
+
+    @Test
+    fun `unparseable primary body does not open the circuit`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Ok("<html>nope</html>") },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        repeat(3) { attempt ->
+            service.translate(request).fold(
+                success = { assertEquals("Bonjour", it.translatedText) },
+                failure = { fail("attempt $attempt failed: ${it.message}") }
+            )
+        }
+
+        assertEquals(3, client.primaryCalls)
+        assertEquals(3, client.fallbackCalls)
+    }
+
+    @Test
+    fun `only one half-open probe is issued for concurrent callers`() = runBlocking {
+        val clock = AtomicLong(0)
+        val probeStarted = CompletableDeferred<Unit>()
+        val probeRelease = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                when (index) {
+                    0, 1 -> Err(ServiceError.TimeoutError("timed out"))
+                    2 -> {
+                        probeStarted.complete(Unit)
+                        probeRelease.await()
+                        Ok(PRIMARY_JSON)
+                    }
+                    else -> Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        service.translate(request)
+        service.translate(request)
+        assertEquals(2, client.primaryCalls)
+
+        clock.set(2_000)
+        val probe = async { service.translate(request) }
+        probeStarted.await()
+
+        val losers = List(4) { async { service.translate(request) } }
+        losers.awaitAll()
+
+        assertEquals(3, client.primaryCalls)
+        assertEquals(6, client.fallbackCalls)
+
+        probeRelease.complete(Unit)
+        probe.await().fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+    }
+
+    @Test
+    fun `successful half-open probe returns the circuit to healthy`() = runBlocking {
+        val clock = AtomicLong(0)
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                if (index < 2) Err(ServiceError.TimeoutError("timed out")) else Ok(PRIMARY_JSON)
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        service.translate(request)
+        service.translate(request)
+        clock.set(2_000)
+
+        service.translate(request)
+        service.translate(request)
+
+        assertEquals(4, client.primaryCalls)
+        assertEquals(2, client.fallbackCalls)
+    }
+
+    @Test
+    fun `failed half-open probe reopens the cooldown`() = runBlocking {
+        val clock = AtomicLong(0)
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, clock)
+
+        service.translate(request)
+        service.translate(request)
+        clock.set(2_000)
+        service.translate(request)
+        service.translate(request)
+        assertEquals(3, client.primaryCalls)
+
+        clock.set(6_000)
+        service.translate(request)
+        assertEquals(4, client.primaryCalls)
+    }
+
+    @Test
+    fun `fallback parses a nested array response`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok("""[["Bonjour","en"]]""") }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request).fold(
+            success = {
+                assertEquals("Bonjour", it.translatedText)
+                assertEquals(LanguageCode.ENGLISH, it.detectedLanguage)
+            },
+            failure = { fail(it.message) }
+        )
+    }
+
+    @Test
+    fun `fallback parses a flat array response`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok("""["Bonjour","en"]""") }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request).fold(
+            success = {
+                assertEquals("Bonjour", it.translatedText)
+                assertEquals(LanguageCode.ENGLISH, it.detectedLanguage)
+            },
+            failure = { fail(it.message) }
+        )
+    }
+
+    @Test
+    fun `fallback response without detected language still succeeds`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok("""["Bonjour"]""") }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(request).fold(
+            success = {
+                assertEquals("Bonjour", it.translatedText)
+                assertNull(it.detectedLanguage)
+            },
+            failure = { fail(it.message) }
+        )
+    }
+
+    @Test
+    fun `empty fallback response fails with an invalid response error`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok("[]") }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        assertIs<ServiceError.InvalidResponseError>(service.translate(request).getError())
+        Unit
+    }
+
+    @Test
+    fun `malformed fallback response fails with an invalid response error`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok("<html>nope</html>") }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        assertIs<ServiceError.InvalidResponseError>(service.translate(request).getError())
+        Unit
+    }
+
+    @Test
+    fun `unsupported fallback object shape fails with an invalid response error`() = runBlocking {
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok("""{"translated":"Bonjour"}""") }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        assertIs<ServiceError.InvalidResponseError>(service.translate(request).getError())
+        Unit
+    }
+
+    @Test
+    fun `backward translation goes through the fallback endpoint`() = runBlocking {
+        val backward = TranslationRequest(
+            text = "Bonjour",
+            sourceLanguage = LanguageCode.FRENCH,
+            targetLanguage = LanguageCode.ENGLISH
+        )
+        val client = GoogleTestHttpClient(
+            primaryHandler = { Err(ServiceError.TimeoutError("timed out")) },
+            fallbackHandler = { Ok("""["Hello","fr"]""") }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        service.translate(backward).fold(
+            success = {
+                assertEquals("Hello", it.translatedText)
+                assertEquals(LanguageCode.FRENCH, it.detectedLanguage)
+            },
+            failure = { fail(it.message) }
+        )
+        assertEquals(1, client.fallbackCalls)
+    }
+
+    @Test
+    fun `cancellation during the primary wait does not fall back`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                if (index == 0) {
+                    started.complete(Unit)
+                    gate.await()
+                    Ok(PRIMARY_JSON)
+                } else {
+                    Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        val job = launch { service.translate(request) }
+        started.await()
+        job.cancel()
+        job.join()
+
+        assertTrue(job.isCancelled)
+        assertEquals(0, client.fallbackCalls)
+
+        // Health was left untouched, so the next call still uses the primary.
+        service.translate(request).fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+        assertEquals(2, client.primaryCalls)
+    }
+
+    @Test
+    fun `late failure of an older request does not reopen a healed circuit`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
+        val client = GoogleTestHttpClient(
+            primaryHandler = { index ->
+                if (index == 0) {
+                    started.complete(Unit)
+                    gate.await()
+                    Err(ServiceError.TimeoutError("timed out"))
+                } else {
+                    Ok(PRIMARY_JSON)
+                }
+            },
+            fallbackHandler = { Ok(FALLBACK_FLAT) }
+        )
+        val service = createService(client, AtomicLong(0))
+
+        val older = async { service.translate(request) }
+        started.await()
+
+        val newer = async { service.translate(request) }
+        newer.await().fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+
+        gate.complete(Unit)
+        older.await().fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+
+        service.translate(request).fold(
+            success = { assertEquals("Bonjour", it.translatedText) },
+            failure = { fail(it.message) }
+        )
+        assertEquals(3, client.primaryCalls)
+        assertEquals(1, client.fallbackCalls)
+    }
+
+    private companion object {
+        const val PRIMARY_JSON = """{"sentences":[{"trans":"Bonjour","orig":"Hello"}],"src":"en"}"""
+        const val FALLBACK_FLAT = """["Bonjour","en"]"""
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Stops the repeated 5-6 second stall on the unofficial Google primary endpoint by tracking its health instead of waiting out its request timeout on every call, and lets that endpoint sidestep the transport's own retry policy so the health decision is made on the first answer.

**Transport: a per-request way to skip retries**

- Adds `SingleAttemptHttpClient`, a new optional capability interface over `HttpClient`, and `getOnce`. `KtorHttpClient` implements it, and a single-attempt request is marked with Ktor's own per-request `retry { noRetry() }`, so only that request skips the client-wide policy. Nothing is disabled globally: every other request keeps retrying exactly as before.
- It is a separate interface rather than a method on `HttpClient` on purpose. Adding a method there would oblige every existing and third-party implementation to grow one, including transports that do not retry and could only ignore it. A caller tests for the capability and falls back to `get` when the transport does not offer it, via a small `HttpClient.getOnce` extension in `plugins/common`.
- Because the published contract gained a type, `ApiVersion.MINOR` moves to 1 (`VERSION` is now `2.1.0`) and the api artifact version follows, per the module's own rule. No existing signature changed and no plugin is obliged to do anything.

**Google plugin: the primary is a single attempt**

- `GoogleTranslatorService.tryPrimaryEndpoint` and `GoogleSpellCheckerService.checkSentence` now use `getOnce` for the unofficial primary host. Previously the transport retried a 429 twice, with backoff, before the plugin ever saw the failure, which is precisely the latency the issue reports. The fallback endpoint and the official API keep using `get`.
- `GoogleEndpointHealth` is a circuit breaker shared by the translator and the spell checker. A caller holds a permit carrying the circuit generation it was issued in, so a request that began before a transition can no longer rewrite newer state: an older success cannot close a circuit that opened while it was in flight, and older failures cannot reopen one that a probe has healed.
- Two consecutive transient failures open the circuit. A rate limit opens it immediately, including when the response carried no `Retry-After`, and the cooldown honours that hint when present. Otherwise the cooldown is bounded exponential backoff with jitter.
- While the circuit is open, callers go straight to the fallback, so the primary timeout is not paid again. After the cooldown exactly one caller is admitted as a half-open probe, and only one probe can be live at a time. A cancelled or abandoned probe hands its permit back and returns the circuit to the cooldown rather than leaving it half open.
- The permit release runs from a `finally`, so it is on the cancellation path. It is now wrapped in `NonCancellable` so the cleanup cannot itself be cancelled while waiting for the lock, which would have stranded the circuit half open. Only the release is protected; the HTTP request stays cancellable.
- Only transient failures count towards opening the circuit: network failure, timeout, 429 and transient 5xx. Errors meaning the request itself is unacceptable are returned unchanged and leave the circuit alone.

**Retry-After**

- The transport previously built `RateLimitError` without ever setting `retryAfterSeconds`, although the API documents the field and several plugins already read it. It is now read from the response header, in both the delta-seconds and the standard HTTP-date form, with a past or malformed value treated as no hint and an absurd one clamped to a sane bound. Both the text and bytes response paths behave identically.
- This is generic transport behaviour and it does affect other plugins that already read the field (DeepL, Yandex, Wikimedia, Reverso): their backoff now honours the server's hint instead of always falling back to a default.

**Fallback response parsing**

- The fallback parser inspects the JSON shape instead of decoding into a fixed type. It handles the flat `["translated","src",...]` variant that previously failed with `Expected start of the array '[', but had '"' instead at path: $[0]`, plus the nested variant, and returns `InvalidResponseError` for anything else instead of throwing. This also repairs backward translation, which reuses the same path.
- A primary that answers 200 with a body the parser cannot read still falls back. It simply does not count as a health signal.

**Evidence**

Nine transport tests and nine Google tests were added, and the load-bearing ones were verified by reverting the production change each covers. Notably: a single-attempt 429 makes exactly one wire attempt with retries enabled globally (three through plain `get`, unchanged); a rate limited primary is attempted once and falls back without waiting out `Retry-After`; a second translation while the circuit is open makes no primary attempt; an ordinary `get` still retries; and removing the `NonCancellable` wrapper makes the cancelled-release test fail.

Note on `GooglePlugin.kt`: this file was committed with CRLF before the repository adopted `* text=auto`, so editing it renormalised the whole file and turned a three line change into a 213 line diff. Its path is now pinned in `.gitattributes` (`-text` with `cr-at-eol`) so the stored bytes are preserved and the change stays readable. No code in that file was reformatted.

## Related issues

Closes #244 
Closes #229 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [x] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected, no logic in UI components
- [x] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots (if UI changes)

None.
