### PR TITLE
fix(ui): preserve clipboard during selection capture

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ flatlaf = "3.7.2"
 
 jnativehook = "2.2.2"
 jkeymaster = "1.3"
+jna = "5.4.0"
 
 jlayer = "1.0.3"
 jsoup = "1.23.1"
@@ -52,6 +53,7 @@ miglayout = { module = "com.miglayout:miglayout-swing", version.ref = "miglayout
 
 jnativehook = { module = "com.github.kwhat:jnativehook", version.ref = "jnativehook" }
 jkeymaster = { module = "com.github.tulskiy:jkeymaster", version.ref = "jkeymaster" }
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 
 
 # Data store

--- a/ui-swing/build.gradle.kts
+++ b/ui-swing/build.gradle.kts
@@ -24,8 +24,10 @@ dependencies {
 
     implementation(libs.jnativehook)
     implementation(libs.jkeymaster)
+    implementation(libs.jna)
 
     implementation(libs.commonmark)
 
     testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinxCoroutinesTest)
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/DoubleCtrlDetector.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/DoubleCtrlDetector.kt
@@ -1,0 +1,71 @@
+package com.github.ahatem.qtranslate.ui.swing.main
+
+/**
+ * Double-Ctrl tap-pair detection as a pure state machine over Control press/release events.
+ *
+ * The load-bearing invariant: a Control release counts as a tap only if a corresponding
+ * Control press was observed first. Orphan or synthetic releases (no observed press) are
+ * ignored completely: they do not count as taps, do not arm or complete a pair, and do not
+ * touch the recorded tap time. This is what keeps synthetic key-up traffic, such as a
+ * clipboard manager releasing modifiers around a paste, from being read as Double Ctrl.
+ *
+ * A repeated Control press while Control is already held is likewise ignored, so auto-repeat
+ * or duplicate down events cannot erase an in-progress combination and turn a shortcut into
+ * a tap. Any non-Control key pressed while Control is held still invalidates that tap.
+ *
+ * Arming and firing only happen while [active] is true; tracking itself is unconditional,
+ * so enabling or disabling the hotkey cannot desynchronize the press/release bookkeeping.
+ */
+internal class DoubleCtrlDetector(
+    private val thresholdMs: Long = DEFAULT_DOUBLE_CTRL_THRESHOLD_MS,
+) {
+
+    private var down = false
+    private var pressObserved = false
+    private var partOfCombination = false
+    private var lastTapMs = 0L
+
+    fun onControlPressed() {
+        if (!down) {
+            down = true
+            pressObserved = true
+            partOfCombination = false
+        }
+    }
+
+    fun onOtherKeyPressed() {
+        if (down) partOfCombination = true
+    }
+
+    /**
+     * Returns true when this release completes a tap pair. Returns false for orphan releases,
+     * combination releases, single taps (which only arm), pairs outside the threshold, and any
+     * release while [active] is false.
+     */
+    fun onControlReleased(nowMs: Long, active: Boolean): Boolean {
+        if (!down || !pressObserved) {
+            down = false
+            pressObserved = false
+            return false
+        }
+        down = false
+        pressObserved = false
+        if (partOfCombination) {
+            partOfCombination = false
+            lastTapMs = 0L
+            return false
+        }
+        if (!active) return false
+        return if (nowMs - lastTapMs < thresholdMs) {
+            lastTapMs = 0L
+            true
+        } else {
+            lastTapMs = nowMs
+            false
+        }
+    }
+
+    companion object {
+        const val DEFAULT_DOUBLE_CTRL_THRESHOLD_MS = 400L
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
@@ -244,59 +244,30 @@ class MainGlobalKeyListener(
      * Handles the double-Ctrl sequence for [HotkeyAction.SHOW_MAIN_WINDOW].
      *
      * This cannot be expressed as a single KeyStroke so it uses JNativeHook's
-     * raw key events. It only fires if:
-     * 1. Global hotkeys are enabled
-     * 2. The SHOW_MAIN_WINDOW binding exists AND isEnabled = true
-     *    (Hoyeun's request — user can disable it from the keyboard panel)
+     * raw key events. Tap-pair bookkeeping lives in [DoubleCtrlDetector]; this listener
+     * only supplies events, the enable/binding gate, and the fire action.
      */
     private inner class CustomSequenceListener : NativeKeyListener {
-        private var lastCtrlTime = 0L
-        private val threshold = 400
-
-        /** True once a key other than Ctrl is pressed while Ctrl is held. */
-        private var ctrlWasPartOfCombination = false
-        private var ctrlIsDown = false
+        private val detector = DoubleCtrlDetector()
 
         override fun nativeKeyPressed(e: NativeKeyEvent) {
-            if (e.keyCode == NativeKeyEvent.VC_CONTROL) {
-                ctrlIsDown = true
-                ctrlWasPartOfCombination = false
-            } else if (ctrlIsDown) {
-                ctrlWasPartOfCombination = true
-            }
+            if (e.keyCode == NativeKeyEvent.VC_CONTROL) detector.onControlPressed()
+            else detector.onOtherKeyPressed()
         }
 
         override fun nativeKeyReleased(e: NativeKeyEvent) {
             if (e.keyCode != NativeKeyEvent.VC_CONTROL) return
-            ctrlIsDown = false
 
-            // The Ctrl that ends a shortcut is not a tap. Every hotkey in this application is a
-            // Ctrl combination, so counting those releases meant two shortcuts pressed within the
-            // threshold — Ctrl+Q twice, or Ctrl+Q then Ctrl+D — read as a double-Ctrl and summoned
-            // the main window on top of the popup the user actually asked for.
-            //
-            // The time is cleared as well as ignored, so the release that ends a shortcut cannot
-            // pair with a genuine tap that follows it either.
-            if (ctrlWasPartOfCombination) {
-                ctrlWasPartOfCombination = false
-                lastCtrlTime = 0L
-                return
-            }
-
-            if (!hotkeysEnabled.get()) return
-
-            // Only fire if the binding exists, is enabled, AND the user
-            // has not opted out of the double-Ctrl mechanism specifically.
+            // Only fire if global hotkeys are on and the binding exists, is enabled, AND
+            // the user has not opted out of the double-Ctrl mechanism specifically.
+            // Tracking inside the detector runs regardless, so toggling these cannot
+            // desynchronize its press/release bookkeeping.
             val binding = bindings.find { it.action == HotkeyAction.SHOW_MAIN_WINDOW }
-            if (binding == null || !binding.isEnabled || !binding.isDoubleCtrlEnabled) return
+            val active = hotkeysEnabled.get() &&
+                binding != null && binding.isEnabled && binding.isDoubleCtrlEnabled
+            if (!detector.onControlReleased(System.currentTimeMillis(), active)) return
 
-            val now = System.currentTimeMillis()
-            if (now - lastCtrlTime < threshold) {
-                scope.launch { handleSelectedText(onShowApp) }
-                lastCtrlTime = 0L
-                return
-            }
-            lastCtrlTime = now
+            scope.launch { handleSelectedText(onShowApp) }
         }
     }
 

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/main/MainGlobalKeyListener.kt
@@ -4,6 +4,9 @@ import com.github.ahatem.qtranslate.api.core.Logger
 import com.github.ahatem.qtranslate.core.settings.data.HotkeyAction
 import com.github.ahatem.qtranslate.core.settings.data.HotkeyBinding
 import com.github.ahatem.qtranslate.core.settings.data.HotkeyScope
+import com.github.ahatem.qtranslate.ui.swing.shared.clipboard.AwtSystemClipboard
+import com.github.ahatem.qtranslate.ui.swing.shared.clipboard.ClipboardChangeMonitors
+import com.github.ahatem.qtranslate.ui.swing.shared.clipboard.SelectionCapture
 import com.github.kwhat.jnativehook.GlobalScreen
 import com.github.kwhat.jnativehook.NativeHookException
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent
@@ -16,12 +19,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.awt.Point
 import java.awt.Robot
-import java.awt.Toolkit
-import java.awt.datatransfer.DataFlavor
-import java.awt.datatransfer.StringSelection
 import java.awt.event.KeyEvent
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.UUID
 
 /**
  * Manages global and local hotkey registration.
@@ -64,7 +63,13 @@ class MainGlobalKeyListener(
     private var nativeHookRegistered = false
     private val sequenceListener = CustomSequenceListener()
     private val selectionMouseListener = SelectionMouseListener()
-    private val clipboardLock = AtomicBoolean(false)
+    private val systemClipboard = AwtSystemClipboard()
+    private val selectionCapture = SelectionCapture(
+        clipboard = systemClipboard,
+        changeMonitor = ClipboardChangeMonitors.create(systemClipboard, logger),
+        simulateCopy = { simulateCopy() },
+        logger = logger
+    )
     private val hotkeysEnabled = AtomicBoolean(true)
     // AtomicBoolean.compareAndSet prevents double-initialization if initialize()
     // is called concurrently (e.g. from two rapid lifecycle events).
@@ -347,45 +352,7 @@ class MainGlobalKeyListener(
     }
 
     private suspend fun handleSelectedText(callback: (String) -> Unit) {
-        if (!clipboardLock.compareAndSet(false, true)) return
-        try {
-            val clipboard = Toolkit.getDefaultToolkit().systemClipboard
-            val original  = runCatching { clipboard.getContents(null) }.getOrNull()
-
-            try {
-                // Global hotkey callbacks can arrive while Ctrl/Cmd is still physically held.
-                // Give the originating key sequence time to finish before synthesizing Copy.
-                delay(80)
-
-                var text: String? = null
-                for (backoffMs in longArrayOf(50, 90, 140)) {
-                    val sentinel = "qtranslate-copy-${UUID.randomUUID()}"
-                    runCatching { clipboard.setContents(StringSelection(sentinel), null) }
-
-                    simulateCopy()
-                    delay(backoffMs)
-
-                    val candidate = runCatching {
-                        if (clipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
-                            clipboard.getData(DataFlavor.stringFlavor).toString().trim()
-                        } else {
-                            null
-                        }
-                    }.getOrNull()
-
-                    if (!candidate.isNullOrEmpty() && candidate != sentinel) {
-                        text = candidate
-                        break
-                    }
-                }
-
-                callback(text.orEmpty())
-            } finally {
-                original?.let { runCatching { clipboard.setContents(it, null) } }
-            }
-        } finally {
-            clipboardLock.set(false)
-        }
+        selectionCapture.capture(callback)
     }
 
     private fun simulateCopy() {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardChangeMonitor.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardChangeMonitor.kt
@@ -9,8 +9,10 @@ import com.github.ahatem.qtranslate.api.core.Logger
  * clipboard contents leaves the text unchanged while the platform still records a new
  * clipboard generation. Tokens therefore track the generation, not the data.
  *
- * [mark] returns null when the implementation cannot observe the platform, so callers can
- * degrade instead of failing.
+ * [mark] returns null when the implementation cannot observe the platform. Callers must
+ * treat a null token as "no verifiable copy is possible" and fail the capture instead of
+ * accepting clipboard text: waiting and then reading would risk dispatching stale
+ * pre-existing clipboard content as a fresh selection.
  */
 interface ClipboardChangeMonitor {
 
@@ -45,5 +47,13 @@ internal class SignatureClipboardChangeMonitor(
 
     override fun mark(): Long? = clipboard.signature()
 
-    override fun hasChangedSince(token: Long): Boolean = clipboard.signature() != token
+    /**
+     * A failed signature read is not a change. Signature reads fail exactly when the
+     * clipboard cannot be observed, and treating that as a confirmed change would let the
+     * caller accept stale clipboard text as a fresh selection.
+     */
+    override fun hasChangedSince(token: Long): Boolean {
+        val current = clipboard.signature() ?: return false
+        return current != token
+    }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardChangeMonitor.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardChangeMonitor.kt
@@ -1,0 +1,49 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import com.github.ahatem.qtranslate.api.core.Logger
+
+/**
+ * Detects whether the clipboard has been touched since a token was taken.
+ *
+ * A synthesized copy is not detected by comparing text: copying a selection equal to the
+ * clipboard contents leaves the text unchanged while the platform still records a new
+ * clipboard generation. Tokens therefore track the generation, not the data.
+ *
+ * [mark] returns null when the implementation cannot observe the platform, so callers can
+ * degrade instead of failing.
+ */
+interface ClipboardChangeMonitor {
+
+    /** Opaque token for the clipboard generation right now, or null when unsupported. */
+    fun mark(): Long?
+
+    /** True when the clipboard generation advanced past [token]. */
+    fun hasChangedSince(token: Long): Boolean
+}
+
+/** Picks the best change monitor for the current platform. */
+object ClipboardChangeMonitors {
+
+    fun create(clipboard: SystemClipboard, logger: Logger): ClipboardChangeMonitor {
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+            WindowsClipboardChangeMonitor.create(logger)?.let { return it }
+        }
+        return SignatureClipboardChangeMonitor(clipboard)
+    }
+}
+
+/**
+ * Fallback for platforms without a clipboard generation counter.
+ *
+ * It hashes the available flavors and text, so most changes are seen, but a copy whose data
+ * is identical to what is already on the clipboard cannot be detected. Windows, the primary
+ * target, uses the native sequence number instead.
+ */
+internal class SignatureClipboardChangeMonitor(
+    private val clipboard: SystemClipboard,
+) : ClipboardChangeMonitor {
+
+    override fun mark(): Long? = clipboard.signature()
+
+    override fun hasChangedSince(token: Long): Boolean = clipboard.signature() != token
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCapture.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCapture.kt
@@ -2,17 +2,33 @@ package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
 
 import com.github.ahatem.qtranslate.api.core.Logger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 /**
  * Captures the selected text by synthesizing Copy, without leaving any internal content on
  * the user's clipboard.
  *
- * The clipboard is snapshotted before the copy and restored before [capture]'s callback runs,
+ * The capture order is serialized capture, key-release settle delay, snapshot taken as close
+ * as practical to the copy, sequence mark, Copy, capture, restore, and only then the callback,
  * so clipboard managers never observe a placeholder and the QTranslate action sees the
- * clipboard as the user left it.
+ * clipboard as the user left it. Keeping the snapshot-to-copy window small matters: a snapshot
+ * taken before the settle delay could otherwise overwrite a legitimate clipboard update that
+ * landed during the delay.
+ *
+ * A snapshot that cannot be acquired ([ClipboardSnapshotResult.Failed]) aborts the capture
+ * before Copy is synthesized: overwriting clipboard state that cannot be restored is worse
+ * than capturing nothing. Likewise an unavailable change monitor fails the capture instead
+ * of accepting whatever text happens to be on the clipboard.
+ *
+ * Restoration is retried a bounded number of times for temporary clipboard-busy failures and
+ * runs cancellation-shielded, so cancellation never strands the clipboard in the captured
+ * state. The capture itself stays cancellable.
  *
  * Concurrent requests are serialized, so two hotkeys cannot fight over clipboard ownership.
  */
@@ -25,6 +41,8 @@ class SelectionCapture(
     private val preCopyDelayMs: Long = DEFAULT_PRE_COPY_DELAY_MS,
     private val pollIntervalMs: Long = DEFAULT_POLL_INTERVAL_MS,
     private val captureTimeoutMs: Long = DEFAULT_CAPTURE_TIMEOUT_MS,
+    private val restoreMaxAttempts: Int = DEFAULT_RESTORE_MAX_ATTEMPTS,
+    private val restoreRetryDelayMs: Long = DEFAULT_RESTORE_RETRY_DELAY_MS,
 ) {
 
     /**
@@ -33,42 +51,59 @@ class SelectionCapture(
      */
     suspend fun capture(callback: (String) -> Unit) {
         mutex.withLock {
-            val snapshot = runCatching { clipboard.snapshot() }
-                .onFailure { logger.warn("Clipboard snapshot failed: ${it.message}") }
-                .getOrNull()
+            // Hotkeys can arrive while the triggering keys are still held; give the
+            // originating sequence time to finish before touching the clipboard at all.
+            delay(preCopyDelayMs)
+
+            val snapshot = when (val result = readSnapshot()) {
+                is ClipboardSnapshotResult.Available -> result.snapshot
+                is ClipboardSnapshotResult.Empty -> null
+                is ClipboardSnapshotResult.Failed -> {
+                    logger.warn("Clipboard snapshot failed, skipping selection capture: ${result.cause?.message}")
+                    currentCoroutineContext().ensureActive()
+                    callback("")
+                    return
+                }
+            }
+
+            val token = changeMonitor.mark()
+            if (token == null) {
+                logger.warn("Clipboard change monitor unavailable, skipping selection capture")
+                restoreShielded(snapshot)
+                currentCoroutineContext().ensureActive()
+                callback("")
+                return
+            }
 
             val text = try {
-                // Hotkeys can arrive while the triggering keys are still held; give the
-                // originating sequence time to finish before synthesizing Copy.
-                delay(preCopyDelayMs)
-                copyAndRead()
+                copyAndRead(token)
             } catch (cancelled: CancellationException) {
-                restore(snapshot)
+                restoreShielded(snapshot)
                 throw cancelled
             } catch (e: Exception) {
                 logger.warn("Selection capture failed: ${e.message}")
                 null
             }
 
-            restore(snapshot)
+            restoreShielded(snapshot)
+            currentCoroutineContext().ensureActive()
             callback(text.orEmpty())
         }
     }
 
-    private suspend fun copyAndRead(): String? {
-        val token = changeMonitor.mark()
+    private suspend fun copyAndRead(token: Long): String? {
         simulateCopy()
-
-        // No generation counter: wait a bounded settle period and take whatever is there.
-        if (token == null) {
-            delay(captureTimeoutMs)
-            return readText()
-        }
 
         var waited = 0L
         while (true) {
+            // With delayed rendering the sequence may not advance until the clipboard data
+            // is actually requested, while the source application waits for that request
+            // before rendering. Reading here triggers rendering; the text is still only
+            // accepted once the sequence change below verifies the copy landed. The nudged
+            // read is always discarded: text equality is never used as proof of a copy.
+            readText()
             if (changeMonitor.hasChangedSince(token)) {
-                readText()?.let { return it }
+                return readText()
             }
             if (waited >= captureTimeoutMs) return null
             delay(pollIntervalMs)
@@ -76,18 +111,38 @@ class SelectionCapture(
         }
     }
 
+    private fun readSnapshot(): ClipboardSnapshotResult =
+        runCatching { clipboard.snapshot() }
+            .getOrElse { ClipboardSnapshotResult.Failed(it) }
+
     private fun readText(): String? =
         runCatching { clipboard.readText() }.getOrNull()?.trim()?.takeIf { it.isNotEmpty() }
 
-    private fun restore(snapshot: ClipboardSnapshot?) {
+    private suspend fun restoreShielded(snapshot: ClipboardSnapshot?) {
+        withContext(NonCancellable) { restoreWithRetry(snapshot) }
+    }
+
+    private suspend fun restoreWithRetry(snapshot: ClipboardSnapshot?) {
         if (snapshot == null) return
-        runCatching { clipboard.restore(snapshot) }
-            .onFailure { logger.warn("Failed to restore clipboard after selection capture: ${it.message}") }
+        var attempt = 0
+        while (true) {
+            attempt++
+            val failure = runCatching { clipboard.restore(snapshot) }.exceptionOrNull()
+            if (failure == null) return
+            // Only a busy clipboard is worth retrying; anything else fails fast.
+            if (failure !is IllegalStateException || attempt >= restoreMaxAttempts) {
+                logger.warn("Failed to restore clipboard after selection capture: ${failure.message}")
+                return
+            }
+            delay(restoreRetryDelayMs)
+        }
     }
 
     private companion object {
         const val DEFAULT_PRE_COPY_DELAY_MS = 80L
         const val DEFAULT_POLL_INTERVAL_MS = 20L
         const val DEFAULT_CAPTURE_TIMEOUT_MS = 600L
+        const val DEFAULT_RESTORE_MAX_ATTEMPTS = 3
+        const val DEFAULT_RESTORE_RETRY_DELAY_MS = 50L
     }
 }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCapture.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCapture.kt
@@ -1,0 +1,93 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import com.github.ahatem.qtranslate.api.core.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Captures the selected text by synthesizing Copy, without leaving any internal content on
+ * the user's clipboard.
+ *
+ * The clipboard is snapshotted before the copy and restored before [capture]'s callback runs,
+ * so clipboard managers never observe a placeholder and the QTranslate action sees the
+ * clipboard as the user left it.
+ *
+ * Concurrent requests are serialized, so two hotkeys cannot fight over clipboard ownership.
+ */
+class SelectionCapture(
+    private val clipboard: SystemClipboard,
+    private val changeMonitor: ClipboardChangeMonitor,
+    private val simulateCopy: suspend () -> Unit,
+    private val logger: Logger,
+    private val mutex: Mutex = Mutex(),
+    private val preCopyDelayMs: Long = DEFAULT_PRE_COPY_DELAY_MS,
+    private val pollIntervalMs: Long = DEFAULT_POLL_INTERVAL_MS,
+    private val captureTimeoutMs: Long = DEFAULT_CAPTURE_TIMEOUT_MS,
+) {
+
+    /**
+     * Runs one capture. [callback] receives the copied text, or an empty string when nothing
+     * was captured, and is always invoked after the clipboard has been restored.
+     */
+    suspend fun capture(callback: (String) -> Unit) {
+        mutex.withLock {
+            val snapshot = runCatching { clipboard.snapshot() }
+                .onFailure { logger.warn("Clipboard snapshot failed: ${it.message}") }
+                .getOrNull()
+
+            val text = try {
+                // Hotkeys can arrive while the triggering keys are still held; give the
+                // originating sequence time to finish before synthesizing Copy.
+                delay(preCopyDelayMs)
+                copyAndRead()
+            } catch (cancelled: CancellationException) {
+                restore(snapshot)
+                throw cancelled
+            } catch (e: Exception) {
+                logger.warn("Selection capture failed: ${e.message}")
+                null
+            }
+
+            restore(snapshot)
+            callback(text.orEmpty())
+        }
+    }
+
+    private suspend fun copyAndRead(): String? {
+        val token = changeMonitor.mark()
+        simulateCopy()
+
+        // No generation counter: wait a bounded settle period and take whatever is there.
+        if (token == null) {
+            delay(captureTimeoutMs)
+            return readText()
+        }
+
+        var waited = 0L
+        while (true) {
+            if (changeMonitor.hasChangedSince(token)) {
+                readText()?.let { return it }
+            }
+            if (waited >= captureTimeoutMs) return null
+            delay(pollIntervalMs)
+            waited += pollIntervalMs
+        }
+    }
+
+    private fun readText(): String? =
+        runCatching { clipboard.readText() }.getOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+
+    private fun restore(snapshot: ClipboardSnapshot?) {
+        if (snapshot == null) return
+        runCatching { clipboard.restore(snapshot) }
+            .onFailure { logger.warn("Failed to restore clipboard after selection capture: ${it.message}") }
+    }
+
+    private companion object {
+        const val DEFAULT_PRE_COPY_DELAY_MS = 80L
+        const val DEFAULT_POLL_INTERVAL_MS = 20L
+        const val DEFAULT_CAPTURE_TIMEOUT_MS = 600L
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCapture.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCapture.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.withContext
  *
  * Restoration is retried a bounded number of times for temporary clipboard-busy failures and
  * runs cancellation-shielded, so cancellation never strands the clipboard in the captured
- * state. The capture itself stays cancellable.
+ * state. The capture itself stays cancellable. Restoration reports success: when the original
+ * clipboard cannot be put back, the captured selection is not dispatched, because the
+ * restore-before-callback invariant means the action must never observe clipboard state the
+ * user did not leave there.
  *
  * Concurrent requests are serialized, so two hotkeys cannot fight over clipboard ownership.
  */
@@ -47,7 +50,8 @@ class SelectionCapture(
 
     /**
      * Runs one capture. [callback] receives the copied text, or an empty string when nothing
-     * was captured, and is always invoked after the clipboard has been restored.
+     * was captured. The callback only ever carries text whose capture was followed by a
+     * successful restoration; when restoration permanently fails the selection is withheld.
      */
     suspend fun capture(callback: (String) -> Unit) {
         mutex.withLock {
@@ -55,21 +59,19 @@ class SelectionCapture(
             // originating sequence time to finish before touching the clipboard at all.
             delay(preCopyDelayMs)
 
-            val snapshot = when (val result = readSnapshot()) {
-                is ClipboardSnapshotResult.Available -> result.snapshot
-                is ClipboardSnapshotResult.Empty -> null
-                is ClipboardSnapshotResult.Failed -> {
-                    logger.warn("Clipboard snapshot failed, skipping selection capture: ${result.cause?.message}")
-                    currentCoroutineContext().ensureActive()
-                    callback("")
-                    return
-                }
+            val snapshot = readSnapshot()
+            if (snapshot is ClipboardSnapshotResult.Failed) {
+                logger.warn("Clipboard snapshot failed, skipping selection capture: ${snapshot.cause?.message}")
+                currentCoroutineContext().ensureActive()
+                callback("")
+                return
             }
 
             val token = changeMonitor.mark()
             if (token == null) {
+                // No synthetic Copy has happened yet, so there is nothing to restore:
+                // abort without touching the clipboard at all.
                 logger.warn("Clipboard change monitor unavailable, skipping selection capture")
-                restoreShielded(snapshot)
                 currentCoroutineContext().ensureActive()
                 callback("")
                 return
@@ -85,9 +87,12 @@ class SelectionCapture(
                 null
             }
 
-            restoreShielded(snapshot)
+            // Only a restored clipboard may be followed by dispatch. A permanently
+            // unrestorable clipboard fails closed: the selection stays undispatched
+            // rather than leaving recovery to the action.
+            val restored = restoreShielded(snapshot)
             currentCoroutineContext().ensureActive()
-            callback(text.orEmpty())
+            callback(if (restored) text.orEmpty() else "")
         }
     }
 
@@ -118,21 +123,24 @@ class SelectionCapture(
     private fun readText(): String? =
         runCatching { clipboard.readText() }.getOrNull()?.trim()?.takeIf { it.isNotEmpty() }
 
-    private suspend fun restoreShielded(snapshot: ClipboardSnapshot?) {
-        withContext(NonCancellable) { restoreWithRetry(snapshot) }
-    }
+    private suspend fun restoreShielded(state: ClipboardSnapshotResult): Boolean =
+        withContext(NonCancellable) { restoreWithRetry(state) }
 
-    private suspend fun restoreWithRetry(snapshot: ClipboardSnapshot?) {
-        if (snapshot == null) return
+    /**
+     * Returns true when the original state is back on the clipboard. A null restore of a
+     * [ClipboardSnapshotResult.Failed] state can never happen (the flow aborts before Copy),
+     * so every state reaching here has a defined restoration.
+     */
+    private suspend fun restoreWithRetry(state: ClipboardSnapshotResult): Boolean {
         var attempt = 0
         while (true) {
             attempt++
-            val failure = runCatching { clipboard.restore(snapshot) }.exceptionOrNull()
-            if (failure == null) return
+            val failure = runCatching { clipboard.restore(state) }.exceptionOrNull()
+            if (failure == null) return true
             // Only a busy clipboard is worth retrying; anything else fails fast.
             if (failure !is IllegalStateException || attempt >= restoreMaxAttempts) {
                 logger.warn("Failed to restore clipboard after selection capture: ${failure.message}")
-                return
+                return false
             }
             delay(restoreRetryDelayMs)
         }

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
@@ -72,9 +72,10 @@ object ClipboardSnapshots {
     /**
      * Null contents classify as [ClipboardSnapshotResult.Empty]. So does a transferable whose
      * flavor enumeration succeeds and reports zero flavors: there is observably nothing to
-     * preserve. Any failure while enumerating or reading classifies as
-     * [ClipboardSnapshotResult.Failed], never as empty, so an unreadable clipboard cannot be
-     * mistaken for an empty one.
+     * preserve. Any failure while enumerating classifies as [ClipboardSnapshotResult.Failed],
+     * and so does a retrieval failure for a recognized flavor (text, image, file list): the
+     * snapshot cannot prove the data was captured, so it must not claim success. Genuinely
+     * unsupported or custom flavors stay best effort and never fail the snapshot on their own.
      */
     fun materialize(contents: Transferable?): ClipboardSnapshotResult {
         if (contents == null) return ClipboardSnapshotResult.Empty
@@ -84,30 +85,57 @@ object ClipboardSnapshots {
 
         val captured = ArrayList<Pair<DataFlavor, Any>>()
         for (flavor in flavors) {
-            materializeFlavor(contents, flavor)?.let { captured += flavor to it }
+            when (val outcome = materializeFlavor(contents, flavor)) {
+                is FlavorOutcome.Materialized -> captured += flavor to outcome.value
+                is FlavorOutcome.Unsupported -> Unit
+                is FlavorOutcome.Failed -> return ClipboardSnapshotResult.Failed(outcome.cause)
+            }
         }
-        // Nothing could be read eagerly: keep the original transferable as a best effort.
+        // Only unsupported flavors were present: keep the original transferable as a best effort.
         if (captured.isEmpty()) return ClipboardSnapshotResult.Available(ClipboardSnapshot(contents))
         return ClipboardSnapshotResult.Available(ClipboardSnapshot(SnapshotTransferable(captured, contents)))
     }
 
-    private fun materializeFlavor(contents: Transferable, flavor: DataFlavor): Any? = runCatching {
-        when (flavor) {
-            DataFlavor.stringFlavor -> contents.getTransferData(DataFlavor.stringFlavor) as String
-            DataFlavor.imageFlavor -> copyImage(contents.getTransferData(DataFlavor.imageFlavor) as Image)
-            DataFlavor.javaFileListFlavor -> {
-                @Suppress("UNCHECKED_CAST")
-                (contents.getTransferData(DataFlavor.javaFileListFlavor) as List<File>).toList()
-            }
-            else -> null
-        }
-    }.getOrNull()
+    private sealed interface FlavorOutcome {
+        data class Materialized(val value: Any) : FlavorOutcome
+        data object Unsupported : FlavorOutcome
+        data class Failed(val cause: Throwable) : FlavorOutcome
+    }
 
-    /** Detaches the image from the source so it survives after the source app loses ownership. */
+    private fun materializeFlavor(contents: Transferable, flavor: DataFlavor): FlavorOutcome {
+        if (flavor != DataFlavor.stringFlavor &&
+            flavor != DataFlavor.imageFlavor &&
+            flavor != DataFlavor.javaFileListFlavor
+        ) {
+            return FlavorOutcome.Unsupported
+        }
+        return runCatching {
+            FlavorOutcome.Materialized(
+                when (flavor) {
+                    DataFlavor.stringFlavor -> contents.getTransferData(DataFlavor.stringFlavor) as String
+                    DataFlavor.imageFlavor -> copyImage(contents.getTransferData(DataFlavor.imageFlavor) as Image)
+                    else -> {
+                        @Suppress("UNCHECKED_CAST")
+                        (contents.getTransferData(DataFlavor.javaFileListFlavor) as List<File>).toList()
+                    }
+                }
+            )
+        }.getOrElse { FlavorOutcome.Failed(it) }
+    }
+
+    /**
+     * Detaches the image from the source so it survives after the source app loses ownership.
+     *
+     * Images whose dimensions are unavailable cannot be detached into a buffered copy; handing
+     * back the lazy original would claim an eager snapshot that was never taken, so this fails
+     * and the snapshot classifies as failed instead.
+     */
     private fun copyImage(image: Image): Image {
         val width = image.getWidth(null)
         val height = image.getHeight(null)
-        if (width <= 0 || height <= 0) return image
+        if (width <= 0 || height <= 0) {
+            throw IllegalStateException("Cannot detach clipboard image with unavailable dimensions")
+        }
         val copy = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
         val graphics = copy.createGraphics()
         try {

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
@@ -4,6 +4,7 @@ import java.awt.Image
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.image.BufferedImage
 import java.io.File
 
@@ -47,25 +48,47 @@ interface SystemClipboard {
     /** Cheap signature of the current contents, used by the fallback change monitor. */
     fun signature(): Long?
 
-    /** Publishes [snapshot] back to the clipboard. May throw. */
-    fun restore(snapshot: ClipboardSnapshot)
+    /**
+     * Publishes a previously snapshotted state back to the clipboard. [ClipboardSnapshotResult.Empty]
+     * clears the clipboard back to empty; [ClipboardSnapshotResult.Failed] is never a valid
+     * argument and fails fast, since the capture flow must abort before Copy instead. May throw.
+     */
+    fun restore(state: ClipboardSnapshotResult)
+}
+
+/** A transferable offering no data, used to restore a genuinely empty clipboard. */
+object EmptyTransferable : Transferable {
+
+    override fun getTransferDataFlavors(): Array<DataFlavor> = emptyArray()
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = false
+
+    override fun getTransferData(flavor: DataFlavor): Any = throw UnsupportedFlavorException(flavor)
 }
 
 /** Materializes [Transferable] contents into an eager snapshot. */
 object ClipboardSnapshots {
 
-    fun materialize(contents: Transferable?): ClipboardSnapshot? {
-        if (contents == null) return null
-        val flavors = runCatching { contents.transferDataFlavors }.getOrNull() ?: return null
-        if (flavors.isEmpty()) return null
+    /**
+     * Null contents classify as [ClipboardSnapshotResult.Empty]. So does a transferable whose
+     * flavor enumeration succeeds and reports zero flavors: there is observably nothing to
+     * preserve. Any failure while enumerating or reading classifies as
+     * [ClipboardSnapshotResult.Failed], never as empty, so an unreadable clipboard cannot be
+     * mistaken for an empty one.
+     */
+    fun materialize(contents: Transferable?): ClipboardSnapshotResult {
+        if (contents == null) return ClipboardSnapshotResult.Empty
+        val flavors = runCatching { contents.transferDataFlavors }
+            .getOrElse { return ClipboardSnapshotResult.Failed(it) }
+        if (flavors.isEmpty()) return ClipboardSnapshotResult.Empty
 
         val captured = ArrayList<Pair<DataFlavor, Any>>()
         for (flavor in flavors) {
             materializeFlavor(contents, flavor)?.let { captured += flavor to it }
         }
         // Nothing could be read eagerly: keep the original transferable as a best effort.
-        if (captured.isEmpty()) return ClipboardSnapshot(contents)
-        return ClipboardSnapshot(SnapshotTransferable(captured, contents))
+        if (captured.isEmpty()) return ClipboardSnapshotResult.Available(ClipboardSnapshot(contents))
+        return ClipboardSnapshotResult.Available(ClipboardSnapshot(SnapshotTransferable(captured, contents)))
     }
 
     private fun materializeFlavor(contents: Transferable, flavor: DataFlavor): Any? = runCatching {
@@ -123,9 +146,7 @@ class AwtSystemClipboard : SystemClipboard {
     override fun snapshot(): ClipboardSnapshotResult = runCatching {
         val contents = systemClipboard.getContents(null)
             ?: return@runCatching ClipboardSnapshotResult.Empty
-        val snapshot = ClipboardSnapshots.materialize(contents)
-            ?: return@runCatching ClipboardSnapshotResult.Empty
-        ClipboardSnapshotResult.Available(snapshot)
+        ClipboardSnapshots.materialize(contents)
     }.getOrElse { ClipboardSnapshotResult.Failed(it) }
 
     override fun readText(): String? = runCatching {
@@ -148,8 +169,15 @@ class AwtSystemClipboard : SystemClipboard {
         "$flavors|$text".hashCode().toLong()
     }.getOrNull()
 
-    override fun restore(snapshot: ClipboardSnapshot) {
-        systemClipboard.setContents(snapshot.transferable, null)
+    override fun restore(state: ClipboardSnapshotResult) {
+        when (state) {
+            is ClipboardSnapshotResult.Available -> systemClipboard.setContents(state.snapshot.transferable, null)
+            // An empty original clipboard is an explicit state to restore, not the
+            // absence of work: without this Copy would leave the selection behind.
+            is ClipboardSnapshotResult.Empty -> systemClipboard.setContents(EmptyTransferable, null)
+            is ClipboardSnapshotResult.Failed ->
+                throw IllegalStateException("Cannot restore a failed clipboard snapshot", state.cause)
+        }
     }
 
     private val systemClipboard get() = Toolkit.getDefaultToolkit().systemClipboard

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
@@ -1,0 +1,132 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import java.awt.Image
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.image.BufferedImage
+import java.io.File
+
+/**
+ * A self-contained copy of the system clipboard.
+ *
+ * The platform clipboard returns lazy proxies whose data can disappear once the owning
+ * application is done with it, so the payload is read eagerly at capture time and kept
+ * alive until it is published back.
+ */
+class ClipboardSnapshot(val transferable: Transferable)
+
+/** Abstract view of the system clipboard so capture logic can be tested without AWT. */
+interface SystemClipboard {
+
+    /** Eagerly copies the current contents. Null when the clipboard is empty or unreadable. */
+    fun snapshot(): ClipboardSnapshot?
+
+    /** Current plain-text contents, or null when the clipboard holds no text. */
+    fun readText(): String?
+
+    /** Cheap signature of the current contents, used by the fallback change monitor. */
+    fun signature(): Long?
+
+    /** Publishes [snapshot] back to the clipboard. May throw. */
+    fun restore(snapshot: ClipboardSnapshot)
+}
+
+/** Materializes [Transferable] contents into an eager snapshot. */
+object ClipboardSnapshots {
+
+    fun materialize(contents: Transferable?): ClipboardSnapshot? {
+        if (contents == null) return null
+        val flavors = runCatching { contents.transferDataFlavors }.getOrNull() ?: return null
+        if (flavors.isEmpty()) return null
+
+        val captured = ArrayList<Pair<DataFlavor, Any>>()
+        for (flavor in flavors) {
+            materializeFlavor(contents, flavor)?.let { captured += flavor to it }
+        }
+        // Nothing could be read eagerly: keep the original transferable as a best effort.
+        if (captured.isEmpty()) return ClipboardSnapshot(contents)
+        return ClipboardSnapshot(SnapshotTransferable(captured, contents))
+    }
+
+    private fun materializeFlavor(contents: Transferable, flavor: DataFlavor): Any? = runCatching {
+        when (flavor) {
+            DataFlavor.stringFlavor -> contents.getTransferData(DataFlavor.stringFlavor) as String
+            DataFlavor.imageFlavor -> copyImage(contents.getTransferData(DataFlavor.imageFlavor) as Image)
+            DataFlavor.javaFileListFlavor -> {
+                @Suppress("UNCHECKED_CAST")
+                (contents.getTransferData(DataFlavor.javaFileListFlavor) as List<File>).toList()
+            }
+            else -> null
+        }
+    }.getOrNull()
+
+    /** Detaches the image from the source so it survives after the source app loses ownership. */
+    private fun copyImage(image: Image): Image {
+        val width = image.getWidth(null)
+        val height = image.getHeight(null)
+        if (width <= 0 || height <= 0) return image
+        val copy = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val graphics = copy.createGraphics()
+        try {
+            graphics.drawImage(image, 0, 0, null)
+        } finally {
+            graphics.dispose()
+        }
+        return copy
+    }
+}
+
+/** Serves eagerly captured data first and falls back to the original transferable otherwise. */
+private class SnapshotTransferable(
+    private val captured: List<Pair<DataFlavor, Any>>,
+    private val fallback: Transferable,
+) : Transferable {
+
+    override fun getTransferDataFlavors(): Array<DataFlavor> {
+        val flavors = LinkedHashSet<DataFlavor>()
+        captured.forEach { flavors += it.first }
+        runCatching { fallback.transferDataFlavors }.getOrNull()?.let { flavors.addAll(it) }
+        return flavors.toTypedArray()
+    }
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+        captured.any { it.first == flavor } ||
+            runCatching { fallback.isDataFlavorSupported(flavor) }.getOrDefault(false)
+
+    override fun getTransferData(flavor: DataFlavor): Any =
+        captured.firstOrNull { it.first == flavor }?.second ?: fallback.getTransferData(flavor)
+}
+
+/** Real clipboard backed by AWT. This is the only place that touches [Toolkit]. */
+class AwtSystemClipboard : SystemClipboard {
+
+    override fun snapshot(): ClipboardSnapshot? =
+        runCatching { ClipboardSnapshots.materialize(systemClipboard.getContents(null)) }.getOrNull()
+
+    override fun readText(): String? = runCatching {
+        val clipboard = systemClipboard
+        if (!clipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) return@runCatching null
+        clipboard.getData(DataFlavor.stringFlavor) as? String
+    }.getOrNull()
+
+    override fun signature(): Long? = runCatching {
+        val clipboard = systemClipboard
+        val contents = clipboard.getContents(null) ?: return@runCatching 0L
+        val flavors = contents.transferDataFlavors.joinToString(",") {
+            "${it.mimeType}:${it.representationClass?.name}"
+        }
+        val text = if (clipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
+            runCatching { clipboard.getData(DataFlavor.stringFlavor).toString() }.getOrNull()
+        } else {
+            null
+        }
+        "$flavors|$text".hashCode().toLong()
+    }.getOrNull()
+
+    override fun restore(snapshot: ClipboardSnapshot) {
+        systemClipboard.setContents(snapshot.transferable, null)
+    }
+
+    private val systemClipboard get() = Toolkit.getDefaultToolkit().systemClipboard
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SystemClipboard.kt
@@ -16,11 +16,30 @@ import java.io.File
  */
 class ClipboardSnapshot(val transferable: Transferable)
 
+/**
+ * The outcome of reading the clipboard for later restoration.
+ *
+ * The three states are deliberately distinct: an unreadable or busy clipboard ([Failed])
+ * must never be confused with an empty one ([Empty]), because the capture flow is only
+ * allowed to overwrite clipboard state it knows how to restore.
+ */
+sealed interface ClipboardSnapshotResult {
+
+    /** The clipboard held readable contents; [snapshot] restores them. */
+    data class Available(val snapshot: ClipboardSnapshot) : ClipboardSnapshotResult
+
+    /** The clipboard was readable and held nothing restorable. */
+    data object Empty : ClipboardSnapshotResult
+
+    /** The clipboard could not be read (busy, unavailable); nothing was captured. */
+    data class Failed(val cause: Throwable?) : ClipboardSnapshotResult
+}
+
 /** Abstract view of the system clipboard so capture logic can be tested without AWT. */
 interface SystemClipboard {
 
-    /** Eagerly copies the current contents. Null when the clipboard is empty or unreadable. */
-    fun snapshot(): ClipboardSnapshot?
+    /** Eagerly copies the current contents for later restoration. Never throws. */
+    fun snapshot(): ClipboardSnapshotResult
 
     /** Current plain-text contents, or null when the clipboard holds no text. */
     fun readText(): String?
@@ -101,8 +120,13 @@ private class SnapshotTransferable(
 /** Real clipboard backed by AWT. This is the only place that touches [Toolkit]. */
 class AwtSystemClipboard : SystemClipboard {
 
-    override fun snapshot(): ClipboardSnapshot? =
-        runCatching { ClipboardSnapshots.materialize(systemClipboard.getContents(null)) }.getOrNull()
+    override fun snapshot(): ClipboardSnapshotResult = runCatching {
+        val contents = systemClipboard.getContents(null)
+            ?: return@runCatching ClipboardSnapshotResult.Empty
+        val snapshot = ClipboardSnapshots.materialize(contents)
+            ?: return@runCatching ClipboardSnapshotResult.Empty
+        ClipboardSnapshotResult.Available(snapshot)
+    }.getOrElse { ClipboardSnapshotResult.Failed(it) }
 
     override fun readText(): String? = runCatching {
         val clipboard = systemClipboard

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/WindowsClipboardChangeMonitor.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/WindowsClipboardChangeMonitor.kt
@@ -1,0 +1,35 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import com.github.ahatem.qtranslate.api.core.Logger
+import com.sun.jna.Native
+import com.sun.jna.win32.StdCallLibrary
+
+/**
+ * Clipboard change detection backed by the Windows clipboard sequence number.
+ *
+ * Windows advances the sequence on every clipboard write, even when the published data is
+ * byte-for-byte identical, so a selection equal to the current clipboard contents is still
+ * detected as a copy.
+ */
+internal class WindowsClipboardChangeMonitor private constructor(
+    private val user32: User32,
+) : ClipboardChangeMonitor {
+
+    override fun mark(): Long? = runCatching { user32.GetClipboardSequenceNumber().toLong() }.getOrNull()
+
+    override fun hasChangedSince(token: Long): Boolean = mark()?.let { it != token } ?: false
+
+    internal interface User32 : StdCallLibrary {
+        fun GetClipboardSequenceNumber(): Int
+    }
+
+    companion object {
+        /** Null when user32 cannot be loaded, so the caller can fall back. */
+        fun create(logger: Logger): WindowsClipboardChangeMonitor? = try {
+            WindowsClipboardChangeMonitor(Native.load("user32", User32::class.java))
+        } catch (t: Throwable) {
+            logger.warn("Windows clipboard sequence number unavailable: ${t.message}")
+            null
+        }
+    }
+}

--- a/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/WindowsClipboardChangeMonitor.kt
+++ b/ui-swing/src/main/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/WindowsClipboardChangeMonitor.kt
@@ -9,13 +9,27 @@ import com.sun.jna.win32.StdCallLibrary
  *
  * Windows advances the sequence on every clipboard write, even when the published data is
  * byte-for-byte identical, so a selection equal to the current clipboard contents is still
- * detected as a copy.
+ * detected as a copy. The counter is a DWORD and wraps; tokens only ever compare for
+ * inequality against a token taken moments earlier, so a wrap between mark and check still
+ * reads as a change, which is the correct answer.
+ *
+ * The constructor takes the native binding so unit tests can substitute a fake; production
+ * uses [create], which loads user32.
  */
-internal class WindowsClipboardChangeMonitor private constructor(
+internal class WindowsClipboardChangeMonitor internal constructor(
     private val user32: User32,
 ) : ClipboardChangeMonitor {
 
-    override fun mark(): Long? = runCatching { user32.GetClipboardSequenceNumber().toLong() }.getOrNull()
+    /**
+     * Null when the sequence cannot be observed. The native API returns zero on failure,
+     * which is reported as unavailable rather than as a token: a zero token would compare
+     * unequal to almost anything and fabricate changes.
+     */
+    override fun mark(): Long? {
+        val sequence = runCatching { user32.GetClipboardSequenceNumber().toLong() }.getOrNull()
+            ?: return null
+        return sequence.takeIf { it != 0L }
+    }
 
     override fun hasChangedSince(token: Long): Boolean = mark()?.let { it != token } ?: false
 

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/main/DoubleCtrlDetectorTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/main/DoubleCtrlDetectorTest.kt
@@ -1,0 +1,143 @@
+package com.github.ahatem.qtranslate.ui.swing.main
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Double-Ctrl tap-pair state machine: a release counts as a tap only after an observed press,
+ * so orphan or synthetic key-up traffic (for example a clipboard manager releasing modifiers
+ * around a paste) can never arm or complete a pair.
+ */
+class DoubleCtrlDetectorTest {
+
+    @Test
+    fun `two genuine taps within threshold trigger exactly once`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+        detector.onControlPressed()
+        assertTrue(detector.onControlReleased(1200L, active = true))
+    }
+
+    @Test
+    fun `a single genuine tap does not trigger`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+    }
+
+    @Test
+    fun `two orphan releases within threshold do not trigger or arm`() {
+        val detector = DoubleCtrlDetector()
+
+        assertFalse(detector.onControlReleased(1000L, active = true))
+        assertFalse(detector.onControlReleased(1100L, active = true))
+
+        // The orphans must not have armed anything: a lone tap afterwards still only arms.
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1200L, active = true))
+    }
+
+    @Test
+    fun `orphan release after a valid tap does not complete double ctrl`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+        assertFalse(detector.onControlReleased(1100L, active = true))
+
+        // The earlier tap is still armed and unspoiled: a genuine second tap fires.
+        detector.onControlPressed()
+        assertTrue(detector.onControlReleased(1200L, active = true))
+    }
+
+    @Test
+    fun `ctrl C does not count as a tap`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        detector.onOtherKeyPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+    }
+
+    @Test
+    fun `ctrl V does not count as a tap`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        detector.onOtherKeyPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+
+        // The combination also clears any previously armed tap.
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1100L, active = true))
+    }
+
+    @Test
+    fun `combination followed by a tap does not trigger`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        detector.onOtherKeyPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1100L, active = true))
+    }
+
+    @Test
+    fun `tap followed by a combination does not trigger`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+        detector.onControlPressed()
+        detector.onOtherKeyPressed()
+        assertFalse(detector.onControlReleased(1100L, active = true))
+
+        // The combination cleared the armed tap: the next lone tap only rearms.
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1200L, active = true))
+    }
+
+    @Test
+    fun `repeated ctrl down while held does not erase combination state`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        detector.onOtherKeyPressed()
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+
+        // Combination path ran (armed tap cleared): a following lone tap only rearms.
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1100L, active = true))
+    }
+
+    @Test
+    fun `two taps outside the threshold do not trigger`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1000L, active = true))
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1500L, active = true))
+    }
+
+    @Test
+    fun `firing is gated on active while tracking continues`() {
+        val detector = DoubleCtrlDetector()
+
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1000L, active = false))
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1100L, active = false))
+
+        detector.onControlPressed()
+        assertFalse(detector.onControlReleased(1200L, active = true))
+        detector.onControlPressed()
+        assertTrue(detector.onControlReleased(1300L, active = true))
+    }
+}

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardMonitorsTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardMonitorsTest.kt
@@ -1,0 +1,89 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Change-monitor failure semantics: an unobservable clipboard must never read as a
+ * confirmed change, and the Windows sequence wrapper must honor the native API contract.
+ * No test here touches a real system clipboard.
+ */
+class ClipboardMonitorsTest {
+
+    @Test
+    fun `signature monitor treats a failed read as no change`() {
+        val clipboard = RecordingClipboard("text").apply { signatureProvider = { null } }
+        val monitor = SignatureClipboardChangeMonitor(clipboard)
+
+        assertFalse(monitor.hasChangedSince(123L))
+    }
+
+    @Test
+    fun `signature monitor detects a real change`() {
+        val clipboard = RecordingClipboard("text").apply { signatureProvider = { 11L } }
+        val monitor = SignatureClipboardChangeMonitor(clipboard)
+
+        assertTrue(monitor.hasChangedSince(10L))
+        assertFalse(monitor.hasChangedSince(11L))
+    }
+
+    @Test
+    fun `windows monitor reports an unchanged sequence as no change`() {
+        val monitor = WindowsClipboardChangeMonitor(FakeUser32(sequence = 7))
+
+        assertEquals(7L, monitor.mark())
+        assertFalse(monitor.hasChangedSince(7L))
+    }
+
+    @Test
+    fun `windows monitor reports an advanced sequence as a change`() {
+        val user32 = FakeUser32(sequence = 7)
+        val monitor = WindowsClipboardChangeMonitor(user32)
+
+        val token = monitor.mark()!!
+        user32.sequence = 8
+
+        assertTrue(monitor.hasChangedSince(token))
+    }
+
+    @Test
+    fun `windows monitor tolerates DWORD wrap between mark and check`() {
+        val user32 = FakeUser32(sequence = Int.MAX_VALUE)
+        val monitor = WindowsClipboardChangeMonitor(user32)
+
+        val token = monitor.mark()!!
+        user32.sequence = Int.MIN_VALUE
+
+        assertTrue(monitor.hasChangedSince(token))
+    }
+
+    @Test
+    fun `windows monitor maps a zero sequence to unavailable`() {
+        // GetClipboardSequenceNumber returns zero on failure, so zero is never a token.
+        val monitor = WindowsClipboardChangeMonitor(FakeUser32(sequence = 0))
+
+        assertNull(monitor.mark())
+    }
+
+    @Test
+    fun `windows monitor maps a native failure to unavailable and no change`() {
+        val monitor = WindowsClipboardChangeMonitor(FakeUser32(fail = true))
+
+        assertNull(monitor.mark())
+        assertFalse(monitor.hasChangedSince(7L))
+    }
+
+    private class FakeUser32(
+        var sequence: Int = 1,
+        var fail: Boolean = false,
+    ) : WindowsClipboardChangeMonitor.User32 {
+
+        override fun GetClipboardSequenceNumber(): Int {
+            if (fail) throw RuntimeException("user32 unavailable")
+            return sequence
+        }
+    }
+}

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardSnapshotsTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardSnapshotsTest.kt
@@ -1,13 +1,14 @@
 package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
 
 import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.image.BufferedImage
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotSame
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -19,16 +20,33 @@ class ClipboardSnapshotsTest {
     private val customFlavor = DataFlavor("application/x-qtranslate-test")
 
     @Test
-    fun `returns null for empty contents`() {
-        assertNull(ClipboardSnapshots.materialize(null))
-        assertNull(ClipboardSnapshots.materialize(MapTransferable(emptyList())))
+    fun `empty contents classify as empty`() {
+        assertIs<ClipboardSnapshotResult.Empty>(ClipboardSnapshots.materialize(null))
+        assertIs<ClipboardSnapshotResult.Empty>(ClipboardSnapshots.materialize(MapTransferable(emptyList())))
+    }
+
+    @Test
+    fun `flavor enumeration failure classifies as failed, never empty`() {
+        val unreadable = object : Transferable {
+            override fun getTransferDataFlavors(): Array<DataFlavor> =
+                throw IllegalStateException("clipboard busy")
+
+            override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+                throw IllegalStateException("clipboard busy")
+
+            override fun getTransferData(flavor: DataFlavor): Any =
+                throw UnsupportedFlavorException(flavor)
+        }
+
+        val result = assertIs<ClipboardSnapshotResult.Failed>(ClipboardSnapshots.materialize(unreadable))
+        assertIs<IllegalStateException>(result.cause)
     }
 
     @Test
     fun `materializes plain text`() {
-        val snapshot = ClipboardSnapshots.materialize(
+        val snapshot = (ClipboardSnapshots.materialize(
             MapTransferable(listOf(DataFlavor.stringFlavor to "hello"))
-        )!!
+        ) as ClipboardSnapshotResult.Available).snapshot
 
         val transferable = snapshot.transferable
         assertTrue(transferable.isDataFlavorSupported(DataFlavor.stringFlavor))
@@ -38,9 +56,9 @@ class ClipboardSnapshotsTest {
     @Test
     fun `copies an image into a detached buffered image`() {
         val image = BufferedImage(6, 4, BufferedImage.TYPE_INT_RGB)
-        val snapshot = ClipboardSnapshots.materialize(
+        val snapshot = (ClipboardSnapshots.materialize(
             MapTransferable(listOf(DataFlavor.imageFlavor to image))
-        )!!
+        ) as ClipboardSnapshotResult.Available).snapshot
 
         val restored = assertIs<BufferedImage>(snapshot.transferable.getTransferData(DataFlavor.imageFlavor))
         assertNotSame(image, restored)
@@ -51,9 +69,9 @@ class ClipboardSnapshotsTest {
     @Test
     fun `retains a file list`() {
         val files = listOf(File("one.txt"), File("two.txt"))
-        val snapshot = ClipboardSnapshots.materialize(
+        val snapshot = (ClipboardSnapshots.materialize(
             MapTransferable(listOf(DataFlavor.javaFileListFlavor to files))
-        )!!
+        ) as ClipboardSnapshotResult.Available).snapshot
 
         assertTrue(snapshot.transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor))
         assertEquals(files, snapshot.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>)
@@ -62,7 +80,7 @@ class ClipboardSnapshotsTest {
     @Test
     fun `keeps unmaterialized flavors through the original transferable`() {
         val source = MapTransferable(listOf(customFlavor to "opaque"))
-        val snapshot = ClipboardSnapshots.materialize(source)!!
+        val snapshot = (ClipboardSnapshots.materialize(source) as ClipboardSnapshotResult.Available).snapshot
 
         // Nothing could be read eagerly, so the original transferable is kept as a fallback.
         assertTrue(snapshot.transferable.isDataFlavorSupported(customFlavor))

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardSnapshotsTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardSnapshotsTest.kt
@@ -1,0 +1,71 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import java.awt.datatransfer.DataFlavor
+import java.awt.image.BufferedImage
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Snapshot materialization: the clipboard proxy is read eagerly so the restoration payload
+ * survives the source application releasing its data.
+ */
+class ClipboardSnapshotsTest {
+
+    private val customFlavor = DataFlavor("application/x-qtranslate-test")
+
+    @Test
+    fun `returns null for empty contents`() {
+        assertNull(ClipboardSnapshots.materialize(null))
+        assertNull(ClipboardSnapshots.materialize(MapTransferable(emptyList())))
+    }
+
+    @Test
+    fun `materializes plain text`() {
+        val snapshot = ClipboardSnapshots.materialize(
+            MapTransferable(listOf(DataFlavor.stringFlavor to "hello"))
+        )!!
+
+        val transferable = snapshot.transferable
+        assertTrue(transferable.isDataFlavorSupported(DataFlavor.stringFlavor))
+        assertEquals("hello", transferable.getTransferData(DataFlavor.stringFlavor))
+    }
+
+    @Test
+    fun `copies an image into a detached buffered image`() {
+        val image = BufferedImage(6, 4, BufferedImage.TYPE_INT_RGB)
+        val snapshot = ClipboardSnapshots.materialize(
+            MapTransferable(listOf(DataFlavor.imageFlavor to image))
+        )!!
+
+        val restored = assertIs<BufferedImage>(snapshot.transferable.getTransferData(DataFlavor.imageFlavor))
+        assertNotSame(image, restored)
+        assertEquals(image.width, restored.width)
+        assertEquals(image.height, restored.height)
+    }
+
+    @Test
+    fun `retains a file list`() {
+        val files = listOf(File("one.txt"), File("two.txt"))
+        val snapshot = ClipboardSnapshots.materialize(
+            MapTransferable(listOf(DataFlavor.javaFileListFlavor to files))
+        )!!
+
+        assertTrue(snapshot.transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor))
+        assertEquals(files, snapshot.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>)
+    }
+
+    @Test
+    fun `keeps unmaterialized flavors through the original transferable`() {
+        val source = MapTransferable(listOf(customFlavor to "opaque"))
+        val snapshot = ClipboardSnapshots.materialize(source)!!
+
+        // Nothing could be read eagerly, so the original transferable is kept as a fallback.
+        assertTrue(snapshot.transferable.isDataFlavorSupported(customFlavor))
+        assertEquals("opaque", snapshot.transferable.getTransferData(customFlavor))
+    }
+}

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardSnapshotsTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardSnapshotsTest.kt
@@ -1,9 +1,14 @@
 package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
 
+import java.awt.Graphics
+import java.awt.Image
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.image.BufferedImage
+import java.awt.image.ImageObserver
+import java.awt.image.ImageProducer
+import java.io.IOException
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,6 +28,38 @@ class ClipboardSnapshotsTest {
     fun `empty contents classify as empty`() {
         assertIs<ClipboardSnapshotResult.Empty>(ClipboardSnapshots.materialize(null))
         assertIs<ClipboardSnapshotResult.Empty>(ClipboardSnapshots.materialize(MapTransferable(emptyList())))
+    }
+
+    @Test
+    fun `recognized string flavor retrieval failure classifies as failed`() {
+        val broken = object : Transferable {
+            override fun getTransferDataFlavors(): Array<DataFlavor> = arrayOf(DataFlavor.stringFlavor)
+
+            override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = true
+
+            override fun getTransferData(flavor: DataFlavor): Any =
+                throw IOException("owning application released the data")
+        }
+
+        val result = assertIs<ClipboardSnapshotResult.Failed>(ClipboardSnapshots.materialize(broken))
+        assertIs<IOException>(result.cause)
+    }
+
+    @Test
+    fun `image that cannot be detached classifies as failed, not lazy`() {
+        val sizeless = object : Image() {
+            override fun getWidth(observer: ImageObserver?): Int = -1
+            override fun getHeight(observer: ImageObserver?): Int = -1
+            override fun getProperty(name: String?, observer: ImageObserver?): Any = UndefinedProperty
+            override fun getSource(): ImageProducer = throw UnsupportedOperationException()
+            override fun getGraphics(): Graphics = throw UnsupportedOperationException()
+            override fun flush() = Unit
+        }
+        val source = MapTransferable(listOf(DataFlavor.imageFlavor to sizeless))
+
+        // Dimensions are unavailable, so no detached copy exists; claiming success with the
+        // lazy original would be unsafe.
+        assertIs<ClipboardSnapshotResult.Failed>(ClipboardSnapshots.materialize(source))
     }
 
     @Test

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
@@ -1,0 +1,86 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import com.github.ahatem.qtranslate.api.core.Logger
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
+
+/** Records the levels used by the capture flow so tests can assert what was logged. */
+internal class RecordingLogger : Logger {
+
+    val warns = mutableListOf<String>()
+    val errors = mutableListOf<String>()
+
+    override fun debug(message: String) = Unit
+    override fun info(message: String) = Unit
+    override fun warn(message: String) { warns += message }
+    override fun error(message: String, error: Throwable?) { errors += message }
+}
+
+/** Change monitor whose token only advances when a test advances it. */
+internal class FakeChangeMonitor(var current: Long = 0L) : ClipboardChangeMonitor {
+
+    override fun mark(): Long? = current
+
+    override fun hasChangedSince(token: Long): Boolean = current != token
+}
+
+/**
+ * In-memory clipboard that records everything ever published, like a clipboard manager would.
+ */
+internal class RecordingClipboard(text: String? = null) : SystemClipboard {
+
+    val published = mutableListOf<String>()
+    val restored = mutableListOf<ClipboardSnapshot>()
+    var contents: ClipboardSnapshot? = text?.let { ClipboardSnapshot(StringSelection(it)) }
+    var text: String? = text
+    var restoreFailure: Throwable? = null
+    var restoreCount = 0
+
+    override fun snapshot(): ClipboardSnapshot? = contents
+
+    override fun readText(): String? = text
+
+    override fun signature(): Long? = null
+
+    override fun restore(snapshot: ClipboardSnapshot) {
+        restoreFailure?.let { throw it }
+        restoreCount++
+        restored += snapshot
+        contents = snapshot
+        val value = runCatching {
+            snapshot.transferable.getTransferData(DataFlavor.stringFlavor) as? String
+        }.getOrNull()
+        published += value ?: NON_TEXT
+        text = value
+    }
+
+    /** Simulates another application putting [value] on the clipboard. */
+    fun simulateExternalCopy(value: String?) {
+        text = value
+        contents = value?.let { ClipboardSnapshot(StringSelection(it)) }
+    }
+
+    fun setSnapshot(snapshot: ClipboardSnapshot) {
+        contents = snapshot
+        text = null
+    }
+
+    companion object {
+        const val NON_TEXT = "<non-text>"
+    }
+}
+
+/** Transferable backed by an explicit flavor map, for building snapshot fixtures. */
+internal class MapTransferable(
+    private val data: List<Pair<DataFlavor, Any>>,
+) : Transferable {
+
+    override fun getTransferDataFlavors(): Array<DataFlavor> = data.map { it.first }.toTypedArray()
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = data.any { it.first == flavor }
+
+    override fun getTransferData(flavor: DataFlavor): Any =
+        data.firstOrNull { it.first == flavor }?.second ?: throw UnsupportedFlavorException(flavor)
+}

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
@@ -86,18 +86,34 @@ internal class RecordingClipboard(text: String? = null) : SystemClipboard {
 
     override fun signature(): Long? = signatureProvider()
 
-    override fun restore(snapshot: ClipboardSnapshot) {
+    override fun restore(state: ClipboardSnapshotResult) {
         restoreAttempts++
         restoreFailures.removeFirstOrNull()?.let { throw it }
         restoreFailure?.let { throw it }
-        restoreCount++
-        restored += snapshot
-        contents = snapshot
-        val value = runCatching {
-            snapshot.transferable.getTransferData(DataFlavor.stringFlavor) as? String
-        }.getOrNull()
-        published += value ?: NON_TEXT
-        text = value
+        when (state) {
+            is ClipboardSnapshotResult.Available -> {
+                val snapshot = state.snapshot
+                restoreCount++
+                restored += snapshot
+                contents = snapshot
+                val value = runCatching {
+                    snapshot.transferable.getTransferData(DataFlavor.stringFlavor) as? String
+                }.getOrNull()
+                published += value ?: NON_TEXT
+                text = value
+            }
+            // Restoring empty is an explicit clear, recorded like any other publish.
+            is ClipboardSnapshotResult.Empty -> {
+                restoreCount++
+                val snapshot = ClipboardSnapshot(EmptyTransferable)
+                restored += snapshot
+                contents = snapshot
+                published += EMPTY
+                text = null
+            }
+            is ClipboardSnapshotResult.Failed ->
+                throw IllegalStateException("Cannot restore a failed clipboard snapshot")
+        }
     }
 
     /** Simulates another application putting [value] on the clipboard. */
@@ -113,6 +129,7 @@ internal class RecordingClipboard(text: String? = null) : SystemClipboard {
 
     companion object {
         const val NON_TEXT = "<non-text>"
+        const val EMPTY = "<empty>"
     }
 }
 

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
@@ -71,12 +71,20 @@ internal class RecordingClipboard(text: String? = null) : SystemClipboard {
     /** Invoked on every [readText], so tests can model render-on-request behavior. */
     var onReadText: (() -> Unit)? = null
     var signatureProvider: () -> Long? = { null }
+    /**
+     * When true, snapshots run the real production materializer over the stored transferable
+     * instead of returning it directly, so orchestration tests exercise the production
+     * snapshot boundary (including retrieval failures) without AWT.
+     */
+    var liveMaterialization: Boolean = false
 
     override fun snapshot(): ClipboardSnapshotResult {
         snapshotCalls++
         snapshotFailure?.let { return ClipboardSnapshotResult.Failed(it) }
         val current = contents ?: return ClipboardSnapshotResult.Empty
-        return ClipboardSnapshotResult.Available(current)
+        if (!liveMaterialization) return ClipboardSnapshotResult.Available(current)
+        return runCatching { ClipboardSnapshots.materialize(current.transferable) }
+            .getOrElse { ClipboardSnapshotResult.Failed(it) }
     }
 
     override fun readText(): String? {

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/ClipboardTestFixtures.kt
@@ -26,6 +26,33 @@ internal class FakeChangeMonitor(var current: Long = 0L) : ClipboardChangeMonito
     override fun hasChangedSince(token: Long): Boolean = current != token
 }
 
+/** Change monitor that can never observe the platform. */
+internal class NullChangeMonitor : ClipboardChangeMonitor {
+
+    override fun mark(): Long? = null
+
+    override fun hasChangedSince(token: Long): Boolean = false
+}
+
+/**
+ * Models Windows delayed rendering: Ctrl+C is accepted but the sequence number does not
+ * advance until the clipboard data is actually requested, which is what prompts the source
+ * application to render. [copyAccepted] is set by the copy lambda; each [SystemClipboard.readText]
+ * should set [renderRequested] (wire via [RecordingClipboard.onReadText]).
+ */
+internal class DelayedRenderingMonitor(var sequence: Long = 100L) : ClipboardChangeMonitor {
+
+    var copyAccepted = false
+    var renderRequested = false
+
+    override fun mark(): Long? = sequence
+
+    override fun hasChangedSince(token: Long): Boolean {
+        if (copyAccepted && renderRequested && sequence == token) sequence++
+        return sequence != token
+    }
+}
+
 /**
  * In-memory clipboard that records everything ever published, like a clipboard manager would.
  */
@@ -36,15 +63,32 @@ internal class RecordingClipboard(text: String? = null) : SystemClipboard {
     var contents: ClipboardSnapshot? = text?.let { ClipboardSnapshot(StringSelection(it)) }
     var text: String? = text
     var restoreFailure: Throwable? = null
+    val restoreFailures = ArrayDeque<Throwable>()
     var restoreCount = 0
+    var restoreAttempts = 0
+    var snapshotFailure: Throwable? = null
+    var snapshotCalls = 0
+    /** Invoked on every [readText], so tests can model render-on-request behavior. */
+    var onReadText: (() -> Unit)? = null
+    var signatureProvider: () -> Long? = { null }
 
-    override fun snapshot(): ClipboardSnapshot? = contents
+    override fun snapshot(): ClipboardSnapshotResult {
+        snapshotCalls++
+        snapshotFailure?.let { return ClipboardSnapshotResult.Failed(it) }
+        val current = contents ?: return ClipboardSnapshotResult.Empty
+        return ClipboardSnapshotResult.Available(current)
+    }
 
-    override fun readText(): String? = text
+    override fun readText(): String? {
+        onReadText?.invoke()
+        return text
+    }
 
-    override fun signature(): Long? = null
+    override fun signature(): Long? = signatureProvider()
 
     override fun restore(snapshot: ClipboardSnapshot) {
+        restoreAttempts++
+        restoreFailures.removeFirstOrNull()?.let { throw it }
         restoreFailure?.let { throw it }
         restoreCount++
         restored += snapshot

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -74,9 +75,9 @@ class SelectionCaptureTest {
     @Test
     fun `image contents are restored after capture`() = runTest {
         val image = BufferedImage(4, 3, BufferedImage.TYPE_INT_RGB)
-        val snapshot = ClipboardSnapshots.materialize(
+        val snapshot = (ClipboardSnapshots.materialize(
             MapTransferable(listOf(DataFlavor.imageFlavor to image))
-        )!!
+        ) as ClipboardSnapshotResult.Available).snapshot
         val clipboard = RecordingClipboard().apply { setSnapshot(snapshot) }
         val monitor = FakeChangeMonitor()
         val capture = SelectionCapture(clipboard, monitor, { monitor.current++ }, RecordingLogger())
@@ -92,14 +93,14 @@ class SelectionCaptureTest {
     @Test
     fun `multi-flavor file list contents are restored after capture`() = runTest {
         val files = listOf(File("a.txt"), File("b.txt"))
-        val snapshot = ClipboardSnapshots.materialize(
+        val snapshot = (ClipboardSnapshots.materialize(
             MapTransferable(
                 listOf(
                     DataFlavor.stringFlavor to "a.txt\nb.txt",
                     DataFlavor.javaFileListFlavor to files
                 )
             )
-        )!!
+        ) as ClipboardSnapshotResult.Available).snapshot
         val clipboard = RecordingClipboard().apply { setSnapshot(snapshot) }
         val monitor = FakeChangeMonitor()
         val capture = SelectionCapture(clipboard, monitor, { monitor.current++ }, RecordingLogger())
@@ -205,7 +206,7 @@ class SelectionCaptureTest {
     }
 
     @Test
-    fun `permanent restore failure is bounded and logged`() = runTest {
+    fun `permanent restore failure is bounded, logged, and not dispatched`() = runTest {
         val clipboard = RecordingClipboard("original").apply {
             restoreFailure = IllegalStateException("still busy")
         }
@@ -216,9 +217,14 @@ class SelectionCaptureTest {
         var captured: String? = null
         capture.capture { captured = it }
 
-        assertEquals("selected", captured)
+        // Copy succeeded but the original clipboard could not be put back: the
+        // callback carries empty instead of the selection, so the action never
+        // observes clipboard state the user did not leave there.
+        assertEquals("", captured)
         assertEquals(3, clipboard.restoreAttempts)
         assertTrue(logger.warns.any { it.contains("restore", ignoreCase = true) })
+        assertTrue(logger.warns.none { it.contains("selected") })
+        assertTrue(logger.warns.none { it.contains("original") })
     }
 
     @Test
@@ -275,11 +281,64 @@ class SelectionCaptureTest {
         assertEquals("", captured)
         assertEquals(0, copyCalls)
         assertEquals("stale", clipboard.text)
-        // The only write is the restoration of the user's own content: no fresh
-        // selection was synthesized and no internal marker was published.
-        assertTrue(clipboard.published.none { it == "fresh" })
-        assertTrue(clipboard.published.none { it.contains("qtranslate") })
         assertTrue(logger.warns.any { it.contains("monitor", ignoreCase = true) })
+    }
+
+    @Test
+    fun `monitor-unavailable abort performs zero clipboard writes`() = runTest {
+        val clipboard = RecordingClipboard("stale")
+        val capture = SelectionCapture(clipboard, NullChangeMonitor(), {
+            clipboard.simulateExternalCopy("fresh")
+        }, RecordingLogger())
+
+        capture.capture {}
+
+        // The abort happens before any synthetic Copy, so there is nothing to
+        // restore and no reason to touch the clipboard: managers observe nothing.
+        assertEquals(1, clipboard.snapshotCalls)
+        assertEquals(0, clipboard.restoreAttempts)
+        assertTrue(clipboard.published.isEmpty())
+        assertEquals("stale", clipboard.text)
+    }
+
+    @Test
+    fun `empty clipboard is restored as empty before dispatch`() = runTest {
+        val clipboard = RecordingClipboard(null)
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), RecordingLogger())
+
+        var captured: String? = null
+        var emptyBeforeCallback = false
+        capture.capture {
+            emptyBeforeCallback = clipboard.text == null
+            captured = it
+        }
+
+        assertEquals("selected", captured)
+        assertTrue(emptyBeforeCallback)
+        assertNull(clipboard.text)
+        assertEquals(1, clipboard.restoreCount)
+    }
+
+    @Test
+    fun `cancellation after copy restores an originally empty clipboard`() = runTest {
+        val clipboard = RecordingClipboard(null)
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, {
+            delay(150)
+            monitor.current++
+            clipboard.simulateExternalCopy("selected")
+        }, RecordingLogger())
+
+        var dispatched = false
+        val job = launch { capture.capture { dispatched = true } }
+        advanceTimeBy(200)
+        job.cancel()
+        job.join()
+
+        assertEquals(1, clipboard.restoreCount)
+        assertNull(clipboard.text)
+        assertFalse(dispatched)
     }
 
     @Test
@@ -388,7 +447,7 @@ class SelectionCaptureTest {
         capture.capture { callbacks++ }
 
         // What COPY_TRANSLATION does after a capture: publish the translated text.
-        clipboard.restore(ClipboardSnapshot(StringSelection("translated")))
+        clipboard.restore(ClipboardSnapshotResult.Available(ClipboardSnapshot(StringSelection("translated"))))
         advanceUntilIdle()
 
         assertEquals(1, callbacks)

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
@@ -144,6 +144,169 @@ class SelectionCaptureTest {
     }
 
     @Test
+    fun `delayed rendering is triggered by reads but only a sequence change counts`() = runTest {
+        // The source app accepts Ctrl+C yet the sequence does not move until the data is
+        // requested; each poll read triggers rendering, and only the verified sequence
+        // advance lets the text through. The pre-copy "original" reads are discarded.
+        val clipboard = RecordingClipboard("original")
+        val monitor = DelayedRenderingMonitor()
+        clipboard.onReadText = { monitor.renderRequested = true }
+        val capture = SelectionCapture(clipboard, monitor, {
+            monitor.copyAccepted = true
+            clipboard.simulateExternalCopy("selected")
+        }, RecordingLogger())
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("selected", captured)
+        assertEquals("original", clipboard.text)
+    }
+
+    @Test
+    fun `snapshot failure skips copy and dispatches nothing`() = runTest {
+        val clipboard = RecordingClipboard("original").apply {
+            snapshotFailure = IllegalStateException("clipboard busy")
+        }
+        var copyCalls = 0
+        val logger = RecordingLogger()
+        val capture = SelectionCapture(clipboard, FakeChangeMonitor(), { copyCalls++ }, logger)
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals(0, copyCalls)
+        assertEquals("", captured)
+        assertEquals(0, clipboard.restoreCount)
+        assertTrue(clipboard.published.isEmpty())
+        assertEquals("original", clipboard.text)
+        assertTrue(logger.warns.any { it.contains("snapshot", ignoreCase = true) })
+        assertTrue(logger.warns.none { it.contains("original") })
+    }
+
+    @Test
+    fun `restore retries a busy clipboard and dispatches only after restoring`() = runTest {
+        val clipboard = RecordingClipboard("original").apply {
+            restoreFailures += IllegalStateException("busy")
+        }
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), RecordingLogger())
+
+        var captured: String? = null
+        capture.capture {
+            // Restore-before-dispatch: the clipboard must already be back when this runs.
+            assertEquals(1, clipboard.restoreCount)
+            captured = it
+        }
+
+        assertEquals("selected", captured)
+        assertEquals(2, clipboard.restoreAttempts)
+        assertEquals("original", clipboard.text)
+    }
+
+    @Test
+    fun `permanent restore failure is bounded and logged`() = runTest {
+        val clipboard = RecordingClipboard("original").apply {
+            restoreFailure = IllegalStateException("still busy")
+        }
+        val monitor = FakeChangeMonitor()
+        val logger = RecordingLogger()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), logger)
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("selected", captured)
+        assertEquals(3, clipboard.restoreAttempts)
+        assertTrue(logger.warns.any { it.contains("restore", ignoreCase = true) })
+    }
+
+    @Test
+    fun `non-busy restore failure does not retry`() = runTest {
+        val clipboard = RecordingClipboard("original").apply {
+            restoreFailure = SecurityException("denied")
+        }
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), RecordingLogger())
+
+        capture.capture {}
+
+        assertEquals(1, clipboard.restoreAttempts)
+    }
+
+    @Test
+    fun `cancellation during restore retries still restores without dispatching`() = runTest {
+        val clipboard = RecordingClipboard("original").apply {
+            restoreFailures += IllegalStateException("busy")
+        }
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(
+            clipboard, monitor,
+            copyThatSelects(clipboard, monitor, "selected"),
+            RecordingLogger(),
+            restoreRetryDelayMs = 1_000L
+        )
+
+        var dispatched = false
+        val job = launch { capture.capture { dispatched = true } }
+        advanceTimeBy(200)
+        job.cancel()
+        job.join()
+
+        assertEquals(1, clipboard.restoreCount)
+        assertEquals(2, clipboard.restoreAttempts)
+        assertEquals("original", clipboard.text)
+        assertFalse(dispatched)
+    }
+
+    @Test
+    fun `unavailable monitor never dispatches stale clipboard text`() = runTest {
+        val clipboard = RecordingClipboard("stale")
+        var copyCalls = 0
+        val logger = RecordingLogger()
+        val capture = SelectionCapture(clipboard, NullChangeMonitor(), {
+            copyCalls++
+            clipboard.simulateExternalCopy("fresh")
+        }, logger)
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("", captured)
+        assertEquals(0, copyCalls)
+        assertEquals("stale", clipboard.text)
+        // The only write is the restoration of the user's own content: no fresh
+        // selection was synthesized and no internal marker was published.
+        assertTrue(clipboard.published.none { it == "fresh" })
+        assertTrue(clipboard.published.none { it.contains("qtranslate") })
+        assertTrue(logger.warns.any { it.contains("monitor", ignoreCase = true) })
+    }
+
+    @Test
+    fun `transient signature failure does not dispatch stale text`() = runTest {
+        val clipboard = RecordingClipboard("stale")
+        var signature = 10L
+        var reads = 0
+        clipboard.signatureProvider = {
+            reads++
+            // The first poll read fails right after a good mark; the failure must read
+            // as "no change", not as a confirmed copy of whatever is on the clipboard.
+            if (reads == 2) null else signature
+        }
+        val monitor = SignatureClipboardChangeMonitor(clipboard)
+        val capture = SelectionCapture(clipboard, monitor, {
+            signature = 11L
+            clipboard.simulateExternalCopy("fresh")
+        }, RecordingLogger())
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("fresh", captured)
+        assertEquals("stale", clipboard.text)
+    }
+
+    @Test
     fun `capture times out within a bounded window`() = runTest {
         val clipboard = RecordingClipboard("original")
         val monitor = FakeChangeMonitor()

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
@@ -2,8 +2,11 @@ package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
 
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.image.BufferedImage
 import java.io.File
+import java.io.IOException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -363,6 +366,39 @@ class SelectionCaptureTest {
 
         assertEquals("fresh", captured)
         assertEquals("stale", clipboard.text)
+    }
+
+    @Test
+    fun `unmaterializable string flavor fails closed before copy`() = runTest {
+        val broken = object : Transferable {
+            override fun getTransferDataFlavors(): Array<DataFlavor> = arrayOf(DataFlavor.stringFlavor)
+
+            override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = true
+
+            override fun getTransferData(flavor: DataFlavor): Any =
+                throw IOException("owning application released the data")
+        }
+        val clipboard = RecordingClipboard(null).apply {
+            contents = ClipboardSnapshot(broken)
+            liveMaterialization = true
+        }
+        var copyCalls = 0
+        val logger = RecordingLogger()
+        val capture = SelectionCapture(clipboard, FakeChangeMonitor(), { copyCalls++ }, logger)
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals(0, copyCalls)
+        assertEquals("", captured)
+        assertEquals(0, clipboard.restoreAttempts)
+        assertTrue(clipboard.published.isEmpty())
+        // The log carries only the failure message: there were no readable clipboard
+        // contents to leak, and none are attached.
+        assertEquals(
+            listOf("Clipboard snapshot failed, skipping selection capture: owning application released the data"),
+            logger.warns
+        )
     }
 
     @Test

--- a/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
+++ b/ui-swing/src/test/kotlin/com/github/ahatem/qtranslate/ui/swing/shared/clipboard/SelectionCaptureTest.kt
@@ -1,0 +1,247 @@
+package com.github.ahatem.qtranslate.ui.swing.shared.clipboard
+
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.image.BufferedImage
+import java.io.File
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The selection-capture orchestration: the clipboard is never left with internal content, is
+ * always restored before the QTranslate action runs, and concurrent hotkeys cannot interleave.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SelectionCaptureTest {
+
+    private fun copyThatSelects(
+        clipboard: RecordingClipboard,
+        monitor: FakeChangeMonitor,
+        selected: String,
+    ): suspend () -> Unit = {
+        monitor.current++
+        clipboard.simulateExternalCopy(selected)
+    }
+
+    @Test
+    fun `capture never publishes an internal marker`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), RecordingLogger())
+
+        capture.capture {}
+
+        assertEquals(listOf("original"), clipboard.published)
+        assertTrue(clipboard.published.none { it.startsWith("qtranslate-copy-") })
+    }
+
+    @Test
+    fun `original plain text is restored after capture`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), RecordingLogger())
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("selected", captured)
+        assertEquals(1, clipboard.restoreCount)
+        assertEquals("original", clipboard.text)
+    }
+
+    @Test
+    fun `selection identical to the existing clipboard text is still captured`() = runTest {
+        // The copy leaves the text unchanged, so only the change token can prove it happened.
+        val clipboard = RecordingClipboard("same")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, { monitor.current++ }, RecordingLogger())
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("same", captured)
+        assertEquals("same", clipboard.text)
+    }
+
+    @Test
+    fun `image contents are restored after capture`() = runTest {
+        val image = BufferedImage(4, 3, BufferedImage.TYPE_INT_RGB)
+        val snapshot = ClipboardSnapshots.materialize(
+            MapTransferable(listOf(DataFlavor.imageFlavor to image))
+        )!!
+        val clipboard = RecordingClipboard().apply { setSnapshot(snapshot) }
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, { monitor.current++ }, RecordingLogger())
+
+        capture.capture {}
+
+        assertEquals(1, clipboard.restoreCount)
+        val restored = clipboard.restored.single().transferable
+        assertTrue(restored.isDataFlavorSupported(DataFlavor.imageFlavor))
+        assertTrue(restored.getTransferData(DataFlavor.imageFlavor) is BufferedImage)
+    }
+
+    @Test
+    fun `multi-flavor file list contents are restored after capture`() = runTest {
+        val files = listOf(File("a.txt"), File("b.txt"))
+        val snapshot = ClipboardSnapshots.materialize(
+            MapTransferable(
+                listOf(
+                    DataFlavor.stringFlavor to "a.txt\nb.txt",
+                    DataFlavor.javaFileListFlavor to files
+                )
+            )
+        )!!
+        val clipboard = RecordingClipboard().apply { setSnapshot(snapshot) }
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, { monitor.current++ }, RecordingLogger())
+
+        capture.capture {}
+
+        val restored = clipboard.restored.single().transferable
+        assertTrue(restored.isDataFlavorSupported(DataFlavor.javaFileListFlavor))
+        assertTrue(restored.isDataFlavorSupported(DataFlavor.stringFlavor))
+        assertEquals(files, restored.getTransferData(DataFlavor.javaFileListFlavor) as List<*>)
+    }
+
+    @Test
+    fun `no clipboard change yields no capture and keeps the original`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, {}, RecordingLogger())
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("", captured)
+        assertEquals("original", clipboard.text)
+        assertEquals(1, clipboard.restoreCount)
+    }
+
+    @Test
+    fun `a delayed clipboard update is still captured within the window`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, {
+            delay(150)
+            monitor.current++
+            clipboard.simulateExternalCopy("delayed")
+        }, RecordingLogger())
+
+        var captured: String? = null
+        capture.capture { captured = it }
+
+        assertEquals("delayed", captured)
+        assertEquals("original", clipboard.text)
+    }
+
+    @Test
+    fun `capture times out within a bounded window`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, {}, RecordingLogger())
+
+        val started = testScheduler.currentTime
+        capture.capture {}
+        val elapsed = testScheduler.currentTime - started
+
+        // 80 ms pre-copy delay plus a 600 ms capture window, then it gives up.
+        assertEquals(680L, elapsed)
+    }
+
+    @Test
+    fun `cancellation restores the clipboard and does not dispatch`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, {}, RecordingLogger())
+
+        var dispatched = false
+        val job = launch { capture.capture { dispatched = true } }
+        advanceTimeBy(200)
+        job.cancel()
+        job.join()
+
+        assertEquals(1, clipboard.restoreCount)
+        assertEquals("original", clipboard.text)
+        assertFalse(dispatched)
+    }
+
+    @Test
+    fun `restoration failure is logged rather than swallowed`() = runTest {
+        val clipboard = RecordingClipboard("original").apply {
+            restoreFailure = IllegalStateException("clipboard busy")
+        }
+        val monitor = FakeChangeMonitor()
+        val logger = RecordingLogger()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), logger)
+
+        capture.capture {}
+
+        assertTrue(logger.warns.any { it.contains("restore", ignoreCase = true) })
+    }
+
+    @Test
+    fun `two simultaneous captures are serialized and both restore the clipboard`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        var active = 0
+        var maxActive = 0
+        val capture = SelectionCapture(clipboard, monitor, {
+            active++
+            maxActive = maxOf(maxActive, active)
+            delay(50)
+            monitor.current++
+            clipboard.simulateExternalCopy("selected")
+            active--
+        }, RecordingLogger())
+
+        val callbacks = mutableListOf<String>()
+        val first = launch { capture.capture { callbacks += it } }
+        val second = launch { capture.capture { callbacks += it } }
+        first.join()
+        second.join()
+
+        assertEquals(1, maxActive)
+        assertEquals(2, clipboard.restoreCount)
+        assertEquals(listOf("selected", "selected"), callbacks)
+        assertEquals("original", clipboard.text)
+    }
+
+    @Test
+    fun `a QTranslate copy action does not recursively trigger capture`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), RecordingLogger())
+
+        var callbacks = 0
+        capture.capture { callbacks++ }
+
+        // What COPY_TRANSLATION does after a capture: publish the translated text.
+        clipboard.restore(ClipboardSnapshot(StringSelection("translated")))
+        advanceUntilIdle()
+
+        assertEquals(1, callbacks)
+        assertEquals("translated", clipboard.published.last())
+    }
+
+    @Test
+    fun `a clipboard manager observes no internal marker`() = runTest {
+        val clipboard = RecordingClipboard("original")
+        val monitor = FakeChangeMonitor()
+        val capture = SelectionCapture(clipboard, monitor, copyThatSelects(clipboard, monitor, "selected"), RecordingLogger())
+
+        capture.capture {}
+
+        assertTrue(clipboard.published.isNotEmpty())
+        assertTrue(clipboard.published.none { it.contains("qtranslate-copy-") })
+        assertTrue(clipboard.published.none { it.contains("qtranslate") })
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Removes the `qtranslate-copy-*` clipboard sentinel so selection capture no longer writes internal content to the user's clipboard, which is what Ditto and Windows Clipboard History were picking up.

**Why the old approach failed**

The capture path wrote a generated marker string to the real system clipboard, synthesized Ctrl+C, read the result back, and only then restored the previous contents. A clipboard manager observes every clipboard write, so the marker was recorded and could be pasted later. The marker was also how the code decided whether Ctrl+C had worked, which cannot be correct in general: copying a selection identical to what is already on the clipboard leaves the text unchanged, so content comparison cannot tell whether the copy happened.

**What replaces it**

- Nothing is written to the clipboard before the copy. The only write is the restoration of the snapshot taken before the capture.
- Detection uses a clipboard change token, not text equality. On Windows this is the native clipboard sequence number (`GetClipboardSequenceNumber`), which Windows advances on every clipboard write even when the data is byte for byte identical, so a selection equal to the current clipboard contents is still detected. Poll reads trigger delayed rendering while a verified sequence change is still required before any text is accepted, so delayed rendering sources are handled without falling back to text comparison.
- On platforms without a sequence number, a content signature is used as a best effort. A copy that leaves the signature unchanged cannot be detected there; this is documented in the code and Windows is the primary target.
- A null or failed monitor, or a failed signature read, never counts as a change. Stale clipboard text is never dispatched as a fresh selection.
- The clipboard snapshot distinguishes readable contents, an empty clipboard, and a read failure. If the snapshot cannot be acquired, no Copy is synthesized and nothing is dispatched, because overwriting unrestorable clipboard state is worse than capturing nothing.
- The clipboard is snapshotted eagerly before the copy (text, image as a detached copy, file list, with the original transferable retained for anything that could not be materialized), because the platform hands back lazy proxies whose data can disappear once the owning application is done with it.
- The key release settle delay runs before the snapshot, so the snapshot is taken as close as practical to the copy and cannot overwrite a legitimate update that landed during the settle period.
- Restoration is retried a bounded number of times for temporary clipboard busy failures and runs shielded from cancellation, so cancellation cannot strand the clipboard in the captured state. The capture itself stays cancellable.
- Restoration happens before the QTranslate action runs. Previously the callback was dispatched first and the clipboard was restored in a `finally` afterwards, so the action could observe the captured content rather than the user's clipboard.
- The snapshot is restored on success, copy failure, timeout, exception and cancellation. Restoration failures are logged rather than swallowed, without logging clipboard contents.
- Capture is bounded by a timeout and never blocks indefinitely.
- Concurrent requests are serialized through a mutex, so two hotkeys can no longer interleave and fight over clipboard ownership. This replaces a fail fast lock that quietly dropped the second request.
- All of this lives behind a small abstraction (`SystemClipboard`, `ClipboardChangeMonitor`, `SelectionCapture`) so the logic is unit tested against fakes with no real clipboard, no `Robot`, and no sleeping. `MainGlobalKeyListener` keeps its public constructor signature and its seven call sites; its capture method is now a delegation.

**Dependency**

The Windows sequence number needs JNA, which was only on the classpath transitively through jkeymaster 1.3. It is now declared directly (`net.java.dev.jna:jna`, pinned to 5.4.0, the version the build already resolved, so no second JNA version is introduced). Native loading is guarded: if `user32` cannot be loaded the code logs and degrades to the signature monitor instead of failing.

**Tests**

51 unit tests, all passing, plus a full `./gradlew build`: 40 in `ui.swing.shared.clipboard` plus 11 for the Double Ctrl state machine. Retrieval failure for a recognized flavor (text, image, file list) classifies the snapshot as failed instead of falling back to the lazy original, and undetachable images fail rather than claiming an eager snapshot. Coverage includes: the only clipboard write is the restoration, identical text selection is still captured (including under simulated delayed rendering), snapshot failure skips Copy entirely, an empty original clipboard is restored as empty before dispatch (including on cancellation after Copy), flavor enumeration failure classifies as a failed snapshot and never triggers Copy, monitor unavailable aborts perform zero clipboard writes, null or unavailable monitors and failed signature reads never dispatch stale text, restore retries a busy clipboard with bounded give up, permanent restoration failure withholds the selection, cancellation during restore retries still restores without dispatching, and the Windows sequence wrapper (unchanged, advanced, wrap, zero, failure).

Not verified: real Ditto and Windows Clipboard History behaviour was not exercised. It needs a manual check on Windows with Ditto or Clipboard History enabled.

Double Ctrl note: a release now counts as a tap only after an observed press, so orphan or synthetic Ctrl releases (such as modifier key-ups around a clipboard manager paste) can no longer arm or complete Double Ctrl, and repeated Ctrl-down while held no longer erases combination state. Tap-pair logic lives in a pure `DoubleCtrlDetector` with deterministic tests. This shares its state machine with the behavior reported in #237, which stays open pending verification of its own reproduction.

## Related issues

Closes #231
Closes #236

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] UI/UX improvement
- [ ] Plugin / API change

## Checklist

- [x] I branched off `develop`, not `main`
- [x] The build passes locally (`./gradlew build`)
- [x] MVI architecture respected, no logic in UI components
- [ ] Blocking I/O is wrapped in `withContext(Dispatchers.IO)`
- [x] Public API has KDoc
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

Left unchecked on purpose: the clipboard reads/writes and the synthesized copy run on the coroutine scope's `Dispatchers.Default`, not `Dispatchers.IO`. That matches the pre-existing behaviour of this capture path, which already ran there, and moving it would also change the context the completion callback resumes on, so it is called out here rather than changed silently. Happy to move just the clipboard and `Robot` work onto `Dispatchers.IO` while keeping the callback on its current dispatcher if that is preferred.

## Screenshots (if UI changes)

None. No visual change; behaviour is clipboard state after a selection capture.



